### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.claude/skills/open-github-issue/SKILL.md
+++ b/.claude/skills/open-github-issue/SKILL.md
@@ -5,7 +5,41 @@ description: Use when creating GitHub issues, filing bugs, opening tickets, or r
 
 # Open a GitHub Issue
 
-Create issues in the `contextbridge/planbridge` GitHub repository using the `gh` CLI.
+Create issues in the `contextbridge/planbridge` GitHub repository using the `gh` CLI. Every issue must follow the structure of one of the issue form templates under `.github/ISSUE_TEMPLATE/` so agent-filed issues look consistent with human-filed reports and downstream tooling can pattern-match the rendered headings.
+
+## Is this even an issue?
+
+GitHub issues are for bugs, regressions, and feature requests against the codebase. They are **not** for:
+
+- Questions or how-do-I support requests
+- Open-ended design discussion
+- Anything that doesn't have a clear "this should change" outcome
+
+Route those to the community Slack at https://go.contextbridge.ai/join-community instead. Only proceed below if you're filing a concrete bug or feature request.
+
+## Pick a template
+
+The repo's available templates are the source of truth — don't hard-code assumptions in your head:
+
+```sh
+ls .github/ISSUE_TEMPLATE/*.yml
+```
+
+Skip `config.yml` (chooser config, not a template). For each remaining file, read its `name:` and `description:` to decide which one matches the issue you're filing. Pick exactly one.
+
+## Pull metadata from the template, not from memory
+
+Once you've picked a template, **read it** and extract:
+
+- **Title prefix** — the `title:` field (e.g., `'bug: '`, `'feat: '`). Include the trailing space exactly as written.
+- **Label** — the `labels:` array (e.g., `["bug"]`). Pass each value through `--label` on the `gh` command.
+- **Body structure** — the `body:` array, in order. Every entry with an `attributes.label` becomes a `### <label>` heading in your issue body.
+- **Required fields** — entries with `validations: required: true` must have substantive content under their heading. Don't skip them.
+- **Optional fields** — entries without that validation are optional. Omit the section entirely if you have nothing useful to write; empty placeholders are noise.
+
+For a required field where literal information doesn't apply (e.g., filing a code-quality bug noticed during review, where "Operating system" is irrelevant), write a single short sentence explaining why (e.g., "Not applicable — issue is in source code, observed during code review of commit `<sha>`."). Don't skip required fields silently.
+
+Mirroring the template's headings produces output indistinguishable from a human-submitted form, which is what downstream search and automation expect.
 
 ## Command
 
@@ -14,31 +48,28 @@ Pass the body via a HEREDOC so newlines, backticks, and code fences render corre
 ```sh
 gh issue create \
   --repo contextbridge/planbridge \
-  --title "<title>" \
+  --label "<label from template>" \
+  --title "<prefix from template><your title>" \
   --body "$(cat <<'EOF'
-<markdown body>
+### <First field label from template>
+
+<content>
+
+### <Next field label>
+
+<content>
 EOF
 )"
 ```
 
-Always pass `--repo contextbridge/planbridge` explicitly so the issue lands in the right repo regardless of the current working directory.
+- Always pass `--repo contextbridge/planbridge` explicitly so the issue lands in the right repo regardless of the current working directory.
+- Do **not** assign a milestone, priority, or assignee — leave those unset. Triage will assign them.
 
-Do **not** assign a milestone, priority, or assignee — leave those unset. Triage will assign them.
+## Writing the content
 
-## Bug Label
+Issues must be **self-contained**. A reader must be able to understand the issue without access to the reporter's machine or session.
 
-If the issue is a bug (crash, incorrect behavior, regression), add the `bug` label:
-
-```sh
-gh issue create --repo contextbridge/planbridge --label bug --title "…" --body "…"
-```
-
-For other categories, omit `--label`.
-
-## Writing the Description
-
-Issues must be **self-contained**. A reader must be able to understand the issue without access to the reporter's machine.
-
-- **Include full context**: reproduction steps, log excerpts, error messages, stack traces.
-- **Use Markdown** for formatting — GitHub renders it natively.
+- **Include full context** under each section: reproduction steps, log excerpts, error messages, stack traces, file paths and line numbers when relevant.
+- Wrap logs, stack traces, and command output in fenced code blocks (```` ```shell ````).
+- Use Markdown for everything else — GitHub renders it natively.
 - After creation, return the issue URL printed by `gh` so the user can open it.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-issue-forms.json
+name: Bug report
+description: Report a problem with the contextbridge CLI or plan review UI.
+title: 'bug: '
+labels: ['bug']
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Make sure you're on the latest version of `contextbridge` before filing. Quick questions and support belong in the [community Slack](https://go.contextbridge.ai/join-community), not the issue tracker.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: A clear, self-contained description of the problem.
+    validations:
+      required: true
+  - type: input
+    id: cli-version
+    attributes:
+      label: contextbridge version
+      description: Run `contextbridge --version` and paste the output.
+      placeholder: 1.2.3
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      description: |
+        Need to share more detail? Paste the output of `uname -a` into "Anything else" below.
+      options:
+        - macOS
+        - Linux
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      value: |
+        1. Run ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or stack trace
+      description: Paste any stderr output, stack traces, or pino log lines. Renders as a code block.
+      render: shell
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      description: Only fill in for plan review UI bugs.
+      placeholder: Chrome 124, Safari 17.4
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Anything else
+      description: Screenshots, related issues, environment notes, `uname -a` output, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-issue-config.json
+
+contact_links:
+  - name: ContextBridge community Slack
+    url: https://go.contextbridge.ai/join-community
+    about: Ask questions, share feedback, or chat with the team and other users.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-issue-forms.json
+# Keep `area` options in sync with `subcommand` in bug_report.yml and packages/cli/src/commands/index.ts.
+
+name: Feature request
+description: Suggest a new capability or an enhancement to an existing one.
+title: 'feat: '
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Big design ideas belong in the [community Slack](https://go.contextbridge.ai/join-community) first — that's where conversations turn into shared direction. File an issue here once the shape is clear.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the problem?
+      description: Describe the user pain or workflow gap before proposing a solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context


### PR DESCRIPTION
## Summary

Adds YAML issue forms for bug reports and feature requests under `.github/ISSUE_TEMPLATE/`, plus a chooser `config.yml` that adds a contact link to the community Slack. Closes #9 / PLAN-1.

## Review focus

- **Field set on `bug_report.yml`.** Required fields are: summary, `contextbridge` version, OS (macOS/Linux dropdown — Windows isn't supported), repro steps, expected, actual. Optional: logs (`render: shell`), browser, additional context. The \"area affected\" dropdown was cut to keep friction low — if triage benefits from it later, easy to add back.
- **`feature_request.yml` is intentionally lean.** Required: problem, proposed solution. Optional: alternatives, additional context. Same call as above on cutting the area dropdown.
- **`config.yml` keeps blank issues enabled** and adds a single Slack contact link. Reporters can still file unstructured issues if they want; the templates are nudges, not gates.
- **Schema reference comments** at the top of each file (`# yaml-language-server: =…`) wire up editor validation. Issue forms use `json.schemastore.org/github-issue-forms.json`; `config.yml` uses `github-issue-config.json` (different schema).
- **`title:` prefixes** are `bug:` and `feat:`. Different from PR commit-style `fix:` for bug fixes — these are issue titles, not commit messages, and `bug:` reads better in the issue list.
- **Stale comment in `feature_request.yml` line 2** references `subcommand` and `area` options that no longer exist after the dropdown removal — left as-is per the modifications you made; flag if you'd like it cleaned up.

## Commits

- [`494a534`](https://github.com/contextbridge/planbridge/pull/HEAD/commits/494a534dca795f75d668dc82cd753b4bade7995f) — add three issue-template files: `bug_report.yml`, `feature_request.yml`, `config.yml`.

## Verification done

- `just verify` passes (Prettier + typecheck + lint + tests).
- All three YAML files parse cleanly.
- Server-side checks (chooser render, dropdown options, label attachment) require this PR's branch on GitHub — open the New Issue page on the branch to confirm.