### PR TITLE
fix: disable telemetry in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,8 @@ jobs:
     name: Install script (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    env:
+      CONTEXTBRIDGE_TELEMETRY_DISABLED: '1'
     strategy:
       fail-fast: false
       matrix:

--- a/packages/cli/src/environment.ts
+++ b/packages/cli/src/environment.ts
@@ -6,6 +6,7 @@ const Environment = z.object({
   LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal', 'silent']).default('info'),
   DO_NOT_TRACK: booleanEnv,
   CONTEXTBRIDGE_TELEMETRY_DISABLED: booleanEnv,
+  CI: booleanEnv,
   CONTEXTBRIDGE_UPDATE_CHECK_DISABLED: booleanEnv,
   XDG_CONFIG_HOME: z.string().optional(),
   HOME: z.string().optional(),

--- a/packages/cli/src/testFactories.ts
+++ b/packages/cli/src/testFactories.ts
@@ -57,6 +57,7 @@ export const environment = Factory.define<Environment>(() => ({
   LOG_LEVEL: 'info',
   DO_NOT_TRACK: false,
   CONTEXTBRIDGE_TELEMETRY_DISABLED: false,
+  CI: false,
   CONTEXTBRIDGE_UPDATE_CHECK_DISABLED: false,
 }));
 

--- a/packages/cli/src/updater/UpdaterImpl.test.ts
+++ b/packages/cli/src/updater/UpdaterImpl.test.ts
@@ -511,6 +511,7 @@ function buildUpdater({
     LOG_LEVEL: 'info',
     DO_NOT_TRACK: false,
     CONTEXTBRIDGE_TELEMETRY_DISABLED: false,
+    CI: false,
     CONTEXTBRIDGE_UPDATE_CHECK_DISABLED: false,
     XDG_CONFIG_HOME: tmpRoot,
     ...envOverrides,

--- a/packages/context/src/base.test.ts
+++ b/packages/context/src/base.test.ts
@@ -61,9 +61,8 @@ describe('isTelemetryDisabled', () => {
     ).toBe(true);
   });
 
-  it('returns true in CI environments', () => {
+  it('returns true when CI is true', () => {
     expect(isTelemetryDisabled({ buildInfo: productionBuildInfo, env: { CI: true } })).toBe(true);
-    expect(isTelemetryDisabled({ buildInfo: productionBuildInfo, env: { GITHUB_ACTIONS: true } })).toBe(true);
   });
 
   it('returns true when the build environment is not production', () => {

--- a/packages/context/src/base.test.ts
+++ b/packages/context/src/base.test.ts
@@ -61,6 +61,11 @@ describe('isTelemetryDisabled', () => {
     ).toBe(true);
   });
 
+  it('returns true in CI environments', () => {
+    expect(isTelemetryDisabled({ buildInfo: productionBuildInfo, env: { CI: true } })).toBe(true);
+    expect(isTelemetryDisabled({ buildInfo: productionBuildInfo, env: { GITHUB_ACTIONS: true } })).toBe(true);
+  });
+
   it('returns true when the build environment is not production', () => {
     expect(
       isTelemetryDisabled({

--- a/packages/context/src/base.ts
+++ b/packages/context/src/base.ts
@@ -45,7 +45,6 @@ export interface TelemetryOptOutEnv {
   readonly DO_NOT_TRACK?: boolean;
   readonly CONTEXTBRIDGE_TELEMETRY_DISABLED?: boolean;
   readonly CI?: boolean;
-  readonly GITHUB_ACTIONS?: boolean;
 }
 
 export interface IsTelemetryDisabledInput {
@@ -60,5 +59,5 @@ export function isTelemetryDisabled(input: IsTelemetryDisabledInput): boolean {
 }
 
 function isEnvOptOut(env: TelemetryOptOutEnv): boolean {
-  return Boolean(env.DO_NOT_TRACK || env.CONTEXTBRIDGE_TELEMETRY_DISABLED || env.CI || env.GITHUB_ACTIONS);
+  return Boolean(env.DO_NOT_TRACK || env.CONTEXTBRIDGE_TELEMETRY_DISABLED || env.CI);
 }

--- a/packages/context/src/base.ts
+++ b/packages/context/src/base.ts
@@ -44,6 +44,8 @@ export function createBaseContext(input: CreateBaseContextInput): BaseContext {
 export interface TelemetryOptOutEnv {
   readonly DO_NOT_TRACK?: boolean;
   readonly CONTEXTBRIDGE_TELEMETRY_DISABLED?: boolean;
+  readonly CI?: boolean;
+  readonly GITHUB_ACTIONS?: boolean;
 }
 
 export interface IsTelemetryDisabledInput {
@@ -58,5 +60,5 @@ export function isTelemetryDisabled(input: IsTelemetryDisabledInput): boolean {
 }
 
 function isEnvOptOut(env: TelemetryOptOutEnv): boolean {
-  return Boolean(env.DO_NOT_TRACK || env.CONTEXTBRIDGE_TELEMETRY_DISABLED);
+  return Boolean(env.DO_NOT_TRACK || env.CONTEXTBRIDGE_TELEMETRY_DISABLED || env.CI || env.GITHUB_ACTIONS);
 }


### PR DESCRIPTION
## Summary

Suppress telemetry (PostHog + Sentry) when running in CI so analytics and error reports aren't polluted by automated runs. Detection now treats `CI=1` as an opt-out alongside the existing `DO_NOT_TRACK` / `CONTEXTBRIDGE_TELEMETRY_DISABLED` signals, and the install-script workflow sets `CONTEXTBRIDGE_TELEMETRY_DISABLED=1` explicitly for the freshly-installed binary's first run.

## Review focus

- `packages/context/src/base.ts` — `isEnvOptOut` now ORs in `CI`. This is set almost universally in CI systems, so any developer or downstream user running the CLI inside any CI will get telemetry disabled by default. That seems like the correct trade-off, but worth a sanity check.
- The install-script job in `.github/workflows/test.yml` sets `CONTEXTBRIDGE_TELEMETRY_DISABLED=1` in addition to the new `CI`-based detection — belt-and-suspenders because that job exercises a binary that may not yet have the new logic.

## Commits

- [\`5070d24\`](https://github.com/contextbridge/planbridge/commit/5070d24) — fix: disable telemetry in CI
- [\`ba66614\`](https://github.com/contextbridge/planbridge/commit/ba66614) — fix: only treat CI as the CI opt-out signal