### PR TITLE
fix: refresh Claude marketplace cache during install

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -6,7 +6,13 @@ import { Command } from 'commander';
 import { CLAUDE_MARKETPLACE_NAME, CLAUDE_PLUGIN_ID } from '#src/harnesses/ClaudeInstaller.ts';
 import { getDescriptor } from '#src/harnesses/registry.ts';
 import { environment } from '#src/testFactories.ts';
-import { createStubContext, marketplaceListResult, pluginListResult, readErrorLogs } from '#src/testHelpers/index.ts';
+import {
+  createStubContext,
+  primeClaudeShellouts,
+  readErrorLogs,
+  stubMarketplaceList,
+  stubPluginList,
+} from '#src/testHelpers/index.ts';
 import { resolveCbCommand, runCli } from './cli.ts';
 
 const CLAUDE_BINARY = getDescriptor('claude').binaryName;
@@ -90,11 +96,7 @@ describe('runCli', () => {
   });
 
   it('routes argv into the install claude subcommand with default user scope', async () => {
-    const { context, io, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
+    const { context, io, commandRunner } = setupClaudeTest();
 
     const exitCode = await runCli(context, ['install', 'claude']);
 
@@ -151,16 +153,9 @@ describe('runCli', () => {
   });
 
   it('routes argv into the uninstall claude subcommand with --scope project', async () => {
-    const { context, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
-      .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]));
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
-      .resolves(marketplaceListResult([{ name: CLAUDE_MARKETPLACE_NAME }]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
+    const { context, commandRunner } = setupClaudeTest();
+    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]);
+    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
 
     const exitCode = await runCli(context, ['uninstall', 'claude', '--scope', 'project']);
 
@@ -171,12 +166,7 @@ describe('runCli', () => {
   });
 
   it('routes argv into the no-target install orchestrator with --yes', async () => {
-    const { context, io, commandRunner, prompter } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
+    const { context, io, prompter } = setupClaudeTest();
 
     const exitCode = await runCli(context, ['install', '--yes']);
 
@@ -186,14 +176,9 @@ describe('runCli', () => {
   });
 
   it('routes argv into install status with --json and emits to stdout', async () => {
-    const { context, io, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
-      .resolves(marketplaceListResult([{ name: CLAUDE_MARKETPLACE_NAME }]));
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
-      .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]));
+    const { context, io, commandRunner } = setupClaudeTest();
+    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
 
     const exitCode = await runCli(context, ['install', 'status', '--json']);
 
@@ -202,14 +187,9 @@ describe('runCli', () => {
   });
 
   it('registers cb_command and identifies before parsing for a top-level subcommand', async () => {
-    const { context, analytics, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
-      .resolves(marketplaceListResult([{ name: CLAUDE_MARKETPLACE_NAME }]));
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
-      .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]));
+    const { context, analytics, commandRunner } = setupClaudeTest();
+    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
 
     const exitCode = await runCli(context, ['install', 'status', '--json']);
 
@@ -279,3 +259,9 @@ describe('resolveCbCommand', () => {
     expect(resolveCbCommand(program, ['parent', '--', 'child'])).toBe('parent');
   });
 });
+
+function setupClaudeTest(overrides?: Parameters<typeof createStubContext>[0]) {
+  const stub = createStubContext(overrides);
+  primeClaudeShellouts(stub.commandRunner);
+  return stub;
+}

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -6,13 +6,7 @@ import { Command } from 'commander';
 import { CLAUDE_MARKETPLACE_NAME, CLAUDE_PLUGIN_ID } from '#src/harnesses/ClaudeInstaller.ts';
 import { getDescriptor } from '#src/harnesses/registry.ts';
 import { environment } from '#src/testFactories.ts';
-import {
-  createStubContext,
-  primeClaudeShellouts,
-  readErrorLogs,
-  stubMarketplaceList,
-  stubPluginList,
-} from '#src/testHelpers/index.ts';
+import { createStubContext, primeClaudeShellouts, readErrorLogs, stubClaudeState } from '#src/testHelpers/index.ts';
 import { resolveCbCommand, runCli } from './cli.ts';
 
 const CLAUDE_BINARY = getDescriptor('claude').binaryName;
@@ -154,8 +148,9 @@ describe('runCli', () => {
 
   it('routes argv into the uninstall claude subcommand with --scope project', async () => {
     const { context, commandRunner } = setupClaudeTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]);
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }] }],
+    });
 
     const exitCode = await runCli(context, ['uninstall', 'claude', '--scope', 'project']);
 
@@ -177,8 +172,9 @@ describe('runCli', () => {
 
   it('routes argv into install status with --json and emits to stdout', async () => {
     const { context, io, commandRunner } = setupClaudeTest();
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] }],
+    });
 
     const exitCode = await runCli(context, ['install', 'status', '--json']);
 
@@ -188,8 +184,9 @@ describe('runCli', () => {
 
   it('registers cb_command and identifies before parsing for a top-level subcommand', async () => {
     const { context, analytics, commandRunner } = setupClaudeTest();
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] }],
+    });
 
     const exitCode = await runCli(context, ['install', 'status', '--json']);
 

--- a/packages/cli/src/commands/install.test.ts
+++ b/packages/cli/src/commands/install.test.ts
@@ -10,12 +10,7 @@ import {
 } from '#src/harnesses/ClaudeInstaller.ts';
 import { getDescriptor } from '#src/harnesses/registry.ts';
 import { environment } from '#src/testFactories.ts';
-import {
-  createStubContext,
-  primeClaudeShellouts,
-  stubMarketplaceList,
-  stubPluginList,
-} from '#src/testHelpers/index.ts';
+import { createStubContext, primeClaudeShellouts, stubClaudeState } from '#src/testHelpers/index.ts';
 import { runInstall } from './install.ts';
 
 const CLAUDE_BINARY = getDescriptor('claude').binaryName;
@@ -48,8 +43,9 @@ describe('runInstall', () => {
 
   it('skips already-installed harnesses by default and notes them in the summary', async () => {
     const { context, io, commandRunner, prompter } = setupTest();
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] }],
+    });
 
     await runInstall(context, { yes: true });
 
@@ -65,8 +61,9 @@ describe('runInstall', () => {
 
   it('with --force re-runs install over an already-installed harness and drops the skipped suffix', async () => {
     const { context, io, commandRunner, prompter } = setupTest();
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] }],
+    });
 
     await runInstall(context, { yes: true, force: true });
 
@@ -80,8 +77,9 @@ describe('runInstall', () => {
 
   it('treats an install at a different scope as already installed and skips by default', async () => {
     const { context, io, commandRunner } = setupTest();
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }] }],
+    });
 
     await runInstall(context, { yes: true });
 
@@ -96,7 +94,7 @@ describe('runInstall', () => {
 
   it('does not skip Claude when only the marketplace is configured', async () => {
     const { context, io, commandRunner } = setupTest();
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubClaudeState(commandRunner, { marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME }] });
 
     await runInstall(context, { yes: true });
 

--- a/packages/cli/src/commands/install.test.ts
+++ b/packages/cli/src/commands/install.test.ts
@@ -10,7 +10,12 @@ import {
 } from '#src/harnesses/ClaudeInstaller.ts';
 import { getDescriptor } from '#src/harnesses/registry.ts';
 import { environment } from '#src/testFactories.ts';
-import { createStubContext, marketplaceListResult, pluginListResult } from '#src/testHelpers/index.ts';
+import {
+  createStubContext,
+  primeClaudeShellouts,
+  stubMarketplaceList,
+  stubPluginList,
+} from '#src/testHelpers/index.ts';
 import { runInstall } from './install.ts';
 
 const CLAUDE_BINARY = getDescriptor('claude').binaryName;
@@ -18,12 +23,7 @@ const CODEX_BINARY = getDescriptor('codex').binaryName;
 
 describe('runInstall', () => {
   it('with --yes installs Claude when not yet wired up and reports the summary', async () => {
-    const { context, io, commandRunner, prompter } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
+    const { context, io, commandRunner, prompter } = setupTest();
 
     await runInstall(context, { yes: true });
 
@@ -47,14 +47,9 @@ describe('runInstall', () => {
   });
 
   it('skips already-installed harnesses by default and notes them in the summary', async () => {
-    const { context, io, commandRunner, prompter } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
-      .resolves(marketplaceListResult([{ name: CLAUDE_MARKETPLACE_NAME }]));
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
-      .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]));
+    const { context, io, commandRunner, prompter } = setupTest();
+    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
 
     await runInstall(context, { yes: true });
 
@@ -69,16 +64,9 @@ describe('runInstall', () => {
   });
 
   it('with --force re-runs install over an already-installed harness and drops the skipped suffix', async () => {
-    const { context, io, commandRunner, prompter } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
-      .resolves(marketplaceListResult([{ name: CLAUDE_MARKETPLACE_NAME }]));
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
-      .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'update']).resolves();
+    const { context, io, commandRunner, prompter } = setupTest();
+    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
 
     await runInstall(context, { yes: true, force: true });
 
@@ -91,14 +79,9 @@ describe('runInstall', () => {
   });
 
   it('treats an install at a different scope as already installed and skips by default', async () => {
-    const { context, io, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
-      .resolves(marketplaceListResult([{ name: CLAUDE_MARKETPLACE_NAME }]));
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
-      .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]));
+    const { context, io, commandRunner } = setupTest();
+    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]);
 
     await runInstall(context, { yes: true });
 
@@ -112,14 +95,8 @@ describe('runInstall', () => {
   });
 
   it('does not skip Claude when only the marketplace is configured', async () => {
-    const { context, io, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner
-      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
-      .resolves(marketplaceListResult([{ name: CLAUDE_MARKETPLACE_NAME }]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
+    const { context, io, commandRunner } = setupTest();
+    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
 
     await runInstall(context, { yes: true });
 
@@ -133,13 +110,8 @@ describe('runInstall', () => {
 
   it('records a status failure for one harness and still installs another detected harness', async () => {
     const tmp = mkdtempSync(join(tmpdir(), 'cb-cli-install-status-failure-'));
-    const { context, io, commandRunner } = createStubContext({ env: environment.build({ HOME: tmp }) });
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { context, io, commandRunner } = setupTest({ env: environment.build({ HOME: tmp }) });
     commandRunner.setWhich(CODEX_BINARY, '/usr/local/bin/codex');
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
 
     try {
       const configDir = join(tmp, '.codex');
@@ -174,10 +146,7 @@ describe('runInstall', () => {
   });
 
   it('without --yes prompts the user and skips when they decline', async () => {
-    const { context, io, commandRunner, prompter } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
+    const { context, io, commandRunner, prompter } = setupTest();
     prompter.setConfirm(false);
 
     await runInstall(context);
@@ -190,12 +159,7 @@ describe('runInstall', () => {
   });
 
   it('without --yes runs confirm + scope prompts and installs at the chosen scope', async () => {
-    const { context, commandRunner, prompter } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
+    const { context, commandRunner, prompter } = setupTest();
     prompter.setConfirm(true);
     prompter.setSelect('project');
 
@@ -213,7 +177,7 @@ describe('runInstall', () => {
   });
 
   it('throws when no supported harnesses are detected', () => {
-    const { context, commandRunner, io } = createStubContext();
+    const { context, commandRunner, io } = setupTest();
     commandRunner.setWhich(CLAUDE_BINARY, null);
 
     expect(runInstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
@@ -221,6 +185,12 @@ describe('runInstall', () => {
     expect(io.stderr.text()).toContain('Claude Code: not detected');
   });
 });
+
+function setupTest(overrides?: Parameters<typeof createStubContext>[0]) {
+  const stub = createStubContext(overrides);
+  primeClaudeShellouts(stub.commandRunner);
+  return stub;
+}
 
 async function captureError(promise: Promise<unknown>): Promise<unknown> {
   try {

--- a/packages/cli/src/harnesses/ClaudeInstaller.test.ts
+++ b/packages/cli/src/harnesses/ClaudeInstaller.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { CommanderError } from 'commander';
 import {
-  type FakeCommandRunner,
   createStubContext,
-  marketplaceListResult,
-  pluginListResult,
+  primeClaudeShellouts,
   readErrorLogs,
   readLogs,
+  stubMarketplaceList,
+  stubPluginList,
 } from '#src/testHelpers/index.ts';
 import {
   CLAUDE_LEGACY_PLUGIN_ID,
@@ -18,17 +18,10 @@ import {
 import { getDescriptor } from './registry.ts';
 
 const CLAUDE_BINARY = getDescriptor('claude').binaryName;
-type PluginFixture = Parameters<typeof pluginListResult>[0][number];
-type MarketplaceFixture = Parameters<typeof marketplaceListResult>[0][number];
 
 describe('ClaudeInstaller.install', () => {
   it('runs marketplace-add then plugin-install at user scope and emits onboarding prose', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, io, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    stubPluginList(commandRunner, []);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
+    const { installer, context, io, commandRunner } = setupTest();
 
     await installer.install(context, { yes: true });
 
@@ -50,15 +43,10 @@ describe('ClaudeInstaller.install', () => {
   });
 
   it('updates the plugin when the new id is already installed at the target scope', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, io, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, io, commandRunner } = setupTest();
     stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves({
       stdout: "Adding marketplace…✔ Marketplace 'contextbridge' already on disk — declared in user settings",
-    });
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'update']).resolves({
-      stdout: 'Updated plugin "planbridge@contextbridge" to latest version',
     });
 
     await installer.install(context, { yes: true });
@@ -71,13 +59,8 @@ describe('ClaudeInstaller.install', () => {
   });
 
   it('migrates a legacy cli@contextbridge install at the target scope after installing the new id', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, io, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, io, commandRunner } = setupTest();
     stubPluginList(commandRunner, [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
 
     await installer.install(context, { yes: true });
 
@@ -100,12 +83,8 @@ describe('ClaudeInstaller.install', () => {
   });
 
   it('leaves legacy cli@contextbridge alone when it is at a different scope than the install target', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, io, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, io, commandRunner } = setupTest();
     stubPluginList(commandRunner, [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'project' }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
 
     await installer.install(context, { yes: true });
 
@@ -115,8 +94,7 @@ describe('ClaudeInstaller.install', () => {
   });
 
   it('aborts when claude is not on PATH and never invokes a shellout', () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner } = createStubContext();
+    const { installer, context, commandRunner } = setupTest();
     commandRunner.setWhich(CLAUDE_BINARY, null);
 
     expect(installer.install(context, { yes: true })).rejects.toThrow('Install Claude Code');
@@ -124,10 +102,7 @@ describe('ClaudeInstaller.install', () => {
   });
 
   it('aborts when marketplace-add fails and bubbles stderr', () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner, logs } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    stubPluginList(commandRunner, []);
+    const { installer, context, commandRunner, logs } = setupTest();
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])
       .resolves({ exitCode: 1, stderr: 'network unreachable' });
@@ -139,11 +114,7 @@ describe('ClaudeInstaller.install', () => {
   });
 
   it('aborts when plugin-install fails after a successful marketplace-add', () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner, logs } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    stubPluginList(commandRunner, []);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+    const { installer, context, commandRunner, logs } = setupTest();
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'install'])
       .resolves({ exitCode: 1, stderr: 'plugin not found in marketplace' });
@@ -155,11 +126,8 @@ describe('ClaudeInstaller.install', () => {
   });
 
   it('does not remove a legacy install when the new plugin install fails', () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner, logs } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, commandRunner, logs } = setupTest();
     stubPluginList(commandRunner, [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'install'])
       .resolves({ exitCode: 1, stderr: 'plugin not found in marketplace' });
@@ -171,14 +139,11 @@ describe('ClaudeInstaller.install', () => {
   });
 
   it('does not remove a legacy install when the new plugin update fails', () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner, logs } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, commandRunner, logs } = setupTest();
     stubPluginList(commandRunner, [
       { id: CLAUDE_PLUGIN_ID, scope: 'user' },
       { id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' },
     ]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'update']).resolves({ exitCode: 1, stderr: 'update failed' });
 
     expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
@@ -188,10 +153,7 @@ describe('ClaudeInstaller.install', () => {
   });
 
   it('logs a synthetic detail when stderr is empty on a non-zero exit', () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner, logs } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    stubPluginList(commandRunner, []);
+    const { installer, context, commandRunner, logs } = setupTest();
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves({ exitCode: 3 });
 
     expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
@@ -201,13 +163,9 @@ describe('ClaudeInstaller.install', () => {
 
 describe('ClaudeInstaller.uninstall', () => {
   it('lists, uninstalls, lists marketplaces, removes marketplace, emits confirmation at user scope', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, io, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, io, commandRunner } = setupTest();
     stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
     stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
 
     await installer.uninstall(context, { yes: true });
 
@@ -222,12 +180,9 @@ describe('ClaudeInstaller.uninstall', () => {
   });
 
   it('skips plugin-uninstall when the plugin is not installed at the user scope', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, io, commandRunner, logs } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, io, commandRunner, logs } = setupTest();
     stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]);
     stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
 
     await installer.uninstall(context, { yes: true });
 
@@ -238,12 +193,8 @@ describe('ClaudeInstaller.uninstall', () => {
   });
 
   it('skips marketplace-remove when the marketplace is not configured', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, io, commandRunner, logs } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, io, commandRunner, logs } = setupTest();
     stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
-    stubMarketplaceList(commandRunner, []);
 
     await installer.uninstall(context, { yes: true });
 
@@ -256,13 +207,9 @@ describe('ClaudeInstaller.uninstall', () => {
   });
 
   it('uninstalls a legacy cli@contextbridge install at the target scope', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, io, commandRunner, logs } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, io, commandRunner, logs } = setupTest();
     stubPluginList(commandRunner, [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
     stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
 
     await installer.uninstall(context, { yes: true });
 
@@ -275,16 +222,12 @@ describe('ClaudeInstaller.uninstall', () => {
   });
 
   it('uninstalls both the new id and the legacy cli@contextbridge when both are at the target scope', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, commandRunner } = setupTest();
     stubPluginList(commandRunner, [
       { id: CLAUDE_PLUGIN_ID, scope: 'user' },
       { id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' },
     ]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
     stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
 
     await installer.uninstall(context, { yes: true });
 
@@ -296,11 +239,7 @@ describe('ClaudeInstaller.uninstall', () => {
   });
 
   it('is fully idempotent when both the plugin and marketplace are already absent', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, io, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    stubPluginList(commandRunner, []);
-    stubMarketplaceList(commandRunner, []);
+    const { installer, context, io, commandRunner } = setupTest();
 
     await installer.uninstall(context, { yes: true });
 
@@ -310,8 +249,7 @@ describe('ClaudeInstaller.uninstall', () => {
   });
 
   it('aborts when claude is not on PATH and never invokes a shellout', () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner } = createStubContext();
+    const { installer, context, commandRunner } = setupTest();
     commandRunner.setWhich(CLAUDE_BINARY, null);
 
     expect(installer.uninstall(context, { yes: true })).rejects.toThrow('Install Claude Code');
@@ -319,9 +257,7 @@ describe('ClaudeInstaller.uninstall', () => {
   });
 
   it('bubbles a CommanderError and runs no further shellouts when `plugin list --json` fails', () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner, logs } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, commandRunner, logs } = setupTest();
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
       .resolves({ exitCode: 1, stderr: 'permission denied' });
@@ -332,9 +268,7 @@ describe('ClaudeInstaller.uninstall', () => {
   });
 
   it('bubbles a real plugin-uninstall failure and does not call marketplace-list', () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner, logs } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, commandRunner, logs } = setupTest();
     stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves({ exitCode: 1, stderr: 'disk full' });
 
@@ -345,11 +279,8 @@ describe('ClaudeInstaller.uninstall', () => {
   });
 
   it('bubbles a real marketplace-remove failure after a clean plugin uninstall', () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner, logs } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, commandRunner, logs } = setupTest();
     stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
     stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])
@@ -363,12 +294,7 @@ describe('ClaudeInstaller.uninstall', () => {
 
 describe('ClaudeInstaller scope prompt', () => {
   it('prompts for scope when yes=false and installs at the chosen scope', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner, prompter } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    stubPluginList(commandRunner, []);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
+    const { installer, context, commandRunner, prompter } = setupTest();
     prompter.setSelect('project');
 
     await installer.install(context, { yes: false });
@@ -380,12 +306,7 @@ describe('ClaudeInstaller scope prompt', () => {
   });
 
   it('skips the scope prompt when yes=true and uses the user-scope default', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner, prompter } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    stubPluginList(commandRunner, []);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
+    const { installer, context, commandRunner, prompter } = setupTest();
 
     await installer.install(context, { yes: true });
 
@@ -394,13 +315,9 @@ describe('ClaudeInstaller scope prompt', () => {
   });
 
   it('prompts for scope on uninstall when yes=false', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner, prompter } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, commandRunner, prompter } = setupTest();
     stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
     stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
     prompter.setSelect('project');
 
     await installer.uninstall(context, { yes: false });
@@ -419,8 +336,7 @@ describe('ClaudeInstaller scope prompt', () => {
 
 describe('ClaudeInstaller.status', () => {
   it('reports detected: false with no managed entries when claude is not on PATH', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner } = createStubContext();
+    const { installer, context, commandRunner } = setupTest();
     commandRunner.setWhich(CLAUDE_BINARY, null);
 
     const status = await installer.status(context);
@@ -432,9 +348,7 @@ describe('ClaudeInstaller.status', () => {
   });
 
   it('reports detected: true with marketplace and user-scope plugin entries when present', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, commandRunner } = setupTest();
     stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
     stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
 
@@ -449,10 +363,7 @@ describe('ClaudeInstaller.status', () => {
   });
 
   it('reports project-scope plugin installs', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    stubMarketplaceList(commandRunner, []);
+    const { installer, context, commandRunner } = setupTest();
     stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]);
 
     const status = await installer.status(context);
@@ -463,9 +374,7 @@ describe('ClaudeInstaller.status', () => {
   });
 
   it('reports a legacy cli@contextbridge install as managed but not installed', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, commandRunner } = setupTest();
     stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
     stubPluginList(commandRunner, [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }]);
 
@@ -480,9 +389,7 @@ describe('ClaudeInstaller.status', () => {
   });
 
   it('reports both new and legacy plugin entries when both are installed', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, commandRunner } = setupTest();
     stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
     stubPluginList(commandRunner, [
       { id: CLAUDE_PLUGIN_ID, scope: 'user' },
@@ -501,11 +408,8 @@ describe('ClaudeInstaller.status', () => {
   });
 
   it('reports marketplace-only partial state as managed but not installed', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, commandRunner } = setupTest();
     stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    stubPluginList(commandRunner, []);
 
     const status = await installer.status(context);
 
@@ -515,11 +419,7 @@ describe('ClaudeInstaller.status', () => {
   });
 
   it('reports detected: true with no managed entries when claude is on PATH but PlanBridge is not installed', async () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
-    stubMarketplaceList(commandRunner, []);
-    stubPluginList(commandRunner, []);
+    const { installer, context } = setupTest();
 
     const status = await installer.status(context);
 
@@ -529,9 +429,7 @@ describe('ClaudeInstaller.status', () => {
   });
 
   it('bubbles a CommanderError when marketplace status cannot be listed', () => {
-    const installer = new ClaudeInstaller();
-    const { context, commandRunner, logs } = createStubContext();
-    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    const { installer, context, commandRunner, logs } = setupTest();
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves({ exitCode: 2 });
 
     expect(installer.status(context)).rejects.toBeInstanceOf(CommanderError);
@@ -539,12 +437,9 @@ describe('ClaudeInstaller.status', () => {
   });
 });
 
-function stubPluginList(commandRunner: FakeCommandRunner, plugins: PluginFixture[]): void {
-  commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult(plugins));
-}
-
-function stubMarketplaceList(commandRunner: FakeCommandRunner, marketplaces: MarketplaceFixture[]): void {
-  commandRunner
-    .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
-    .resolves(marketplaceListResult(marketplaces));
+function setupTest() {
+  const installer = new ClaudeInstaller();
+  const stub = createStubContext();
+  primeClaudeShellouts(stub.commandRunner);
+  return { installer, ...stub };
 }

--- a/packages/cli/src/harnesses/ClaudeInstaller.test.ts
+++ b/packages/cli/src/harnesses/ClaudeInstaller.test.ts
@@ -32,6 +32,7 @@ describe('ClaudeInstaller.install', () => {
         args: ['plugin', 'marketplace', 'add', CLAUDE_MARKETPLACE_SOURCE, '--scope', 'user'],
         opts: {},
       },
+      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'update', CLAUDE_MARKETPLACE_NAME], opts: {} },
       { cmd: CLAUDE_BINARY, args: ['plugin', 'install', CLAUDE_PLUGIN_ID, '--scope', 'user'], opts: {} },
     ]);
 
@@ -55,6 +56,7 @@ describe('ClaudeInstaller.install', () => {
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0]?.args).toEqual(['plugin', 'update', CLAUDE_PLUGIN_ID, '--scope', 'user']);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'update'])).toHaveLength(1);
     expect(io.stderr.text()).toContain('installed for Claude Code');
   });
 
@@ -71,6 +73,7 @@ describe('ClaudeInstaller.install', () => {
         args: ['plugin', 'marketplace', 'add', CLAUDE_MARKETPLACE_SOURCE, '--scope', 'user'],
         opts: {},
       },
+      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'update', CLAUDE_MARKETPLACE_NAME], opts: {} },
       { cmd: CLAUDE_BINARY, args: ['plugin', 'install', CLAUDE_PLUGIN_ID, '--scope', 'user'], opts: {} },
       { cmd: CLAUDE_BINARY, args: ['plugin', 'uninstall', CLAUDE_LEGACY_PLUGIN_ID, '--scope', 'user'], opts: {} },
     ]);

--- a/packages/cli/src/harnesses/ClaudeInstaller.test.ts
+++ b/packages/cli/src/harnesses/ClaudeInstaller.test.ts
@@ -5,8 +5,7 @@ import {
   primeClaudeShellouts,
   readErrorLogs,
   readLogs,
-  stubMarketplaceList,
-  stubPluginList,
+  stubClaudeState,
 } from '#src/testHelpers/index.ts';
 import {
   CLAUDE_LEGACY_PLUGIN_ID,
@@ -45,7 +44,7 @@ describe('ClaudeInstaller.install', () => {
 
   it('updates the plugin when the new id is already installed at the target scope', async () => {
     const { installer, context, io, commandRunner } = setupTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
+    stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] });
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves({
       stdout: "Adding marketplace…✔ Marketplace 'contextbridge' already on disk — declared in user settings",
     });
@@ -62,7 +61,7 @@ describe('ClaudeInstaller.install', () => {
 
   it('migrates a legacy cli@contextbridge install at the target scope after installing the new id', async () => {
     const { installer, context, io, commandRunner } = setupTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }]);
+    stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }] });
 
     await installer.install(context, { yes: true });
 
@@ -87,7 +86,7 @@ describe('ClaudeInstaller.install', () => {
 
   it('leaves legacy cli@contextbridge alone when it is at a different scope than the install target', async () => {
     const { installer, context, io, commandRunner } = setupTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'project' }]);
+    stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'project' }] });
 
     await installer.install(context, { yes: true });
 
@@ -130,7 +129,7 @@ describe('ClaudeInstaller.install', () => {
 
   it('does not remove a legacy install when the new plugin install fails', () => {
     const { installer, context, commandRunner, logs } = setupTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }]);
+    stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }] });
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'install'])
       .resolves({ exitCode: 1, stderr: 'plugin not found in marketplace' });
@@ -143,10 +142,12 @@ describe('ClaudeInstaller.install', () => {
 
   it('does not remove a legacy install when the new plugin update fails', () => {
     const { installer, context, commandRunner, logs } = setupTest();
-    stubPluginList(commandRunner, [
-      { id: CLAUDE_PLUGIN_ID, scope: 'user' },
-      { id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' },
-    ]);
+    stubClaudeState(commandRunner, {
+      unmanagedPlugins: [
+        { id: CLAUDE_PLUGIN_ID, scope: 'user' },
+        { id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' },
+      ],
+    });
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'update']).resolves({ exitCode: 1, stderr: 'update failed' });
 
     expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
@@ -167,8 +168,9 @@ describe('ClaudeInstaller.install', () => {
 describe('ClaudeInstaller.uninstall', () => {
   it('lists, uninstalls, lists marketplaces, removes marketplace, emits confirmation at user scope', async () => {
     const { installer, context, io, commandRunner } = setupTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] }],
+    });
 
     await installer.uninstall(context, { yes: true });
 
@@ -184,8 +186,9 @@ describe('ClaudeInstaller.uninstall', () => {
 
   it('skips plugin-uninstall when the plugin is not installed at the user scope', async () => {
     const { installer, context, io, commandRunner, logs } = setupTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]);
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }] }],
+    });
 
     await installer.uninstall(context, { yes: true });
 
@@ -197,7 +200,7 @@ describe('ClaudeInstaller.uninstall', () => {
 
   it('skips marketplace-remove when the marketplace is not configured', async () => {
     const { installer, context, io, commandRunner, logs } = setupTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
+    stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] });
 
     await installer.uninstall(context, { yes: true });
 
@@ -211,8 +214,9 @@ describe('ClaudeInstaller.uninstall', () => {
 
   it('uninstalls a legacy cli@contextbridge install at the target scope', async () => {
     const { installer, context, io, commandRunner, logs } = setupTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }]);
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }] }],
+    });
 
     await installer.uninstall(context, { yes: true });
 
@@ -226,11 +230,17 @@ describe('ClaudeInstaller.uninstall', () => {
 
   it('uninstalls both the new id and the legacy cli@contextbridge when both are at the target scope', async () => {
     const { installer, context, commandRunner } = setupTest();
-    stubPluginList(commandRunner, [
-      { id: CLAUDE_PLUGIN_ID, scope: 'user' },
-      { id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' },
-    ]);
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [
+        {
+          name: CLAUDE_MARKETPLACE_NAME,
+          plugins: [
+            { id: CLAUDE_PLUGIN_ID, scope: 'user' },
+            { id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' },
+          ],
+        },
+      ],
+    });
 
     await installer.uninstall(context, { yes: true });
 
@@ -272,7 +282,7 @@ describe('ClaudeInstaller.uninstall', () => {
 
   it('bubbles a real plugin-uninstall failure and does not call marketplace-list', () => {
     const { installer, context, commandRunner, logs } = setupTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
+    stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] });
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves({ exitCode: 1, stderr: 'disk full' });
 
     expect(installer.uninstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
@@ -283,8 +293,9 @@ describe('ClaudeInstaller.uninstall', () => {
 
   it('bubbles a real marketplace-remove failure after a clean plugin uninstall', () => {
     const { installer, context, commandRunner, logs } = setupTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] }],
+    });
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])
       .resolves({ exitCode: 1, stderr: 'some other marketplace error' });
@@ -319,8 +330,9 @@ describe('ClaudeInstaller scope prompt', () => {
 
   it('prompts for scope on uninstall when yes=false', async () => {
     const { installer, context, commandRunner, prompter } = setupTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]);
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }] }],
+    });
     prompter.setSelect('project');
 
     await installer.uninstall(context, { yes: false });
@@ -352,8 +364,9 @@ describe('ClaudeInstaller.status', () => {
 
   it('reports detected: true with marketplace and user-scope plugin entries when present', async () => {
     const { installer, context, commandRunner } = setupTest();
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] }],
+    });
 
     const status = await installer.status(context);
 
@@ -367,7 +380,7 @@ describe('ClaudeInstaller.status', () => {
 
   it('reports project-scope plugin installs', async () => {
     const { installer, context, commandRunner } = setupTest();
-    stubPluginList(commandRunner, [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]);
+    stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }] });
 
     const status = await installer.status(context);
 
@@ -378,8 +391,9 @@ describe('ClaudeInstaller.status', () => {
 
   it('reports a legacy cli@contextbridge install as managed but not installed', async () => {
     const { installer, context, commandRunner } = setupTest();
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    stubPluginList(commandRunner, [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }] }],
+    });
 
     const status = await installer.status(context);
 
@@ -393,11 +407,17 @@ describe('ClaudeInstaller.status', () => {
 
   it('reports both new and legacy plugin entries when both are installed', async () => {
     const { installer, context, commandRunner } = setupTest();
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
-    stubPluginList(commandRunner, [
-      { id: CLAUDE_PLUGIN_ID, scope: 'user' },
-      { id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' },
-    ]);
+    stubClaudeState(commandRunner, {
+      marketplaces: [
+        {
+          name: CLAUDE_MARKETPLACE_NAME,
+          plugins: [
+            { id: CLAUDE_PLUGIN_ID, scope: 'user' },
+            { id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' },
+          ],
+        },
+      ],
+    });
 
     const status = await installer.status(context);
 
@@ -412,7 +432,7 @@ describe('ClaudeInstaller.status', () => {
 
   it('reports marketplace-only partial state as managed but not installed', async () => {
     const { installer, context, commandRunner } = setupTest();
-    stubMarketplaceList(commandRunner, [{ name: CLAUDE_MARKETPLACE_NAME }]);
+    stubClaudeState(commandRunner, { marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME }] });
 
     const status = await installer.status(context);
 

--- a/packages/cli/src/harnesses/ClaudeInstaller.test.ts
+++ b/packages/cli/src/harnesses/ClaudeInstaller.test.ts
@@ -63,15 +63,10 @@ describe('ClaudeInstaller.install', () => {
 
     await installer.install(context, { yes: true });
 
-    expect(commandRunner.calls).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
-      {
-        cmd: CLAUDE_BINARY,
-        args: ['plugin', 'marketplace', 'add', CLAUDE_MARKETPLACE_SOURCE, '--scope', 'user'],
-        opts: {},
-      },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'update', CLAUDE_PLUGIN_ID, '--scope', 'user'], opts: {} },
-    ]);
+    const updateCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'update']);
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]?.args).toEqual(['plugin', 'update', CLAUDE_PLUGIN_ID, '--scope', 'user']);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toEqual([]);
     expect(io.stderr.text()).toContain('installed for Claude Code');
   });
 
@@ -114,15 +109,8 @@ describe('ClaudeInstaller.install', () => {
 
     await installer.install(context, { yes: true });
 
-    expect(commandRunner.calls).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
-      {
-        cmd: CLAUDE_BINARY,
-        args: ['plugin', 'marketplace', 'add', CLAUDE_MARKETPLACE_SOURCE, '--scope', 'user'],
-        opts: {},
-      },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'install', CLAUDE_PLUGIN_ID, '--scope', 'user'], opts: {} },
-    ]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
     expect(io.stderr.text()).not.toContain('renamed from cli@contextbridge');
   });
 
@@ -145,7 +133,8 @@ describe('ClaudeInstaller.install', () => {
       .resolves({ exitCode: 1, stderr: 'network unreachable' });
 
     expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
-    expect(commandRunner.calls).toHaveLength(2);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'update'])).toEqual([]);
     expect(readErrorLogs(logs).some((r) => r.msg.includes('network unreachable'))).toBe(true);
   });
 
@@ -160,7 +149,8 @@ describe('ClaudeInstaller.install', () => {
       .resolves({ exitCode: 1, stderr: 'plugin not found in marketplace' });
 
     expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
-    expect(commandRunner.calls).toHaveLength(3);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
     expect(readErrorLogs(logs).some((r) => r.msg.includes('plugin not found in marketplace'))).toBe(true);
   });
 
@@ -175,15 +165,8 @@ describe('ClaudeInstaller.install', () => {
       .resolves({ exitCode: 1, stderr: 'plugin not found in marketplace' });
 
     expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
-    expect(commandRunner.calls).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
-      {
-        cmd: CLAUDE_BINARY,
-        args: ['plugin', 'marketplace', 'add', CLAUDE_MARKETPLACE_SOURCE, '--scope', 'user'],
-        opts: {},
-      },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'install', CLAUDE_PLUGIN_ID, '--scope', 'user'], opts: {} },
-    ]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
     expect(readErrorLogs(logs).some((r) => r.msg.includes('plugin not found in marketplace'))).toBe(true);
   });
 
@@ -199,15 +182,8 @@ describe('ClaudeInstaller.install', () => {
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'update']).resolves({ exitCode: 1, stderr: 'update failed' });
 
     expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
-    expect(commandRunner.calls).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
-      {
-        cmd: CLAUDE_BINARY,
-        args: ['plugin', 'marketplace', 'add', CLAUDE_MARKETPLACE_SOURCE, '--scope', 'user'],
-        opts: {},
-      },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'update', CLAUDE_PLUGIN_ID, '--scope', 'user'], opts: {} },
-    ]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'update'])).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
     expect(readErrorLogs(logs).some((r) => r.msg.includes('update failed'))).toBe(true);
   });
 
@@ -255,11 +231,8 @@ describe('ClaudeInstaller.uninstall', () => {
 
     await installer.uninstall(context, { yes: true });
 
-    expect(commandRunner.calls).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'list', '--json'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'remove', CLAUDE_MARKETPLACE_NAME], opts: {} },
-    ]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toHaveLength(1);
     expect(io.stderr.text()).toContain('PlanBridge plugin removed');
     expect(readLogs(logs).some((r) => r.msg.includes('not installed at scope user'))).toBe(true);
   });
@@ -274,11 +247,10 @@ describe('ClaudeInstaller.uninstall', () => {
 
     await installer.uninstall(context, { yes: true });
 
-    expect(commandRunner.calls).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'uninstall', CLAUDE_PLUGIN_ID, '--scope', 'user'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'list', '--json'], opts: {} },
-    ]);
+    const uninstallCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall']);
+    expect(uninstallCalls).toHaveLength(1);
+    expect(uninstallCalls[0]?.args).toEqual(['plugin', 'uninstall', CLAUDE_PLUGIN_ID, '--scope', 'user']);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toEqual([]);
     expect(io.stderr.text()).toContain('PlanBridge plugin removed');
     expect(readLogs(logs).some((r) => r.msg.includes('marketplace is not configured'))).toBe(true);
   });
@@ -294,12 +266,10 @@ describe('ClaudeInstaller.uninstall', () => {
 
     await installer.uninstall(context, { yes: true });
 
-    expect(commandRunner.calls).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'uninstall', CLAUDE_LEGACY_PLUGIN_ID, '--scope', 'user'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'list', '--json'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'remove', CLAUDE_MARKETPLACE_NAME], opts: {} },
-    ]);
+    const uninstallCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall']);
+    expect(uninstallCalls).toHaveLength(1);
+    expect(uninstallCalls[0]?.args).toEqual(['plugin', 'uninstall', CLAUDE_LEGACY_PLUGIN_ID, '--scope', 'user']);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toHaveLength(1);
     expect(io.stderr.text()).toContain('PlanBridge plugin removed');
     expect(readLogs(logs).some((r) => r.msg.includes('not installed at scope user'))).toBe(true);
   });
@@ -318,13 +288,11 @@ describe('ClaudeInstaller.uninstall', () => {
 
     await installer.uninstall(context, { yes: true });
 
-    expect(commandRunner.calls).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'uninstall', CLAUDE_PLUGIN_ID, '--scope', 'user'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'uninstall', CLAUDE_LEGACY_PLUGIN_ID, '--scope', 'user'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'list', '--json'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'remove', CLAUDE_MARKETPLACE_NAME], opts: {} },
-    ]);
+    const uninstallCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall']);
+    expect(uninstallCalls).toHaveLength(2);
+    expect(uninstallCalls[0]?.args).toEqual(['plugin', 'uninstall', CLAUDE_PLUGIN_ID, '--scope', 'user']);
+    expect(uninstallCalls[1]?.args).toEqual(['plugin', 'uninstall', CLAUDE_LEGACY_PLUGIN_ID, '--scope', 'user']);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toHaveLength(1);
   });
 
   it('is fully idempotent when both the plugin and marketplace are already absent', async () => {
@@ -336,10 +304,8 @@ describe('ClaudeInstaller.uninstall', () => {
 
     await installer.uninstall(context, { yes: true });
 
-    expect(commandRunner.calls).toEqual([
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
-      { cmd: CLAUDE_BINARY, args: ['plugin', 'marketplace', 'list', '--json'], opts: {} },
-    ]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toEqual([]);
     expect(io.stderr.text()).toContain('PlanBridge plugin removed');
   });
 
@@ -373,7 +339,8 @@ describe('ClaudeInstaller.uninstall', () => {
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves({ exitCode: 1, stderr: 'disk full' });
 
     expect(installer.uninstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
-    expect(commandRunner.calls).toHaveLength(2);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toHaveLength(1);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])).toEqual([]);
     expect(readErrorLogs(logs).some((r) => r.msg.includes('disk full'))).toBe(true);
   });
 
@@ -389,7 +356,7 @@ describe('ClaudeInstaller.uninstall', () => {
       .resolves({ exitCode: 1, stderr: 'some other marketplace error' });
 
     expect(installer.uninstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
-    expect(commandRunner.calls).toHaveLength(4);
+    expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toHaveLength(1);
     expect(readErrorLogs(logs).some((r) => r.msg.includes('some other marketplace error'))).toBe(true);
   });
 });

--- a/packages/cli/src/harnesses/ClaudeInstaller.ts
+++ b/packages/cli/src/harnesses/ClaudeInstaller.ts
@@ -70,6 +70,7 @@ export class ClaudeInstaller extends ScopedHarnessInstaller {
       '--scope',
       scope,
     ]);
+    await runPluginCommand(ctx, binaryName, 'marketplace update', ['marketplace', 'update', CLAUDE_MARKETPLACE_NAME]);
     if (hasCurrentAtScope) {
       await runPluginCommand(ctx, binaryName, 'update', ['update', CLAUDE_PLUGIN_ID, '--scope', scope]);
     } else {

--- a/packages/cli/src/testHelpers/FakeCommandRunner.test.ts
+++ b/packages/cli/src/testHelpers/FakeCommandRunner.test.ts
@@ -83,15 +83,27 @@ describe('FakeCommandRunner', () => {
     });
   });
 
-  describe('matcher order — first match wins', () => {
-    it('uses the responder registered first when multiple match', async () => {
+  describe('matcher order — last match wins', () => {
+    it('uses the responder registered last when multiple match, so later overrides win', async () => {
       const cr = new FakeCommandRunner();
       cr.onAny().resolves({ stdout: 'first' });
       cr.onAny().resolves({ stdout: 'second' });
 
       const result = await cr.run('claude', []);
 
-      expect(result.stdout).toBe('first');
+      expect(result.stdout).toBe('second');
+    });
+
+    it('lets a specific override replace a generic default', async () => {
+      const cr = new FakeCommandRunner();
+      cr.on('claude').resolves({ stdout: 'default' });
+      cr.on('claude', ['plugin', 'install']).resolves({ stdout: 'override' });
+
+      const generic = await cr.run('claude', ['plugin', 'list']);
+      const overridden = await cr.run('claude', ['plugin', 'install']);
+
+      expect(generic.stdout).toBe('default');
+      expect(overridden.stdout).toBe('override');
     });
 
     it('falls through past responders that do not match', async () => {

--- a/packages/cli/src/testHelpers/FakeCommandRunner.ts
+++ b/packages/cli/src/testHelpers/FakeCommandRunner.ts
@@ -53,7 +53,7 @@ export class FakeCommandRunner implements CommandRunner {
 
   run(cmd: string, args: readonly string[], opts: RunCommandOptions = {}): Promise<RunCommandResult> {
     this.calls.push({ cmd, args, opts });
-    const responder = this.responders.find((r) => r.matcher(cmd, args));
+    const responder = this.responders.findLast((r) => r.matcher(cmd, args));
     if (!responder) {
       return Promise.reject(new Error(this.formatMiss(cmd, args)));
     }

--- a/packages/cli/src/testHelpers/claudeInstallerFakes.ts
+++ b/packages/cli/src/testHelpers/claudeInstallerFakes.ts
@@ -4,6 +4,18 @@ import type { FakeCommandRunner } from './FakeCommandRunner.ts';
 export type PluginFixture = { id: string; scope: string };
 export type MarketplaceFixture = { name: string };
 
+export interface ClaudeStateFixture {
+  marketplaces?: Array<{ name: string; plugins?: PluginFixture[] }>;
+  /**
+   * Plugins listed by `claude plugin list --json` that don't belong to any
+   * fixture marketplace. The CLI's `plugin list` output is `{ id, scope }` —
+   * no marketplace association — so this models tests that exercise code
+   * paths reading only the plugin list (e.g. the "already installed"
+   * early-return) without needing a corresponding marketplace fixture.
+   */
+  unmanagedPlugins?: PluginFixture[];
+}
+
 export function pluginListResult(plugins: PluginFixture[]) {
   return { exitCode: 0, stdout: JSON.stringify(plugins), stderr: '' };
 }
@@ -34,12 +46,17 @@ export function primeClaudeShellouts(commandRunner: FakeCommandRunner): void {
   commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
 }
 
-export function stubPluginList(commandRunner: FakeCommandRunner, plugins: PluginFixture[]): void {
-  commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult(plugins));
-}
-
-export function stubMarketplaceList(commandRunner: FakeCommandRunner, marketplaces: MarketplaceFixture[]): void {
+/**
+ * Stub the two `claude plugin` listing shellouts in one call, encoding which
+ * plugins live in which marketplace. Plugins in `marketplaces[i].plugins` and
+ * any `unmanagedPlugins` are merged into the `plugin list --json` response;
+ * marketplace names go into `plugin marketplace list --json`.
+ */
+export function stubClaudeState(commandRunner: FakeCommandRunner, state: ClaudeStateFixture): void {
+  const { marketplaces = [], unmanagedPlugins = [] } = state;
+  const allPlugins = [...marketplaces.flatMap((m) => m.plugins ?? []), ...unmanagedPlugins];
+  commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult(allPlugins));
   commandRunner
     .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
-    .resolves(marketplaceListResult(marketplaces));
+    .resolves(marketplaceListResult(marketplaces.map(({ name }) => ({ name }))));
 }

--- a/packages/cli/src/testHelpers/claudeInstallerFakes.ts
+++ b/packages/cli/src/testHelpers/claudeInstallerFakes.ts
@@ -1,7 +1,44 @@
-export function pluginListResult(plugins: Array<{ id: string; scope: string }>) {
+import { getDescriptor } from '#src/harnesses/registry.ts';
+import type { FakeCommandRunner } from './FakeCommandRunner.ts';
+
+export type PluginFixture = { id: string; scope: string };
+export type MarketplaceFixture = { name: string };
+
+export function pluginListResult(plugins: PluginFixture[]) {
   return { exitCode: 0, stdout: JSON.stringify(plugins), stderr: '' };
 }
 
-export function marketplaceListResult(marketplaces: Array<{ name: string }>) {
+export function marketplaceListResult(marketplaces: MarketplaceFixture[]) {
   return { exitCode: 0, stdout: JSON.stringify(marketplaces), stderr: '' };
+}
+
+const CLAUDE_BINARY = getDescriptor('claude').binaryName;
+
+/**
+ * Prime a FakeCommandRunner with the canonical happy-path responses for every
+ * `claude plugin` subcommand the installer can fire: claude on PATH, empty
+ * plugin/marketplace lists, and all write commands resolve cleanly. Callers
+ * register more-specific overrides (failure cases, populated lists, etc.) with
+ * the usual `commandRunner.on(...)` after this — last-match-wins makes them
+ * take precedence.
+ */
+export function primeClaudeShellouts(commandRunner: FakeCommandRunner): void {
+  commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+  commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
+  commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
+  commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+  commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
+  commandRunner.on(CLAUDE_BINARY, ['plugin', 'update']).resolves();
+  commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
+  commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
+}
+
+export function stubPluginList(commandRunner: FakeCommandRunner, plugins: PluginFixture[]): void {
+  commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult(plugins));
+}
+
+export function stubMarketplaceList(commandRunner: FakeCommandRunner, marketplaces: MarketplaceFixture[]): void {
+  commandRunner
+    .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+    .resolves(marketplaceListResult(marketplaces));
 }

--- a/packages/cli/src/testHelpers/claudeInstallerFakes.ts
+++ b/packages/cli/src/testHelpers/claudeInstallerFakes.ts
@@ -27,6 +27,7 @@ export function primeClaudeShellouts(commandRunner: FakeCommandRunner): void {
   commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
   commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
   commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves();
+  commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'update']).resolves();
   commandRunner.on(CLAUDE_BINARY, ['plugin', 'install']).resolves();
   commandRunner.on(CLAUDE_BINARY, ['plugin', 'update']).resolves();
   commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();

--- a/packages/cli/src/testHelpers/index.ts
+++ b/packages/cli/src/testHelpers/index.ts
@@ -1,11 +1,11 @@
 export {
+  type ClaudeStateFixture,
   type MarketplaceFixture,
   type PluginFixture,
   marketplaceListResult,
   pluginListResult,
   primeClaudeShellouts,
-  stubMarketplaceList,
-  stubPluginList,
+  stubClaudeState,
 } from './claudeInstallerFakes.ts';
 export { type CommandStub, type FakeCommandCall, FakeCommandRunner } from './FakeCommandRunner.ts';
 export { FakeIo } from './FakeIo.ts';

--- a/packages/cli/src/testHelpers/index.ts
+++ b/packages/cli/src/testHelpers/index.ts
@@ -1,4 +1,12 @@
-export { marketplaceListResult, pluginListResult } from './claudeInstallerFakes.ts';
+export {
+  type MarketplaceFixture,
+  type PluginFixture,
+  marketplaceListResult,
+  pluginListResult,
+  primeClaudeShellouts,
+  stubMarketplaceList,
+  stubPluginList,
+} from './claudeInstallerFakes.ts';
 export { type CommandStub, type FakeCommandCall, FakeCommandRunner } from './FakeCommandRunner.ts';
 export { FakeIo } from './FakeIo.ts';
 export { FakePrompter } from './FakePrompter.ts';


### PR DESCRIPTION
## Summary

`contextbridge install claude` failed for users upgrading across the `cli@contextbridge` → `planbridge@contextbridge` rename because Claude's locally cached marketplace catalog still listed the old plugin id. Run `claude plugin marketplace update contextbridge` after `marketplace add` so the cached catalog always reflects upstream — closes #61.

## Review focus

**Recommend reviewing commit-by-commit.** The first two commits are pure test-side refactors (no source change); the third is the one-line fix. Splitting them keeps the fix obvious to read and the refactors independently revertable.

- **Commit 1 (assertion refactor)**: most install/uninstall tests previously asserted the full `commandRunner.calls` chain via `.toEqual` even when they only cared about one or two specific calls. That made every shellout addition require fixture updates in 13 unrelated tests. Converted to targeted `callsTo(...)` checks; kept one canonical full-sequence test per scenario family (clean install, migration, clean uninstall) so ordering invariants stay locked down in one place.
- **Commit 2 (setup refactor)**: extracted `primeClaudeShellouts` + promoted `stubPluginList` / `stubMarketplaceList` to shared helpers. Each test file now wraps these with a local `setupTest`. **Adjacent infrastructure change**: flipped `FakeCommandRunner` from first-match-wins to last-match-wins so overrides registered after `primeClaudeShellouts` actually take effect — matches Jest/vitest/sinon override semantics. Added a regression test for the override path; renamed the existing matcher-order test.
- **Commit 3 (the fix)**: 1 source line in `runInstall`, 1 default stub in `primeClaudeShellouts`, 3 fixture line additions. Run unconditionally — on a fresh install the second shellout is a near-no-op `git pull`; on the bug case it does the actual refresh. The post-update refresh path in `runUpdate` benefits automatically by re-entering `runInstall`.

The fix-only commit is what reviewers should weigh-in on most carefully; the refactors are mechanical and have green tests with no source change.

## Commits

- [`ec22228`](https://github.com/contextbridge/planbridge/commit/ec22228089a04e94620735cb75ee66e4b17ea0b3) — replace over-specified `commandRunner.calls.toEqual([...])` chains with targeted `callsTo(...)` assertions across `ClaudeInstaller.test.ts`. Net -33 lines, no source change.
- [`cf12c48`](https://github.com/contextbridge/planbridge/commit/cf12c48319096fd9e7b2354d741470ee89cac763) — centralize Claude test setup with `primeClaudeShellouts` and per-file `setupTest` helpers; flip `FakeCommandRunner` to last-match-wins for clean override semantics. Net -92 lines, no source change.
- [`7abf4f7`](https://github.com/contextbridge/planbridge/commit/7abf4f731253910ab96974426d921fff244cbd3a) — add `claude plugin marketplace update contextbridge` after `marketplace add` in `ClaudeInstaller.runInstall`; strengthen the existing "already on disk" test as the regression test for #61.