### PR TITLE
fix: resolve contextbridge via PATH for post-update refresh

### DIFF
--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -16,6 +16,9 @@ import { runUpdate } from './update.ts';
 
 const CLAUDE_BINARY = getDescriptor('claude').binaryName;
 const CODEX_BINARY = getDescriptor('codex').binaryName;
+// Arbitrary fake path returned from `commandRunner.which('contextbridge')` so tests
+// can stub the refresh-spawn target separately from process.execPath.
+const FAKE_CONTEXTBRIDGE_PATH = '/usr/local/bin/contextbridge';
 
 describe('runUpdate', () => {
   it('prints "up to date" and exits 0 when there is no notice', async () => {
@@ -207,6 +210,7 @@ describe('runUpdate', () => {
   it('refreshes Claude after a successful update when the plugin is wired up', async () => {
     const { context, commandRunner, updater } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    commandRunner.setWhich('contextbridge', FAKE_CONTEXTBRIDGE_PATH);
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({
       status: 'executed',
@@ -219,11 +223,11 @@ describe('runUpdate', () => {
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
       .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]));
-    commandRunner.on(process.execPath, ['install', 'claude']).resolves();
+    commandRunner.on(FAKE_CONTEXTBRIDGE_PATH, ['install', 'claude']).resolves();
 
     await runUpdate(context);
 
-    const spawnCall = commandRunner.calls.find((c) => c.cmd === process.execPath);
+    const spawnCall = commandRunner.calls.find((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
     expect(spawnCall).toBeDefined();
     expect(spawnCall?.args).toEqual(['install', 'claude', '--scope', 'user']);
   });
@@ -231,6 +235,7 @@ describe('runUpdate', () => {
   it('refreshes Claude after update when only the legacy cli@contextbridge plugin is installed', async () => {
     const { context, commandRunner, updater } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    commandRunner.setWhich('contextbridge', FAKE_CONTEXTBRIDGE_PATH);
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({
       status: 'executed',
@@ -243,11 +248,11 @@ describe('runUpdate', () => {
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
       .resolves(pluginListResult([{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }]));
-    commandRunner.on(process.execPath, ['install', 'claude']).resolves();
+    commandRunner.on(FAKE_CONTEXTBRIDGE_PATH, ['install', 'claude']).resolves();
 
     await runUpdate(context);
 
-    const spawnCall = commandRunner.calls.find((c) => c.cmd === process.execPath);
+    const spawnCall = commandRunner.calls.find((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
     expect(spawnCall).toBeDefined();
     expect(spawnCall?.args).toEqual(['install', 'claude', '--scope', 'user']);
   });
@@ -255,6 +260,7 @@ describe('runUpdate', () => {
   it('refreshes Claude at project scope when the new plugin is installed at project scope', async () => {
     const { context, commandRunner, updater } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    commandRunner.setWhich('contextbridge', FAKE_CONTEXTBRIDGE_PATH);
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({
       status: 'executed',
@@ -267,11 +273,11 @@ describe('runUpdate', () => {
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
       .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]));
-    commandRunner.on(process.execPath, ['install', 'claude']).resolves();
+    commandRunner.on(FAKE_CONTEXTBRIDGE_PATH, ['install', 'claude']).resolves();
 
     await runUpdate(context);
 
-    const spawnCall = commandRunner.calls.find((c) => c.cmd === process.execPath);
+    const spawnCall = commandRunner.calls.find((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
     expect(spawnCall).toBeDefined();
     expect(spawnCall?.args).toEqual(['install', 'claude', '--scope', 'project']);
   });
@@ -279,6 +285,7 @@ describe('runUpdate', () => {
   it('refreshes Claude at project scope when only the legacy plugin is installed at project scope', async () => {
     const { context, commandRunner, updater } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    commandRunner.setWhich('contextbridge', FAKE_CONTEXTBRIDGE_PATH);
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({
       status: 'executed',
@@ -291,11 +298,11 @@ describe('runUpdate', () => {
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
       .resolves(pluginListResult([{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'project' }]));
-    commandRunner.on(process.execPath, ['install', 'claude']).resolves();
+    commandRunner.on(FAKE_CONTEXTBRIDGE_PATH, ['install', 'claude']).resolves();
 
     await runUpdate(context);
 
-    const spawnCall = commandRunner.calls.find((c) => c.cmd === process.execPath);
+    const spawnCall = commandRunner.calls.find((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
     expect(spawnCall).toBeDefined();
     expect(spawnCall?.args).toEqual(['install', 'claude', '--scope', 'project']);
   });
@@ -305,6 +312,7 @@ describe('runUpdate', () => {
     const projectRoot = join(tmp, 'repo');
     const { context, commandRunner, updater } = createStubContext({ projectRoot });
     commandRunner.setWhich(CODEX_BINARY, '/usr/local/bin/codex');
+    commandRunner.setWhich('contextbridge', FAKE_CONTEXTBRIDGE_PATH);
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({
       status: 'executed',
@@ -320,11 +328,11 @@ describe('runUpdate', () => {
         JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: 'command', command: 'contextbridge hook codex' }] }] } }),
       );
       writeFileSync(join(configDir, 'config.toml'), '[features]\ncodex_hooks = true\n');
-      commandRunner.on(process.execPath, ['install', 'codex']).resolves();
+      commandRunner.on(FAKE_CONTEXTBRIDGE_PATH, ['install', 'codex']).resolves();
 
       await runUpdate(context);
 
-      const spawnCall = commandRunner.calls.find((c) => c.cmd === process.execPath);
+      const spawnCall = commandRunner.calls.find((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
       expect(spawnCall).toBeDefined();
       expect(spawnCall?.args).toEqual(['install', 'codex', '--scope', 'project']);
     } finally {
@@ -335,6 +343,7 @@ describe('runUpdate', () => {
   it('skips refresh for harnesses with no PlanBridge state after update', async () => {
     const { context, commandRunner, updater } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    commandRunner.setWhich('contextbridge', FAKE_CONTEXTBRIDGE_PATH);
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({
       status: 'executed',
@@ -346,13 +355,14 @@ describe('runUpdate', () => {
 
     await runUpdate(context);
 
-    const spawnCalls = commandRunner.calls.filter((c) => c.cmd === process.execPath);
+    const spawnCalls = commandRunner.calls.filter((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
     expect(spawnCalls).toEqual([]);
   });
 
   it('skips refresh for Claude marketplace-only state after update', async () => {
     const { context, commandRunner, updater } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    commandRunner.setWhich('contextbridge', FAKE_CONTEXTBRIDGE_PATH);
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({
       status: 'executed',
@@ -366,13 +376,14 @@ describe('runUpdate', () => {
 
     await runUpdate(context);
 
-    const spawnCalls = commandRunner.calls.filter((c) => c.cmd === process.execPath);
+    const spawnCalls = commandRunner.calls.filter((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
     expect(spawnCalls).toEqual([]);
   });
 
-  it('logs a warning when post-update refresh exits non-zero but still completes the update', async () => {
+  it('logs an error when post-update refresh exits non-zero but still completes the update', async () => {
     const { context, io, logs, commandRunner, updater } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    commandRunner.setWhich('contextbridge', FAKE_CONTEXTBRIDGE_PATH);
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({
       status: 'executed',
@@ -385,11 +396,37 @@ describe('runUpdate', () => {
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
       .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]));
-    commandRunner.on(process.execPath, ['install', 'claude']).resolves({ exitCode: 1, stderr: 'install failed' });
+    commandRunner
+      .on(FAKE_CONTEXTBRIDGE_PATH, ['install', 'claude'])
+      .resolves({ exitCode: 1, stderr: 'install failed' });
 
     await runUpdate(context);
 
     expect(io.stderr.text()).toContain('update complete');
-    expect(readWarnLogs(logs).some((r) => r.msg.includes('post-update harness refresh failed'))).toBe(true);
+    expect(readErrorLogs(logs).some((r) => r.msg.includes('post-update harness refresh failed'))).toBe(true);
+  });
+
+  it('logs an error and skips refresh when contextbridge cannot be resolved on PATH', async () => {
+    const { context, io, logs, commandRunner, updater } = createStubContext();
+    commandRunner.setWhich(CLAUDE_BINARY, '/usr/local/bin/claude');
+    // No setWhich for 'contextbridge' — simulates the binary missing from PATH.
+    updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
+    updater.setPerformResult({
+      status: 'executed',
+      command: ['brew', 'upgrade', '--cask', 'contextbridge/tap/cli'],
+      exitCode: 0,
+    });
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])
+      .resolves(marketplaceListResult([{ name: CLAUDE_MARKETPLACE_NAME }]));
+    commandRunner
+      .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
+      .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]));
+
+    await runUpdate(context);
+
+    expect(io.stderr.text()).toContain('update complete');
+    expect(readErrorLogs(logs).some((r) => r.msg.includes('contextbridge not found on PATH'))).toBe(true);
+    expect(commandRunner.calls.filter((c) => c.cmd === process.execPath)).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -65,9 +65,16 @@ export function registerUpdate(ctx: CliContext, program: Command): void {
 // sync with the binary across renames and hook-contract changes. Skips harnesses
 // the user never wired up; never blocks update success on a refresh failure.
 async function refreshInstalledHarnesses(ctx: CliContext): Promise<void> {
+  const { commandRunner, logger } = ctx;
+  // Resolve via PATH, not process.execPath: brew purges the old cellar dir before this runs.
+  const binaryPath = commandRunner.which('contextbridge');
+  if (!binaryPath) {
+    logger.error('post-update harness refresh skipped: contextbridge not found on PATH');
+    return;
+  }
   for (const installer of ALL_INSTALLERS) {
     for (const scope of await getInstallerRefreshScopes(ctx, installer)) {
-      await refreshInstallerScope(ctx, installer, scope);
+      await refreshInstallerScope(ctx, binaryPath, installer, scope);
     }
   }
 }
@@ -77,25 +84,30 @@ async function getInstallerRefreshScopes(ctx: CliContext, installer: HarnessInst
     const status = await installer.status(ctx);
     return getRefreshScopes(status.managed);
   } catch (err) {
-    ctx.logger.warn({ err, harness: installer.descriptor.id }, 'post-update harness refresh failed');
+    ctx.logger.error({ err, harness: installer.descriptor.id }, 'post-update harness refresh failed');
     return [];
   }
 }
 
-async function refreshInstallerScope(ctx: CliContext, installer: HarnessInstaller, scope: string): Promise<void> {
+async function refreshInstallerScope(
+  ctx: CliContext,
+  binaryPath: string,
+  installer: HarnessInstaller,
+  scope: string,
+): Promise<void> {
   const { commandRunner, logger } = ctx;
   try {
-    const result = await commandRunner.run(process.execPath, ['install', installer.descriptor.id, '--scope', scope], {
+    const result = await commandRunner.run(binaryPath, ['install', installer.descriptor.id, '--scope', scope], {
       stdio: 'inherit',
     });
     if (result.exitCode !== 0) {
-      logger.warn(
+      logger.error(
         { exitCode: result.exitCode, harness: installer.descriptor.id, scope },
         'post-update harness refresh failed',
       );
     }
   } catch (err) {
-    logger.warn({ err, harness: installer.descriptor.id, scope }, 'post-update harness refresh failed');
+    logger.error({ err, harness: installer.descriptor.id, scope }, 'post-update harness refresh failed');
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #63. After `brew upgrade --cask cli@alpha` (or `cli`), the post-update harness refresh introduced in #52 fails silently with `ENOENT` because `process.execPath` was captured at process start and now points at the cellar dir brew already purged. The refresh exists to keep harness state in sync across binary changes (renames, hook contracts) — silent no-op defeats the entire feature for every brew-installed user.

Resolve the binary via `commandRunner.which('contextbridge')` instead. The PATH symlink (`/opt/homebrew/bin/contextbridge` for brew, `~/.local/bin/contextbridge` for install-script users) survives the upgrade. If `which` returns null, log `error` and skip — refusing to fall back to the broken `execPath` keeps us from silently masking the very bug we're fixing.

Also bumped refresh-failure logs from `warn` → `error` so Sentry surfaces these in production.

## Review focus

- **Logging level decision** in `update.ts`: I bumped four warn paths to error (which-null, status-throws, exitCode-non-zero, spawn-throws). All four are anomalies for a working install; a non-actionable user environment issue should not realistically trigger them. If you'd rather a subset stay at warn, let me know.
- **No fallback to `execPath`** when `which` returns null. Considered an `existsSync(process.execPath)` fallback for users with non-PATH installs but rejected: such users are rare (both supported install methods put the binary on PATH), and the fallback would mask exactly the brew-purge case the fix targets.
- **Test coverage**: the seven existing refresh tests were updated to stub against the PATH-resolved path and never stub `execPath`, so any future change reintroducing `execPath` spawning fails them via `FakeCommandRunner: no responder`. One new test covers the `which`-null early-return branch (the only genuinely new behavior).

## Commits

- [`ae70910`](https://github.com/contextbridge/planbridge/commit/ae70910a7a541e37e1d61a2859850a5ce40e19db) — replace `process.execPath` with PATH-resolved binary in post-update refresh; bump warn → error on refresh failures.