### PR TITLE
chore(agents): fix agent bootstrap to not init submodules

### DIFF
--- a/.contextbridge/bootstrap.sh
+++ b/.contextbridge/bootstrap.sh
@@ -6,6 +6,4 @@ set -eu
 # install.scopes via $GITHUB_PACKAGES_AUTH_TOKEN, forwarded by docker-compose.
 bun install --frozen-lockfile
 
-./scripts/initToolsSubmodule.sh
-
 bunx playwright install chromium


### PR DESCRIPTION
## Summary

This PR fixes our clanker bootstrap script via avoiding submodules