### PR TITLE
refactor(testHelpers): replace FakeCommandRunner FIFO scripts with argument-keyed matchers

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'bun:test';
 import { Command } from 'commander';
 import { getDescriptor } from '#src/harnesses/registry.ts';
 import { environment } from '#src/testFactories.ts';
-import { createStubContext, readErrorLogs } from '#src/testHelpers/index.ts';
+import { createStubContext, marketplaceListResult, pluginListResult, readErrorLogs } from '#src/testHelpers/index.ts';
 import { resolveCbCommand, runCli } from './cli.ts';
 
 const CLAUDE_BINARY = getDescriptor('claude').binaryName;
@@ -91,13 +91,15 @@ describe('runCli', () => {
   it('routes argv into the install claude subcommand with default user scope', async () => {
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script({ exitCode: 0, stdout: '', stderr: '' }, { exitCode: 0, stdout: '', stderr: '' });
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
 
     const exitCode = await runCli(context, ['install', 'claude']);
 
     expect(exitCode).toBe(0);
-    expect(commandRunner.calls[0]?.args).toContain('--scope');
-    expect(commandRunner.calls[0]?.args).toContain('user');
+    const marketplaceAdd = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']);
+    expect(marketplaceAdd[0]?.args).toContain('--scope');
+    expect(marketplaceAdd[0]?.args).toContain('user');
     expect(io.stderr.text()).toContain('scope: user');
   });
 
@@ -149,28 +151,30 @@ describe('runCli', () => {
   it('routes argv into the uninstall claude subcommand with --scope project', async () => {
     const { context, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      { exitCode: 0, stdout: JSON.stringify([{ id: 'cli@contextbridge', scope: 'project' }]), stderr: '' },
-      { exitCode: 0, stdout: '', stderr: '' },
-      { exitCode: 0, stdout: JSON.stringify([{ name: 'contextbridge' }]), stderr: '' },
-      { exitCode: 0, stdout: '', stderr: '' },
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'project' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
 
     const exitCode = await runCli(context, ['uninstall', 'claude', '--scope', 'project']);
 
     expect(exitCode).toBe(0);
-    expect(commandRunner.calls[1]?.args).toEqual(['plugin', 'uninstall', 'cli@contextbridge', '--scope', 'project']);
+    const uninstallCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall']);
+    expect(uninstallCalls).toHaveLength(1);
+    expect(uninstallCalls[0]?.args).toEqual(['plugin', 'uninstall', 'cli@contextbridge', '--scope', 'project']);
   });
 
   it('routes argv into the no-target install orchestrator with --yes', async () => {
     const { context, io, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      { exitCode: 0, stdout: '[]', stderr: '' },
-      { exitCode: 0, stdout: '[]', stderr: '' },
-      { exitCode: 0, stdout: '', stderr: '' },
-      { exitCode: 0, stdout: '', stderr: '' },
-    );
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
 
     const exitCode = await runCli(context, ['install', '--yes']);
 
@@ -182,10 +186,12 @@ describe('runCli', () => {
   it('routes argv into install status with --json and emits to stdout', async () => {
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      { exitCode: 0, stdout: JSON.stringify([{ name: 'contextbridge' }]), stderr: '' },
-      { exitCode: 0, stdout: JSON.stringify([{ id: 'cli@contextbridge', scope: 'user' }]), stderr: '' },
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
 
     const exitCode = await runCli(context, ['install', 'status', '--json']);
 
@@ -196,10 +202,12 @@ describe('runCli', () => {
   it('registers cb_command and identifies before parsing for a top-level subcommand', async () => {
     const { context, analytics, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      { exitCode: 0, stdout: JSON.stringify([{ name: 'contextbridge' }]), stderr: '' },
-      { exitCode: 0, stdout: JSON.stringify([{ id: 'cli@contextbridge', scope: 'user' }]), stderr: '' },
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
 
     const exitCode = await runCli(context, ['install', 'status', '--json']);
 

--- a/packages/cli/src/commands/install.test.ts
+++ b/packages/cli/src/commands/install.test.ts
@@ -5,13 +5,7 @@ import { describe, expect, it } from 'bun:test';
 import { CommanderError } from 'commander';
 import { getDescriptor } from '#src/harnesses/registry.ts';
 import { environment } from '#src/testFactories.ts';
-import {
-  type FakeCommandCall,
-  type FakeCommandRunner,
-  createStubContext,
-  marketplaceListResult,
-  pluginListResult,
-} from '#src/testHelpers/index.ts';
+import { createStubContext, marketplaceListResult, pluginListResult } from '#src/testHelpers/index.ts';
 import { runInstall } from './install.ts';
 
 const CLAUDE_BINARY = getDescriptor('claude').binaryName;
@@ -21,23 +15,26 @@ describe('runInstall', () => {
   it('with --yes installs Claude when not yet wired up and reports the summary', async () => {
     const { context, io, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([]),
-      pluginListResult([]),
-      { exitCode: 0, stdout: '', stderr: '' },
-      { exitCode: 0, stdout: '', stderr: '' },
-    );
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
 
     await runInstall(context, { yes: true });
 
-    expect(installCalls(commandRunner)).toEqual([
-      {
-        cmd: CLAUDE_BINARY,
-        args: ['plugin', 'marketplace', 'add', 'contextbridge/claude-plugin', '--scope', 'user'],
-        opts: {},
-      },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'install', 'cli@contextbridge', '--scope', 'user'], opts: {} },
+    const marketplaceAdd = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']);
+    const pluginInstall = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install']);
+    expect(marketplaceAdd).toHaveLength(1);
+    expect(marketplaceAdd[0]?.args).toEqual([
+      'plugin',
+      'marketplace',
+      'add',
+      'contextbridge/claude-plugin',
+      '--scope',
+      'user',
     ]);
+    expect(pluginInstall).toHaveLength(1);
+    expect(pluginInstall[0]?.args).toEqual(['plugin', 'install', 'cli@contextbridge', '--scope', 'user']);
     expect(prompter.calls).toEqual([]);
     const stderr = io.stderr.text();
     expect(stderr).toContain('Claude Code: not installed');
@@ -47,14 +44,17 @@ describe('runInstall', () => {
   it('skips already-installed harnesses by default and notes them in the summary', async () => {
     const { context, io, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]),
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
 
     await runInstall(context, { yes: true });
 
-    expect(installCalls(commandRunner)).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toEqual([]);
     expect(prompter.calls).toEqual([]);
     const stderr = io.stderr.text();
     expect(stderr).toContain('Claude Code: installed (marketplace contextbridge; plugin cli@contextbridge @ user)');
@@ -64,16 +64,19 @@ describe('runInstall', () => {
   it('with --force re-runs install over an already-installed harness and drops the skipped suffix', async () => {
     const { context, io, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]),
-      { exitCode: 0, stdout: '', stderr: '' },
-      { exitCode: 0, stdout: '', stderr: '' },
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
 
     await runInstall(context, { yes: true, force: true });
 
-    expect(installCalls(commandRunner)).toHaveLength(2);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toHaveLength(1);
     expect(prompter.calls).toEqual([]);
     const stderr = io.stderr.text();
     expect(stderr).toContain('Installed 1 of 1 detected harness');
@@ -83,14 +86,17 @@ describe('runInstall', () => {
   it('treats an install at a different scope as already installed and skips by default', async () => {
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'project' }]),
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'project' }]));
 
     await runInstall(context, { yes: true });
 
-    expect(installCalls(commandRunner)).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toEqual([]);
     const stderr = io.stderr.text();
     expect(stderr).toContain('Claude Code: installed (marketplace contextbridge; plugin cli@contextbridge @ project)');
     expect(stderr).toContain('(1 already installed, skipped)');
@@ -99,16 +105,17 @@ describe('runInstall', () => {
   it('does not skip Claude when only the marketplace is configured', async () => {
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      pluginListResult([]),
-      { exitCode: 0, stdout: '', stderr: '' },
-      { exitCode: 0, stdout: '', stderr: '' },
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
 
     await runInstall(context, { yes: true });
 
-    expect(installCalls(commandRunner)).toHaveLength(2);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toHaveLength(1);
     const stderr = io.stderr.text();
     expect(stderr).toContain('Claude Code: not installed (marketplace contextbridge)');
     expect(stderr).toContain('Installed 1 of 1 detected harness');
@@ -120,12 +127,10 @@ describe('runInstall', () => {
     const { context, io, commandRunner } = createStubContext({ env: environment.build({ HOME: tmp }) });
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
     commandRunner.setWhich(CODEX_BINARY, '/usr/local/bin/codex');
-    commandRunner.script(
-      marketplaceListResult([]),
-      pluginListResult([]),
-      { exitCode: 0, stdout: '', stderr: '' },
-      { exitCode: 0, stdout: '', stderr: '' },
-    );
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
 
     try {
       const configDir = join(tmp, '.codex');
@@ -138,14 +143,19 @@ describe('runInstall', () => {
       if (!(err instanceof CommanderError)) throw err;
       expect(err.message).toBe('Install failed for: Codex CLI');
 
-      expect(installCalls(commandRunner)).toEqual([
-        {
-          cmd: CLAUDE_BINARY,
-          args: ['plugin', 'marketplace', 'add', 'contextbridge/claude-plugin', '--scope', 'user'],
-          opts: {},
-        },
-        { cmd: CLAUDE_BINARY, args: ['plugin', 'install', 'cli@contextbridge', '--scope', 'user'], opts: {} },
+      const marketplaceAdd = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']);
+      const pluginInstall = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install']);
+      expect(marketplaceAdd).toHaveLength(1);
+      expect(marketplaceAdd[0]?.args).toEqual([
+        'plugin',
+        'marketplace',
+        'add',
+        'contextbridge/claude-plugin',
+        '--scope',
+        'user',
       ]);
+      expect(pluginInstall).toHaveLength(1);
+      expect(pluginInstall[0]?.args).toEqual(['plugin', 'install', 'cli@contextbridge', '--scope', 'user']);
       const stderr = io.stderr.text();
       expect(stderr).toContain('Codex CLI: status unavailable (invalid Codex hooks.json');
       expect(stderr).toContain('Installed 1 of 2 detected harnesses.');
@@ -157,12 +167,14 @@ describe('runInstall', () => {
   it('without --yes prompts the user and skips when they decline', async () => {
     const { context, io, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(marketplaceListResult([]), pluginListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
     prompter.setConfirm(false);
 
     await runInstall(context);
 
-    expect(installCalls(commandRunner)).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toEqual([]);
     expect(prompter.calls).toEqual([{ message: 'Install PlanBridge into Claude Code?', default: true }]);
     expect(io.stderr.text()).toContain('Claude Code: skipped');
     expect(io.stderr.text()).toContain('Installed 0 of 1 detected harness');
@@ -171,20 +183,21 @@ describe('runInstall', () => {
   it('without --yes runs confirm + scope prompts and installs at the chosen scope', async () => {
     const { context, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([]),
-      pluginListResult([]),
-      { exitCode: 0, stdout: '', stderr: '' },
-      { exitCode: 0, stdout: '', stderr: '' },
-    );
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
     prompter.setConfirm(true);
     prompter.setSelect('project');
 
     await runInstall(context);
 
-    const calls = installCalls(commandRunner);
-    expect(calls).toHaveLength(2);
-    expect(calls[0]?.args).toContain('project');
+    const marketplaceAdd = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']);
+    const pluginInstall = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install']);
+    expect(marketplaceAdd).toHaveLength(1);
+    expect(pluginInstall).toHaveLength(1);
+    expect(marketplaceAdd[0]?.args).toContain('project');
+    expect(pluginInstall[0]?.args).toContain('project');
     expect(prompter.calls).toHaveLength(1);
     expect(prompter.selectCalls).toHaveLength(1);
     expect(prompter.selectCalls[0]?.message).toBe('Install scope:');
@@ -199,13 +212,6 @@ describe('runInstall', () => {
     expect(io.stderr.text()).toContain('Claude Code: not detected');
   });
 });
-
-function installCalls(commandRunner: FakeCommandRunner): FakeCommandCall[] {
-  return commandRunner.calls.filter((call) => {
-    const joined = call.args.join(' ');
-    return joined !== 'plugin marketplace list --json' && joined !== 'plugin list --json';
-  });
-}
 
 async function captureError(promise: Promise<unknown>): Promise<unknown> {
   try {

--- a/packages/cli/src/commands/installStatus.test.ts
+++ b/packages/cli/src/commands/installStatus.test.ts
@@ -9,10 +9,12 @@ describe('runInstallStatus', () => {
   it('writes prose to stderr and leaves stdout empty by default when PlanBridge is fully wired', async () => {
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]),
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
 
     await runInstallStatus(context);
 
@@ -26,7 +28,8 @@ describe('runInstallStatus', () => {
   it('reports "not installed" when claude is on PATH but PlanBridge is absent', async () => {
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(marketplaceListResult([]), pluginListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
 
     await runInstallStatus(context);
 
@@ -36,7 +39,10 @@ describe('runInstallStatus', () => {
   it('reports partial Claude artifacts without calling them installed', async () => {
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(marketplaceListResult([{ name: 'contextbridge' }]), pluginListResult([]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
 
     await runInstallStatus(context);
 
@@ -48,7 +54,10 @@ describe('runInstallStatus', () => {
   it('reports project-scope Claude installs', async () => {
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(marketplaceListResult([]), pluginListResult([{ id: 'cli@contextbridge', scope: 'project' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'project' }]));
 
     await runInstallStatus(context);
 
@@ -68,10 +77,12 @@ describe('runInstallStatus', () => {
   it('with --json writes machine-readable JSON to stdout and leaves stderr empty', async () => {
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]),
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
 
     await runInstallStatus(context, { json: true });
 

--- a/packages/cli/src/commands/uninstall.test.ts
+++ b/packages/cli/src/commands/uninstall.test.ts
@@ -10,25 +10,23 @@ describe('runUninstall', () => {
   it('with --yes uninstalls when PlanBridge is wired up and reports the summary', async () => {
     const { context, io, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]),
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]),
-      { exitCode: 0, stdout: '', stderr: '' },
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      { exitCode: 0, stdout: '', stderr: '' },
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
 
     await runUninstall(context, { yes: true });
 
-    const sideEffects = commandRunner.calls.filter((call) => {
-      const joined = call.args.join(' ');
-      return !joined.endsWith('--json');
-    });
-    expect(sideEffects).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'uninstall', 'cli@contextbridge', '--scope', 'user'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'remove', 'contextbridge'], opts: {} },
-    ]);
+    const uninstallCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall']);
+    const marketplaceRemoveCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']);
+    expect(uninstallCalls).toHaveLength(1);
+    expect(uninstallCalls[0]?.args).toEqual(['plugin', 'uninstall', 'cli@contextbridge', '--scope', 'user']);
+    expect(marketplaceRemoveCalls).toHaveLength(1);
+    expect(marketplaceRemoveCalls[0]?.args).toEqual(['plugin', 'marketplace', 'remove', 'contextbridge']);
     expect(prompter.calls).toEqual([]);
     expect(io.stderr.text()).toContain('Uninstalled 1 of 1 detected harness');
   });
@@ -36,11 +34,13 @@ describe('runUninstall', () => {
   it('skips harnesses where PlanBridge is not installed and notes them in the summary', async () => {
     const { context, io, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(marketplaceListResult([]), pluginListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
 
     await runUninstall(context, { yes: true });
 
-    expect(commandRunner.calls).toHaveLength(2);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toEqual([]);
     expect(prompter.calls).toEqual([]);
     const stderr = io.stderr.text();
     expect(stderr).toContain('Claude Code: not installed');
@@ -50,20 +50,18 @@ describe('runUninstall', () => {
   it('cleans up Claude marketplace-only partial installs instead of treating them as already uninstalled', async () => {
     const { context, io, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      pluginListResult([]),
-      pluginListResult([]),
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      { exitCode: 0, stdout: '', stderr: '' },
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
 
     await runUninstall(context, { yes: true });
 
-    const sideEffects = commandRunner.calls.filter((call) => !call.args.join(' ').endsWith('--json'));
-    expect(sideEffects).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'remove', 'contextbridge'], opts: {} },
-    ]);
+    const marketplaceRemoveCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
+    expect(marketplaceRemoveCalls).toHaveLength(1);
+    expect(marketplaceRemoveCalls[0]?.args).toEqual(['plugin', 'marketplace', 'remove', 'contextbridge']);
     expect(prompter.calls).toEqual([]);
     const stderr = io.stderr.text();
     expect(stderr).toContain('Claude Code: not installed (marketplace contextbridge)');
@@ -73,16 +71,13 @@ describe('runUninstall', () => {
   it('with --force runs uninstall even when nothing is installed and drops the skipped suffix', async () => {
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([]),
-      pluginListResult([]),
-      pluginListResult([]),
-      marketplaceListResult([]),
-    );
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
 
     await runUninstall(context, { yes: true, force: true });
 
-    expect(commandRunner.calls).toHaveLength(4);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toEqual([]);
     const stderr = io.stderr.text();
     expect(stderr).toContain('Uninstalled 1 of 1 detected harness');
     expect(stderr).not.toContain('skipped');
@@ -91,10 +86,12 @@ describe('runUninstall', () => {
   it('without --yes prompts the user and skips when they decline', async () => {
     const { context, io, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]),
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
     prompter.setConfirm(false);
 
     await runUninstall(context);

--- a/packages/cli/src/harnesses/ClaudeInstaller.test.ts
+++ b/packages/cli/src/harnesses/ClaudeInstaller.test.ts
@@ -17,10 +17,12 @@ describe('ClaudeInstaller.install', () => {
     const installer = new ClaudeInstaller();
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script({ exitCode: 0, stdout: '', stderr: '' }, { exitCode: 0, stdout: '', stderr: '' });
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
 
     await installer.install(context, { yes: true });
 
+    // Ordering is load-bearing: marketplace-add must precede plugin-install.
     expect(commandRunner.calls).toEqual([
       {
         cmd: CLAUDE_BINARY,
@@ -40,19 +42,12 @@ describe('ClaudeInstaller.install', () => {
     const installer = new ClaudeInstaller();
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      {
-        exitCode: 0,
-        stdout: "Adding marketplace…✔ Marketplace 'contextbridge' already on disk — declared in user settings",
-        stderr: '',
-      },
-      {
-        exitCode: 0,
-        stdout:
-          'Installing plugin "cli@contextbridge"...✔ Plugin "cli@contextbridge" is already installed (scope: user)',
-        stderr: '',
-      },
-    );
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves({
+      stdout: "Adding marketplace…✔ Marketplace 'contextbridge' already on disk — declared in user settings",
+    });
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves({
+      stdout: 'Installing plugin "cli@contextbridge"...✔ Plugin "cli@contextbridge" is already installed (scope: user)',
+    });
 
     await installer.install(context, { yes: true });
 
@@ -72,10 +67,13 @@ describe('ClaudeInstaller.install', () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner, logs } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script({ exitCode: 1, stdout: '', stderr: 'network unreachable' });
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])
+      .resolves({ exitCode: 1, stderr: 'network unreachable' });
 
     expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
-    expect(commandRunner.calls).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toEqual([]);
     expect(readErrorLogs(logs).some((r) => r.msg.includes('network unreachable'))).toBe(true);
   });
 
@@ -83,13 +81,14 @@ describe('ClaudeInstaller.install', () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner, logs } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      { exitCode: 0, stdout: '', stderr: '' },
-      { exitCode: 1, stdout: '', stderr: 'plugin not found in marketplace' },
-    );
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'install'])
+      .resolves({ exitCode: 1, stderr: 'plugin not found in marketplace' });
 
     expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
-    expect(commandRunner.calls).toHaveLength(2);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toHaveLength(1);
     expect(readErrorLogs(logs).some((r) => r.msg.includes('plugin not found in marketplace'))).toBe(true);
   });
 
@@ -97,7 +96,7 @@ describe('ClaudeInstaller.install', () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner, logs } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script({ exitCode: 3, stdout: '', stderr: '' });
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves({ exitCode: 3 });
 
     expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
     expect(readLogs(logs).some((r) => r.msg.includes('exited 3'))).toBe(true);
@@ -109,15 +108,18 @@ describe('ClaudeInstaller.uninstall', () => {
     const installer = new ClaudeInstaller();
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]),
-      { exitCode: 0, stdout: '', stderr: '' },
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      { exitCode: 0, stdout: '', stderr: '' },
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
 
     await installer.uninstall(context, { yes: true });
 
+    // Ordering is load-bearing: list → uninstall → list-marketplaces → remove-marketplace.
     expect(commandRunner.calls).toEqual([
       { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
       { cmd: CLAUDE_BINARY, args: ['plugin', 'uninstall', 'cli@contextbridge', '--scope', 'user'], opts: {} },
@@ -132,19 +134,18 @@ describe('ClaudeInstaller.uninstall', () => {
     const installer = new ClaudeInstaller();
     const { context, io, commandRunner, logs } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'project' }]),
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      { exitCode: 0, stdout: '', stderr: '' },
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'project' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
 
     await installer.uninstall(context, { yes: true });
 
-    expect(commandRunner.calls).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'list', '--json'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'remove', 'contextbridge'], opts: {} },
-    ]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toHaveLength(1);
     expect(io.stderr.text()).toContain('PlanBridge plugin removed');
     expect(readLogs(logs).some((r) => r.msg.includes('not installed at scope user'))).toBe(true);
   });
@@ -153,19 +154,16 @@ describe('ClaudeInstaller.uninstall', () => {
     const installer = new ClaudeInstaller();
     const { context, io, commandRunner, logs } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]),
-      { exitCode: 0, stdout: '', stderr: '' },
-      marketplaceListResult([]),
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
 
     await installer.uninstall(context, { yes: true });
 
-    expect(commandRunner.calls).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'uninstall', 'cli@contextbridge', '--scope', 'user'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'list', '--json'], opts: {} },
-    ]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toEqual([]);
     expect(io.stderr.text()).toContain('PlanBridge plugin removed');
     expect(readLogs(logs).some((r) => r.msg.includes('marketplace is not configured'))).toBe(true);
   });
@@ -174,14 +172,13 @@ describe('ClaudeInstaller.uninstall', () => {
     const installer = new ClaudeInstaller();
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(pluginListResult([]), marketplaceListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
 
     await installer.uninstall(context, { yes: true });
 
-    expect(commandRunner.calls).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'list', '--json'], opts: {} },
-    ]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toEqual([]);
     expect(io.stderr.text()).toContain('PlanBridge plugin removed');
   });
 
@@ -198,7 +195,9 @@ describe('ClaudeInstaller.uninstall', () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner, logs } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script({ exitCode: 1, stdout: '', stderr: 'permission denied' });
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves({ exitCode: 1, stderr: 'permission denied' });
 
     expect(installer.uninstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
     expect(commandRunner.calls).toHaveLength(1);
@@ -209,14 +208,15 @@ describe('ClaudeInstaller.uninstall', () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner, logs } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]), {
-      exitCode: 1,
-      stdout: '',
-      stderr: 'disk full',
-    });
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves({ exitCode: 1, stderr: 'disk full' });
 
     expect(installer.uninstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
-    expect(commandRunner.calls).toHaveLength(2);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'list', '--json'])).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])).toEqual([]);
     expect(readErrorLogs(logs).some((r) => r.msg.includes('disk full'))).toBe(true);
   });
 
@@ -224,15 +224,19 @@ describe('ClaudeInstaller.uninstall', () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner, logs } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]),
-      { exitCode: 0, stdout: '', stderr: '' },
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      { exitCode: 1, stdout: '', stderr: 'some other marketplace error' },
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])
+      .resolves({ exitCode: 1, stderr: 'some other marketplace error' });
 
     expect(installer.uninstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
-    expect(commandRunner.calls).toHaveLength(4);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toHaveLength(1);
     expect(readErrorLogs(logs).some((r) => r.msg.includes('some other marketplace error'))).toBe(true);
   });
 });
@@ -242,46 +246,53 @@ describe('ClaudeInstaller scope prompt', () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script({ exitCode: 0, stdout: '', stderr: '' }, { exitCode: 0, stdout: '', stderr: '' });
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
     prompter.setSelect('project');
 
     await installer.install(context, { yes: false });
 
     expect(prompter.selectCalls).toHaveLength(1);
     expect(prompter.selectCalls[0]?.message).toBe('Install scope:');
-    expect(commandRunner.calls[0]?.args).toContain('project');
-    expect(commandRunner.calls[1]?.args).toContain('project');
+    const marketplaceAdd = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']);
+    const pluginInstall = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install']);
+    expect(marketplaceAdd[0]?.args).toContain('project');
+    expect(pluginInstall[0]?.args).toContain('project');
   });
 
   it('skips the scope prompt when yes=true and uses the user-scope default', async () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script({ exitCode: 0, stdout: '', stderr: '' }, { exitCode: 0, stdout: '', stderr: '' });
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
 
     await installer.install(context, { yes: true });
 
     expect(prompter.selectCalls).toEqual([]);
-    expect(commandRunner.calls[0]?.args).toContain('user');
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])[0]?.args).toContain('user');
   });
 
   it('prompts for scope on uninstall when yes=false', async () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner, prompter } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'project' }]),
-      { exitCode: 0, stdout: '', stderr: '' },
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      { exitCode: 0, stdout: '', stderr: '' },
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'project' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
     prompter.setSelect('project');
 
     await installer.uninstall(context, { yes: false });
 
     expect(prompter.selectCalls).toHaveLength(1);
     expect(prompter.selectCalls[0]?.message).toBe('Uninstall scope:');
-    expect(commandRunner.calls[1]?.args).toEqual(['plugin', 'uninstall', 'cli@contextbridge', '--scope', 'project']);
+    const uninstallCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall']);
+    expect(uninstallCalls[0]?.args).toEqual(['plugin', 'uninstall', 'cli@contextbridge', '--scope', 'project']);
   });
 });
 
@@ -303,10 +314,12 @@ describe('ClaudeInstaller.status', () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(
-      marketplaceListResult([{ name: 'contextbridge' }]),
-      pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]),
-    );
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'user' }]));
 
     const status = await installer.status(context);
 
@@ -322,7 +335,10 @@ describe('ClaudeInstaller.status', () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(marketplaceListResult([]), pluginListResult([{ id: 'cli@contextbridge', scope: 'project' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: 'cli@contextbridge', scope: 'project' }]));
 
     const status = await installer.status(context);
 
@@ -335,7 +351,10 @@ describe('ClaudeInstaller.status', () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(marketplaceListResult([{ name: 'contextbridge' }]), pluginListResult([]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: 'contextbridge' }]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
 
     const status = await installer.status(context);
 
@@ -348,7 +367,8 @@ describe('ClaudeInstaller.status', () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script(marketplaceListResult([]), pluginListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
 
     const status = await installer.status(context);
 
@@ -361,7 +381,7 @@ describe('ClaudeInstaller.status', () => {
     const installer = new ClaudeInstaller();
     const { context, commandRunner, logs } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.script({ exitCode: 2, stdout: '', stderr: '' });
+    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves({ exitCode: 2 });
 
     expect(installer.status(context)).rejects.toBeInstanceOf(CommanderError);
     expect(readErrorLogs(logs).some((r) => r.msg.includes('exited 2'))).toBe(true);

--- a/packages/cli/src/testHelpers/FakeCommandRunner.test.ts
+++ b/packages/cli/src/testHelpers/FakeCommandRunner.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'bun:test';
+import { FakeCommandRunner } from './FakeCommandRunner.ts';
+
+describe('FakeCommandRunner', () => {
+  describe('which', () => {
+    it('returns the resolved path when set', () => {
+      const cr = new FakeCommandRunner();
+      cr.setWhich('claude', '/usr/local/bin/claude');
+      expect(cr.which('claude')).toBe('/usr/local/bin/claude');
+    });
+
+    it('returns null when set to null', () => {
+      const cr = new FakeCommandRunner();
+      cr.setWhich('claude', null);
+      expect(cr.which('claude')).toBeNull();
+    });
+  });
+
+  describe('on(cmd, args) — prefix match', () => {
+    it('matches when call args start with the matcher args', async () => {
+      const cr = new FakeCommandRunner();
+      cr.on('claude', ['plugin', 'install']).resolves({ stdout: 'ok' });
+
+      const result = await cr.run('claude', ['plugin', 'install', 'cli@contextbridge', '--scope', 'user']);
+
+      expect(result.stdout).toBe('ok');
+    });
+
+    it('does not match when prefix differs', () => {
+      const cr = new FakeCommandRunner();
+      cr.on('claude', ['plugin', 'install']).resolves();
+
+      expect(cr.run('claude', ['plugin', 'list'])).rejects.toThrow(/no responder/);
+    });
+
+    it('does not match when cmd differs', () => {
+      const cr = new FakeCommandRunner();
+      cr.on('claude', ['plugin']).resolves();
+
+      expect(cr.run('codex', ['plugin'])).rejects.toThrow(/no responder/);
+    });
+
+    it('without args matches any args for cmd', async () => {
+      const cr = new FakeCommandRunner();
+      cr.on('claude').resolves({ stdout: 'ok' });
+
+      const result = await cr.run('claude', ['anything', 'goes']);
+
+      expect(result.stdout).toBe('ok');
+    });
+  });
+
+  describe('onAny()', () => {
+    it('fires for any call', async () => {
+      const cr = new FakeCommandRunner();
+      cr.onAny().resolves({ stdout: 'catch' });
+
+      const r1 = await cr.run('claude', ['plugin', 'list']);
+      const r2 = await cr.run('codex', ['something', 'else']);
+
+      expect(r1.stdout).toBe('catch');
+      expect(r2.stdout).toBe('catch');
+    });
+  });
+
+  describe('resolves() defaults', () => {
+    it('resolves with { exitCode: 0, stdout: "", stderr: "" } when called with no argument', async () => {
+      const cr = new FakeCommandRunner();
+      cr.onAny().resolves();
+
+      const result = await cr.run('claude', []);
+
+      expect(result).toEqual({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    it('fills missing fields when given a partial result', async () => {
+      const cr = new FakeCommandRunner();
+      cr.onAny().resolves({ exitCode: 1, stderr: 'boom' });
+
+      const result = await cr.run('claude', []);
+
+      expect(result).toEqual({ exitCode: 1, stdout: '', stderr: 'boom' });
+    });
+  });
+
+  describe('matcher order — first match wins', () => {
+    it('uses the responder registered first when multiple match', async () => {
+      const cr = new FakeCommandRunner();
+      cr.onAny().resolves({ stdout: 'first' });
+      cr.onAny().resolves({ stdout: 'second' });
+
+      const result = await cr.run('claude', []);
+
+      expect(result.stdout).toBe('first');
+    });
+
+    it('falls through past responders that do not match', async () => {
+      const cr = new FakeCommandRunner();
+      cr.on('claude').resolves({ stdout: 'claude-result' });
+      cr.on('codex').resolves({ stdout: 'codex-result' });
+
+      const result = await cr.run('codex', []);
+
+      expect(result.stdout).toBe('codex-result');
+    });
+  });
+
+  describe('rejects()', () => {
+    it('rejects with the provided Error', () => {
+      const cr = new FakeCommandRunner();
+      cr.on('claude').rejects(new Error('boom'));
+
+      expect(cr.run('claude', [])).rejects.toThrow('boom');
+    });
+
+    it('wraps non-Error rejection values in an Error', () => {
+      const cr = new FakeCommandRunner();
+      cr.onAny().rejects('string failure');
+
+      expect(cr.run('claude', [])).rejects.toThrow('string failure');
+    });
+  });
+
+  describe('miss diagnostic', () => {
+    it('describes the failing call, registered matchers, and prior calls', async () => {
+      const cr = new FakeCommandRunner();
+      cr.on('claude', ['plugin']).resolves();
+      cr.on('codex').resolves();
+
+      await cr.run('claude', ['plugin', 'list']);
+
+      const reason = await cr.run('zsh', ['-c', 'pwd']).catch((err: unknown) => (err as Error).message);
+
+      expect(reason).toContain('no responder for `zsh -c pwd`');
+      expect(reason).toContain('Registered matchers (2, in order):');
+      expect(reason).toContain('1. on("claude", ["plugin"])');
+      expect(reason).toContain('2. on("codex")');
+      expect(reason).toContain('Prior calls in this run (1):');
+      expect(reason).toContain('1. claude plugin list');
+    });
+
+    it('shows "(none)" when no matchers are registered', async () => {
+      const cr = new FakeCommandRunner();
+      const reason = await cr.run('zsh', []).catch((err: unknown) => (err as Error).message);
+      expect(reason).toContain('Registered matchers (0, in order):\n  (none)');
+      expect(reason).toContain('Prior calls in this run (0):\n  (none)');
+    });
+
+    it('records the failing call in calls[]', () => {
+      const cr = new FakeCommandRunner();
+      expect(cr.run('claude', ['x'])).rejects.toThrow(/no responder/);
+      expect(cr.calls).toEqual([{ cmd: 'claude', args: ['x'], opts: {} }]);
+    });
+  });
+
+  describe('calls bookkeeping', () => {
+    it('records every call regardless of whether a responder matched', async () => {
+      const cr = new FakeCommandRunner();
+      cr.onAny().resolves();
+
+      await cr.run('claude', ['one']);
+      await cr.run('codex', ['two', 'three']);
+
+      expect(cr.calls).toEqual([
+        { cmd: 'claude', args: ['one'], opts: {} },
+        { cmd: 'codex', args: ['two', 'three'], opts: {} },
+      ]);
+    });
+
+    it('records the opts argument', async () => {
+      const cr = new FakeCommandRunner();
+      cr.onAny().resolves();
+
+      await cr.run('claude', ['x'], { stdio: 'inherit' });
+
+      expect(cr.calls[0]?.opts).toEqual({ stdio: 'inherit' });
+    });
+  });
+
+  describe('callsTo', () => {
+    it('filters by prefix match', async () => {
+      const cr = new FakeCommandRunner();
+      cr.onAny().resolves();
+
+      await cr.run('claude', ['plugin', 'install', 'cli@contextbridge']);
+      await cr.run('claude', ['plugin', 'list', '--json']);
+      await cr.run('codex', ['plugin', 'install']);
+
+      expect(cr.callsTo('claude', ['plugin', 'install'])).toHaveLength(1);
+      expect(cr.callsTo('claude', ['plugin', 'install'])[0]?.args).toEqual(['plugin', 'install', 'cli@contextbridge']);
+      expect(cr.callsTo('claude')).toHaveLength(2);
+    });
+  });
+});

--- a/packages/cli/src/testHelpers/FakeCommandRunner.ts
+++ b/packages/cli/src/testHelpers/FakeCommandRunner.ts
@@ -1,3 +1,4 @@
+import { toError } from '@contextbridge/shared/errors';
 import type { CommandRunner, RunCommandOptions, RunCommandResult } from '#src/CommandRunnerImpl.ts';
 
 export interface FakeCommandCall {
@@ -6,29 +7,84 @@ export interface FakeCommandCall {
   readonly opts: RunCommandOptions;
 }
 
+export interface CommandStub {
+  /** Defaults: `exitCode: 0`, `stdout: ''`, `stderr: ''`. Pass a partial to override. */
+  resolves(result?: Partial<RunCommandResult>): void;
+  /** Reject the run() promise (simulates the runner itself throwing — not a non-zero exit). */
+  rejects(err: unknown): void;
+}
+
+type Matcher = (cmd: string, args: readonly string[]) => boolean;
+type Outcome = { kind: 'resolve'; result: RunCommandResult } | { kind: 'reject'; err: unknown };
+
+interface Responder {
+  readonly matcher: Matcher;
+  readonly label: string;
+  readonly outcome: Outcome;
+}
+
 export class FakeCommandRunner implements CommandRunner {
   readonly calls: FakeCommandCall[] = [];
   private readonly whichMap = new Map<string, string | null>();
-  private readonly scripted: RunCommandResult[] = [];
+  private readonly responders: Responder[] = [];
 
   setWhich(cmd: string, resolved: string | null): void {
     this.whichMap.set(cmd, resolved);
   }
 
-  script(...results: RunCommandResult[]): void {
-    this.scripted.push(...results);
+  which(cmd: string): string | null {
+    return this.whichMap.get(cmd) ?? null;
   }
 
-  which(cmd: string): string | null {
-    return this.whichMap.has(cmd) ? (this.whichMap.get(cmd) ?? null) : null;
+  on(cmd: string, args: readonly string[] = []): CommandStub {
+    return this.register(
+      (c, callArgs) => c === cmd && args.every((v, i) => callArgs[i] === v),
+      `on(${JSON.stringify(cmd)}${args.length === 0 ? '' : `, ${JSON.stringify(args)}`})`,
+    );
+  }
+
+  onAny(): CommandStub {
+    return this.register(() => true, 'onAny()');
+  }
+
+  callsTo(cmd: string, args: readonly string[] = []): FakeCommandCall[] {
+    return this.calls.filter((call) => call.cmd === cmd && args.every((v, i) => call.args[i] === v));
   }
 
   run(cmd: string, args: readonly string[], opts: RunCommandOptions = {}): Promise<RunCommandResult> {
     this.calls.push({ cmd, args, opts });
-    const next = this.scripted.shift();
-    if (!next) {
-      return Promise.reject(new Error(`FakeCommandRunner: no scripted result for ${cmd} ${args.join(' ')}`));
+    const responder = this.responders.find((r) => r.matcher(cmd, args));
+    if (!responder) {
+      return Promise.reject(new Error(this.formatMiss(cmd, args)));
     }
-    return Promise.resolve(next);
+    return responder.outcome.kind === 'resolve'
+      ? Promise.resolve(responder.outcome.result)
+      : Promise.reject(toError(responder.outcome.err));
+  }
+
+  private register(matcher: Matcher, label: string): CommandStub {
+    const push = (outcome: Outcome): void => {
+      this.responders.push({ matcher, label, outcome });
+    };
+    return {
+      resolves: ({ exitCode = 0, stdout = '', stderr = '' } = {}) =>
+        push({ kind: 'resolve', result: { exitCode, stdout, stderr } }),
+      rejects: (err) => push({ kind: 'reject', err }),
+    };
+  }
+
+  private formatMiss(cmd: string, args: readonly string[]): string {
+    const prior = this.calls.slice(0, -1);
+    const matchers =
+      this.responders.length === 0 ? '  (none)' : this.responders.map((r, i) => `  ${i + 1}. ${r.label}`).join('\n');
+    const priorList =
+      prior.length === 0 ? '  (none)' : prior.map((c, i) => `  ${i + 1}. ${[c.cmd, ...c.args].join(' ')}`).join('\n');
+    return [
+      `FakeCommandRunner: no responder for \`${[cmd, ...args].join(' ')}\`.`,
+      `Registered matchers (${this.responders.length}, in order):`,
+      matchers,
+      `Prior calls in this run (${prior.length}):`,
+      priorList,
+    ].join('\n');
   }
 }

--- a/packages/cli/src/testHelpers/index.ts
+++ b/packages/cli/src/testHelpers/index.ts
@@ -1,5 +1,5 @@
 export { marketplaceListResult, pluginListResult } from './claudeInstallerFakes.ts';
-export { type FakeCommandCall, FakeCommandRunner } from './FakeCommandRunner.ts';
+export { type CommandStub, type FakeCommandCall, FakeCommandRunner } from './FakeCommandRunner.ts';
 export { FakeIo } from './FakeIo.ts';
 export { FakePrompter } from './FakePrompter.ts';
 export { FakeUpdater } from './FakeUpdater.ts';

--- a/packages/cli/src/updater/UpdaterImpl.test.ts
+++ b/packages/cli/src/updater/UpdaterImpl.test.ts
@@ -299,7 +299,7 @@ describe('UpdaterImpl.performUpdate', () => {
     ['/home/linuxbrew/.linuxbrew/Cellar/contextbridge/0.1.0/bin/contextbridge', 'linuxbrew'],
   ])('detects %s as homebrew (%s layout)', async (execPath) => {
     const commandRunner = new FakeCommandRunner();
-    commandRunner.script({ exitCode: 0, stdout: '', stderr: '' });
+    commandRunner.onAny().resolves();
     const fetcher = new FakeFetcher();
     fetcher.script(new Response(caskBody('0.2.0')));
     const updater = buildUpdater({
@@ -315,7 +315,7 @@ describe('UpdaterImpl.performUpdate', () => {
 
   it('builds the brew argv for homebrew + stable', async () => {
     const commandRunner = new FakeCommandRunner();
-    commandRunner.script({ exitCode: 0, stdout: '', stderr: '' });
+    commandRunner.onAny().resolves();
     const fetcher = new FakeFetcher();
     fetcher.script(new Response(caskBody('0.2.0')));
     const updater = buildUpdater({
@@ -333,7 +333,7 @@ describe('UpdaterImpl.performUpdate', () => {
 
   it('builds the brew argv with @alpha cask for homebrew + alpha', async () => {
     const commandRunner = new FakeCommandRunner();
-    commandRunner.script({ exitCode: 0, stdout: '', stderr: '' });
+    commandRunner.onAny().resolves();
     const fetcher = new FakeFetcher();
     fetcher.script(new Response(caskBody('0.1.0-alpha.2')));
     const updater = buildUpdater({
@@ -351,7 +351,7 @@ describe('UpdaterImpl.performUpdate', () => {
 
   it('builds the curl sh -c argv for curl + stable', async () => {
     const commandRunner = new FakeCommandRunner();
-    commandRunner.script({ exitCode: 0, stdout: '', stderr: '' });
+    commandRunner.onAny().resolves();
     const fetcher = new FakeFetcher();
     fetcher.script(new Response(caskBody('0.2.0')));
     const updater = buildUpdater({
@@ -377,7 +377,7 @@ describe('UpdaterImpl.performUpdate', () => {
 
   it('builds the curl sh -c argv with --channel alpha for curl + alpha', async () => {
     const commandRunner = new FakeCommandRunner();
-    commandRunner.script({ exitCode: 0, stdout: '', stderr: '' });
+    commandRunner.onAny().resolves();
     const fetcher = new FakeFetcher();
     fetcher.script(new Response(caskBody('0.1.0-alpha.2')));
     const updater = buildUpdater({
@@ -408,7 +408,7 @@ describe('UpdaterImpl.performUpdate', () => {
     'preserves tarball install method on update via --no-brew (curl + %s)',
     async (channel, current, latest) => {
       const commandRunner = new FakeCommandRunner();
-      commandRunner.script({ exitCode: 0, stdout: '', stderr: '' });
+      commandRunner.onAny().resolves();
       const fetcher = new FakeFetcher();
       fetcher.script(new Response(caskBody(latest)));
       const updater = buildUpdater({
@@ -430,7 +430,7 @@ describe('UpdaterImpl.performUpdate', () => {
     'skips post-install configure on update via --no-configure (curl + %s)',
     async (channel, current, latest) => {
       const commandRunner = new FakeCommandRunner();
-      commandRunner.script({ exitCode: 0, stdout: '', stderr: '' });
+      commandRunner.onAny().resolves();
       const fetcher = new FakeFetcher();
       fetcher.script(new Response(caskBody(latest)));
       const updater = buildUpdater({
@@ -447,7 +447,7 @@ describe('UpdaterImpl.performUpdate', () => {
 
   it('returns { status: error } with the captured stderr in the message on non-zero installer exits', async () => {
     const commandRunner = new FakeCommandRunner();
-    commandRunner.script({ exitCode: 17, stdout: '', stderr: 'boom' });
+    commandRunner.onAny().resolves({ exitCode: 17, stderr: 'boom' });
     const fetcher = new FakeFetcher();
     fetcher.script(new Response(caskBody('0.2.0')));
     const updater = buildUpdater({


### PR DESCRIPTION
## Summary

Replaces `FakeCommandRunner.script(...)` with a fluent matcher API: `cr.on('claude', ['plugin', 'install']).resolves({ stdout: 'ok' })`. Tests now declare command outcomes by command shape instead of padding a FIFO queue, so production command ordering changes do not force unrelated test rewrites.

The final helper keeps the matcher machinery inside `FakeCommandRunner`, adds diagnostics for missed responders, and defaults `resolves()` to `{ exitCode: 0, stdout: '', stderr: '' }` with partial overrides.

## Review focus

- **API shape and defaults.** `CommandStub.resolves()` accepts `Partial<RunCommandResult>` and fills the normal successful shell result fields. `rejects()` simulates the runner promise rejecting rather than a non-zero command exit.
- **Prefix-match default for `on(cmd, args)`.** Tests can match the command prefix they care about while ignoring trailing args; `callsTo()` uses the same prefix behavior for assertions.
- **Persistent first-match responders.** Matchers are intentionally reusable and first-match-wins, which keeps repeated status queries easy to stub without duplicating FIFO entries.
- **Ordering-sensitive assertions.** `ClaudeInstaller.test.ts` still uses full ordered `commandRunner.calls` assertions where sequence is part of the contract; most other tests now assert the specific calls they care about with `.callsTo()`.

## Commits

- [`8e47d94`](https://github.com/contextbridge/planbridge/commit/8e47d94) — Add the `FakeCommandRunner` matcher API, defaulted responses, rejection support, call filtering, and focused helper tests.
- [`4670251`](https://github.com/contextbridge/planbridge/commit/4670251) — Migrate CLI, install, uninstall, Claude installer, install status, and updater tests from FIFO scripts to command matchers.
