### PR TITLE
fix(plan): stop vitest reload flake from lazy zod optimization

### DIFF
--- a/packages/plan/vitest.config.ts
+++ b/packages/plan/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   ],
   optimizeDeps: {
     include: ['@testing-library/jest-dom/vitest'],
+    entries: ['src/**/*.{ts,tsx}'],
   },
   test: {
     setupFiles: ['./vitest.setup.ts'],


### PR DESCRIPTION
## Summary

The plan package's vitest browser run was flaky because Vite's initial dep-scan didn't follow imports into workspace package source, so `zod` (transitively pulled in via `@contextbridge/shared` schema files) was discovered lazily mid-run and triggered a reload that raced with the next test file's import — crashing `describe()` with `Cannot read properties of undefined (reading 'config')`. Pointing `optimizeDeps.entries` at plan's `src/**/*.{ts,tsx}` forces the scanner to crawl through shared up front, so transitive deps land in the pre-bundle before any test loads.

Closes #12.

## Review focus

- Whether `optimizeDeps.entries` is the right layer for this. The alternative is declaring `zod` as a direct devDep on plan; I argued against that since plan never directly imports zod and bun's `.bun/` isolation correctly enforces "import what you declare." The scan-based fix also stays durable if shared adds another transitive dep later — no per-dep maintenance.
- Glob breadth: `src/**/*.{ts,tsx}` scans demo/storybook files too. Not harmful (those files only run under storybook, not vitest), but worth a sanity check that no story-only import accidentally pulls a heavy lib into the pre-bundle.

## Commits

- [`0399e70`](https://github.com/contextbridge/planbridge/commit/0399e70b4b686accea9dcd8d8a7efc721df4ca77) — fix(plan): pre-scan src for transitive deps to stop vitest reload flake