### PR TITLE
chore: ignore CHANGELOG.md in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,6 @@ tools/infrastructure/cdk.out/
 .projen/
 .github/CODEOWNERS
 .github/workflows/auto-approve.yml
+
+# release-please owns CHANGELOG.md formatting; don't fight it.
+CHANGELOG.md


### PR DESCRIPTION
## Summary

The first release-please release PR ([#22](https://github.com/contextbridge/planbridge/pull/22)) fails the Lint job because `prettier --check "**/*.{ts,md,json}"` rejects `CHANGELOG.md` — release-please writes the file in its own opinionated markdown style and prettier wants to reformat it. Adding the file to `.prettierignore` is the path of least resistance and lets release-please own the formatting unchallenged.

## Review focus

The change is one entry in `.prettierignore`. Worth a quick gut-check that we're comfortable letting release-please own this file's formatting outright (the alternative would be running `prettier --write` post-release, which would just create churn — release-please rewrites the file every release).

This unblocks PR #22's lint, but does not by itself fix the duplicate Bug Fixes entry in 0.3.0 — that's a separate hand-edit on the release branch, planned as a follow-up after this lands.

## Commits

- [`e96ecac`](https://github.com/contextbridge/planbridge/commit/e96ecac) — add `CHANGELOG.md` to `.prettierignore` with a one-line comment explaining why.