### PR TITLE
chore: ignore release-please-managed plugin.json in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,8 +16,9 @@ tools/infrastructure/cdk.out/
 .github/CODEOWNERS
 .github/workflows/auto-approve.yml
 
-# release-please owns CHANGELOG.md formatting; don't fight it.
+# release-please owns formatting of files it writes; don't fight it.
 CHANGELOG.md
+harnessIntegrations/claude/.claude-plugin/plugin.json
 
 # ContextBot owns formatting of agents and its own rules
 AGENTS.md


### PR DESCRIPTION
## Summary

Release-please rewrites `harnessIntegrations/claude/.claude-plugin/plugin.json` on every release (it bumps `$.version` via the `extra-files` config in `release-please-config.json`). Its JSON updater does not respect Prettier's array-wrapping rules, so the resulting PR fails `format:check` in CI — see #22 for the most recent instance. Adding the file to `.prettierignore` matches the existing precedent for `CHANGELOG.md`: release-please owns the formatting of files it writes, and Prettier should not fight it.

## Review focus

- The trade-off: humans editing `plugin.json` between releases lose Prettier normalization on it. Given the file is ~12 lines and rarely hand-edited, this seems fine, but flagging it explicitly.
- I generalized the comment above `CHANGELOG.md` to cover both entries rather than duplicating it.
- I did not pursue the alternative of formatting release-please's output inside the workflow (extra workflow time, fix-up commit on every release PR) — happy to switch approaches if you'd prefer that.

## Commits

- [`ff372ca`](https://github.com/contextbridge/planbridge/commit/ff372caf0bd3b9feb2ceabe155ec678063816728) — chore: ignore release-please-managed plugin.json in prettier