### PR TITLE
chore(ci): allow any-case PR title subjects

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -32,6 +32,3 @@ jobs:
             build
             ci
           requireScope: false
-          subjectPattern: ^(?![A-Z]).+$
-          subjectPatternError: |
-            The subject "{subject}" must start with a lowercase letter.


### PR DESCRIPTION
## Summary

Removes the lowercase-only `subjectPattern` from the PR-title lint workflow. release-please renders the subject verbatim into the changelog and uses only the conventional-commit `type` for version bumps and section routing, so allowing either case has no effect on release tooling — the rule was purely cosmetic and was rejecting otherwise-valid titles.

## Review focus

Confirm you're OK with the resulting changelog mixing capitalized and lowercased subjects in perpetuity. If consistency matters, the alternative is to normalize at squash-merge time rather than reinstate the lint.

## Commits

- [`2332c55`](https://github.com/contextbridge/planbridge/commit/2332c559d3b3ad6c65f9715116564ff6a7d04c4b) — drop `subjectPattern`/`subjectPatternError` from `.github/workflows/lint-pr-title.yml`; the action now only enforces conventional-commit type/scope grammar.