### PR TITLE
chore: make submodule pointer relative

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tools"]
 	path = tools
-	url = git@github.com:contextbridge/planbridge-private.git
+	url = ../planbridge-private.git
 	branch = main
 	update = rebase
 	ignore = all


### PR DESCRIPTION
## Summary

This PR makes the submodule pointer for our internal `tools` relative to this repo's remote. This allows developers and our internal `cb-bot` to work with our submodule. 