### PR TITLE
chore: keep release-please in pre-1.0 with bump-minor-pre-major

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "contextbridge",
       "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary

The previous breaking-change commit (`feat!: rename Claude plugin...`) bumped the open release-please PR to 1.0.0. We're still pre-1.0 and not ready to commit to a stable API. Setting `bump-minor-pre-major: true` tells release-please to treat breaking changes as minor bumps (0.2.0 → 0.3.0) until we explicitly cross to 1.0.0; the flag becomes a no-op once major is non-zero, so it's safe to leave in long-term.

## Review focus

- After this merges, the existing release PR needs to be closed so release-please regenerates it as 0.3.0 on the next push to `main`. The config change alone won't retroactively recompute the open PR.
- Plain `feat:` commits will still bump the minor version. If we later want features to ship as patches in pre-1.0, we'd add `bump-patch-for-minor-pre-major` — intentionally not doing that here.

## Commits

- [`7c59f5e`](https://github.com/contextbridge/planbridge/commit/7c59f5ebdd8a75ac76c8bfd470df19e57129bbfe) — chore: keep release-please in pre-1.0 with bump-minor-pre-major