### PR TITLE
feat: add 'contextbridge open' subcommand and planbridge-open skill

### DIFF
--- a/.claude/rules/claude-plugin-skills.md
+++ b/.claude/rules/claude-plugin-skills.md
@@ -1,0 +1,22 @@
+---
+paths:
+  - "harnessIntegrations/claude/skills/**/SKILL.md"
+  - "packages/cli/src/bundledSkills.ts"
+---
+
+# Adding a Claude-plugin skill
+
+Claude-plugin skills auto-distribute to Codex via `packages/cli/src/bundledSkills.ts`. The Claude file is the single source of truth; `CodexInstaller` iterates the registry — no installer changes per skill.
+
+## Steps
+
+1. Create `harnessIntegrations/claude/skills/<name>/SKILL.md` with standard frontmatter (`name`, `description`) and a harness-agnostic body. Don't hardcode `/planbridge:` or `$planbridge-` prefixes in the body — the harness routes invocation before the SKILL.md loads.
+2. In `packages/cli/src/bundledSkills.ts`, add an import and one `{ name, body }` entry to the `bundledSkills` array.
+3. Run `bun run --cwd packages/cli test bundledSkills` — the per-skill sync test picks up the new entry automatically.
+
+If the skill needs a new CLI subcommand, add it under `packages/cli/src/commands/` and register in `commands/index.ts`.
+
+## Invocation surfaces
+
+- Claude: `/planbridge:<name>`
+- Codex: `$planbridge-<name>` (installed to `~/.agents/skills/planbridge-<name>/SKILL.md`)

--- a/harnessIntegrations/claude/skills/open/SKILL.md
+++ b/harnessIntegrations/claude/skills/open/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: open
+description: Open a markdown file, document, or piece of content in the PlanBridge browser UI for human annotation. Use when the user wants to give human feedback on a file, draft, plan, spec, or any markdown content.
+---
+
+# Open content in PlanBridge
+
+Opens a markdown file or piped content in the PlanBridge browser UI, where the user can leave inline annotations and general comments. Their feedback is returned on stdout.
+
+## When to use
+
+Use this skill when the user wants to annotate something themselves in the browser. Typical triggers:
+
+- "I want to annotate this in PlanBridge"
+- "Open this in the browser so I can mark it up"
+- "Let me leave comments on this before you continue"
+- The user asks you to revise based on their annotations and you haven't collected them yet
+
+## How to invoke
+
+The CLI takes a file path or stdin content:
+
+    # A path on disk (most common)
+    contextbridge open /absolute/path/to/file.md
+
+    # Piped content (when the content lives in conversation, not on disk)
+    printf %s "<content>" | contextbridge open
+
+### Resolving the argument
+
+The user's argument may be a literal path or a human-language description. Resolve it first:
+
+1. If it looks like a path and the file exists, use it directly.
+2. If it's a description (e.g., "the plan we discussed", "the spec for X"), use your normal file-discovery tools to locate the file in the working directory or recent conversation, then call `contextbridge open <resolved-path>`.
+3. If the content lives in conversation rather than on disk (e.g., the user wants to annotate something you just wrote), pipe it via stdin.
+
+If you can't resolve the argument confidently, ask the user for clarification before running anything.
+
+## What happens
+
+1. PlanBridge starts a local browser session and prints the URL.
+2. The user annotates in the browser. Block on the CLI until they submit.
+3. The CLI prints a markdown summary of the user's feedback to stdout.
+
+## What to do with the output
+
+The output is feedback for discussion, not a directive. Read it carefully:
+
+- If the user left no annotations, acknowledge briefly and continue with whatever they were doing.
+- If the user left annotations, respond conversationally. They may want edits, may want discussion, may be flagging things for later. Don't assume edits are required unless the comments make that clear. When in doubt, ask what they want to do next.
+
+Treat the comments the way you'd treat a colleague's review notes — context for the next step, not a checklist to silently execute.
+
+## Limitations
+
+Folders, URLs, and multi-file annotation are not currently supported. Pass a single file path or pipe a single document.

--- a/packages/annotation/index.html
+++ b/packages/annotation/index.html
@@ -8,7 +8,7 @@
       type="image/svg+xml"
       href='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="210" height="210" viewBox="0 0 210 210" fill="none"><style>.bg{fill:%23000}.logo{fill:%23fff}@media (prefers-color-scheme: dark){.bg{fill:%23fff}.logo{fill:%23000}}</style><rect class="bg" width="210" height="210"/><g transform="translate(29.848,23.445)"><path class="logo" d="M127.035 43.2306L134.972 0H21.973L0 119.88H23.2335L37.303 43.2306H127.035Z"/><path class="logo" d="M127.037 43.231L113.001 119.881H23.2355L15.332 163.111H128.297L150.304 43.231H127.037Z"/></g></svg>'
     />
-    <title>Plan Review — PlanBridge</title>
+    <title>Review — PlanBridge</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -43,7 +43,7 @@ describe('App', () => {
   it('shows an empty state when the plan content is blank', () => {
     renderApp({ initialPayload: { contentKind: 'plan', content: '' } });
 
-    expect(screen.getByTestId(appTestIds.emptyState)).toHaveTextContent('No plan content was provided.');
+    expect(screen.getByTestId(appTestIds.emptyState)).toHaveTextContent('No content was provided.');
   });
 
   it('renders the update-notice card when /update-notice resolves with a notice', async () => {
@@ -292,7 +292,32 @@ describe('App', () => {
     });
 
     await waitFor(() => {
-      expect(document.title).toBe('Plan Review — PlanBridge');
+      expect(document.title).toBe('Review — PlanBridge');
+    });
+  });
+
+  it('uses the basename of metadata.sourcePath in the document title when present', async () => {
+    const payload: AnnotationPayload = {
+      content: '# A doc\n',
+      contentKind: 'document',
+      metadata: { entrypoint: 'open_command', sourcePath: '/abs/path/to/draft.md' },
+    };
+    renderApp({ initialPayload: payload });
+    await waitFor(() => {
+      expect(document.title).toBe('draft.md — PlanBridge');
+    });
+  });
+
+  it('falls back to payload title when no sourcePath is set', async () => {
+    const payload: AnnotationPayload = {
+      content: '# A doc\n',
+      contentKind: 'document',
+      title: 'A doc',
+      metadata: { entrypoint: 'open_command' },
+    };
+    renderApp({ initialPayload: payload });
+    await waitFor(() => {
+      expect(document.title).toBe('A doc — PlanBridge');
     });
   });
 

--- a/packages/annotation/src/App.tsx
+++ b/packages/annotation/src/App.tsx
@@ -64,7 +64,7 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
         setPayload(next);
         analytics.capture('plan_review_viewed', { bytes: next.content.length });
       })
-      .catch(() => setPayload({ content: '(unable to load plan)', contentKind: 'plan' }));
+      .catch(() => setPayload({ content: '(unable to load content)', contentKind: 'document' }));
   }, [initialPayload, fetchPayload, analytics]);
 
   useEffect(() => {
@@ -73,7 +73,7 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
       .catch(() => {});
   }, [fetchUpdateNotice]);
 
-  const documentTitle = payload?.title ? `${payload.title} — PlanBridge` : 'Plan Review — PlanBridge';
+  const documentTitle = resolveDocumentTitle(payload);
 
   return (
     <>
@@ -89,7 +89,7 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
           />
           <div className="mx-auto max-w-4xl px-6 py-16">
             <p className="text-sm text-muted-foreground" data-testid={appTestIds.loading}>
-              Loading plan review…
+              Loading…
             </p>
           </div>
         </main>
@@ -126,7 +126,7 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
                     className="rounded-md border border-dashed border-border px-4 py-8 text-sm text-muted-foreground"
                     data-testid={appTestIds.emptyState}
                   >
-                    No plan content was provided.
+                    No content was provided.
                   </div>
                 )}
               </section>
@@ -184,4 +184,13 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
       )}
     </>
   );
+}
+
+const DEFAULT_DOCUMENT_TITLE = 'Review — PlanBridge';
+
+function resolveDocumentTitle(payload: AnnotationPayload | null): string {
+  if (!payload) return DEFAULT_DOCUMENT_TITLE;
+  const sourcePath = payload.metadata?.sourcePath;
+  const stem = sourcePath ? sourcePath.split('/').pop() || sourcePath : payload.title;
+  return stem ? `${stem} — PlanBridge` : DEFAULT_DOCUMENT_TITLE;
 }

--- a/packages/annotation/src/SubmitBar.tsx
+++ b/packages/annotation/src/SubmitBar.tsx
@@ -35,7 +35,7 @@ export function SubmitBar({ submission, source }: SubmitBarProps) {
         >
           {isCodexApproval ? (
             <>
-              <span>Plan approved.</span>
+              <span>Approved.</span>
               <strong className="block" data-testid={submitBarTestIds.codexHandoffNotice}>
                 Return to Codex to confirm implementation.
               </strong>

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -48,7 +48,7 @@ stdin / [path]  ─▶  contextbridge plan
                        { status: "approved" | "changes_requested", annotations: [...] }
 ```
 
-The loop is kind-agnostic: it serves a markdown document into the annotation UI and emits a structured result on stdout. The `plan` subcommand is the only user-facing entrypoint today and is tuned for plan-mode handoffs from Claude Code and Codex hooks; additional sibling entrypoints (e.g., `contextbridge open` per issue #51) will land on the same loop. The CLI process owns the server and the browser lifecycle. When the user submits in the browser, the server shuts down and the CLI emits its structured result to stdout. That stdout contract is what harness hooks (Claude `exitPlanMode`, Codex Stop hook, etc.) consume.
+The loop is kind-agnostic: it serves a markdown document into the annotation UI and emits a structured result on stdout. Sibling entrypoints on this same loop today: `plan` (plan-mode handoffs from Claude Code and Codex hooks) and `open` (manual annotation of a markdown file or piped content, surfaced as `/planbridge:open` in Claude and `$planbridge-open` in Codex). The CLI process owns the server and the browser lifecycle. When the user submits in the browser, the server shuts down and the CLI emits its structured result to stdout. That stdout contract is what harness hooks (Claude `exitPlanMode`, Codex Stop hook, etc.) consume.
 
 ## Build: embedded annotation UI
 

--- a/packages/cli/src/annotation/runAnnotation.test.ts
+++ b/packages/cli/src/annotation/runAnnotation.test.ts
@@ -1,9 +1,8 @@
-import type { AnnotationPayload, AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
-import { annotationSubmission } from '@contextbridge/shared/testFactories';
+import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
 import { describe, expect, it } from 'bun:test';
 import { annotationArgs } from '#src/testFactories.ts';
-import { createStubContext } from '#src/testHelpers/index.ts';
-import { type AnnotationDependencies, runAnnotation } from './runAnnotation.ts';
+import { createAnnotationDependencies, createDeferred, createStubContext } from '#src/testHelpers/index.ts';
+import { runAnnotation } from './runAnnotation.ts';
 
 describe('runAnnotation', () => {
   it('opens the browser and returns the submitted review', async () => {
@@ -63,80 +62,26 @@ describe('runAnnotation', () => {
     expect(deps.sigintHandlerRemoved).toBe(true);
     expect(analytics.captures.some((c) => c.event === 'plan_review_submitted')).toBe(false);
   });
-});
 
-function createAnnotationDependencies(
-  options: {
-    result?: Promise<AnnotationSubmission>;
-  } = {},
-): AnnotationDependencies & {
-  closeCount: number;
-  payloads: AnnotationPayload[];
-  sigintHandlerRegistered: Promise<void>;
-  sigintHandlerRemoved: boolean;
-  submission: AnnotationSubmission;
-  triggerSigint(): void;
-} {
-  const payloads: AnnotationPayload[] = [];
-  const submission = annotationSubmission.build();
-  const sigintRegistration = createDeferred<void>();
-  let closeCount = 0;
-  let sigintHandler: (() => void) | null = null;
-  let sigintHandlerRemoved = false;
-
-  return {
-    get closeCount() {
-      return closeCount;
-    },
-    payloads,
-    sigintHandlerRegistered: sigintRegistration.promise,
-    get sigintHandlerRemoved() {
-      return sigintHandlerRemoved;
-    },
-    submission,
-    triggerSigint() {
-      if (!sigintHandler) {
-        throw new Error('SIGINT handler was not registered');
-      }
-
-      sigintHandler();
-    },
-    loadHtml: () => Promise.resolve('<html><body>annotation</body></html>'),
-    startReviewServer: (_ctx, { payload }) => {
-      payloads.push(payload);
-      return {
-        port: 4312,
-        url: 'http://localhost:4312',
-        result: options.result ?? Promise.resolve(submission),
-        close: () => {
-          closeCount += 1;
-          return Promise.resolve();
-        },
-      };
-    },
-    registerSigintHandler: (handler) => {
-      sigintHandler = handler;
-      sigintHandlerRemoved = false;
-      sigintRegistration.resolve();
-      return () => {
-        sigintHandlerRemoved = true;
-        sigintHandler = null;
-      };
-    },
-  };
-}
-
-function createDeferred<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: unknown) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve;
-    reject = promiseReject;
+  it('places sourcePath in payload.metadata.sourcePath when provided', () => {
+    const { context } = createStubContext();
+    const deps = createAnnotationDependencies();
+    expect(
+      runAnnotation(
+        context,
+        { content: '# doc', contentKind: 'document', entrypoint: 'open_command', sourcePath: '/abs/doc.md' },
+        deps,
+      ),
+    ).resolves.toEqual(deps.submission);
+    expect(deps.payloads[0]?.metadata?.sourcePath).toBe('/abs/doc.md');
   });
 
-  return { promise, resolve, reject };
-}
+  it('omits sourcePath from payload.metadata when not provided', () => {
+    const { context } = createStubContext();
+    const deps = createAnnotationDependencies();
+    expect(
+      runAnnotation(context, { content: '# doc', contentKind: 'document', entrypoint: 'open_command' }, deps),
+    ).resolves.toEqual(deps.submission);
+    expect(deps.payloads[0]?.metadata?.sourcePath).toBeUndefined();
+  });
+});

--- a/packages/cli/src/annotation/runAnnotation.ts
+++ b/packages/cli/src/annotation/runAnnotation.ts
@@ -24,6 +24,7 @@ export interface RunAnnotationArgs {
   content: string;
   contentKind: ContentKind;
   entrypoint: AnnotationEntrypoint;
+  sourcePath?: string;
 }
 
 export interface AnnotationDependencies {
@@ -52,7 +53,10 @@ export async function runAnnotation(
     content: args.content,
     title: extractDocumentTitle(args.content),
     contentKind: args.contentKind,
-    metadata: { entrypoint: args.entrypoint },
+    metadata: {
+      entrypoint: args.entrypoint,
+      ...(args.sourcePath ? { sourcePath: args.sourcePath } : {}),
+    },
   };
   analytics.capture('plan_review_started', { source: args.entrypoint });
 

--- a/packages/cli/src/bundledSkills.test.ts
+++ b/packages/cli/src/bundledSkills.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'bun:test';
+import { bundledSkills } from './bundledSkills.ts';
+
+const repoRoot = join(import.meta.dirname, '..', '..', '..');
+
+describe('bundled skills', () => {
+  it('has at least one registered skill', () => {
+    expect(bundledSkills.length).toBeGreaterThan(0);
+  });
+
+  for (const { name, body } of bundledSkills) {
+    it(`embedded ${name} skill matches the Claude plugin SKILL.md`, () => {
+      const claudeSource = readFileSync(join(repoRoot, 'harnessIntegrations/claude/skills', name, 'SKILL.md'), 'utf8');
+      expect(body).toBe(claudeSource);
+    });
+  }
+});

--- a/packages/cli/src/bundledSkills.ts
+++ b/packages/cli/src/bundledSkills.ts
@@ -1,0 +1,20 @@
+// Skill assets embedded into the CLI binary at build time. The Codex installer
+// writes each entry to disk under `~/.agents/skills/planbridge-<name>/SKILL.md`;
+// the Claude side ships the same files as plugin assets at
+// `harnessIntegrations/claude/skills/<name>/SKILL.md`. A sync test
+// (`bundledSkills.test.ts`) asserts each embedded copy stays in lockstep with
+// its on-disk Claude source.
+//
+// To add a new skill: drop `harnessIntegrations/claude/skills/<name>/SKILL.md`
+// in place, then add a single line to the `bundledSkills` array below — the
+// Codex installer iterates over this registry and writes each one.
+import openSkill from '../../../harnessIntegrations/claude/skills/open/SKILL.md' with { type: 'text' };
+
+export interface BundledSkill {
+  /** Directory name under `harnessIntegrations/claude/skills/`. Becomes `planbridge-<name>` on Codex install. */
+  readonly name: string;
+  /** SKILL.md content embedded at build time. */
+  readonly body: string;
+}
+
+export const bundledSkills: readonly BundledSkill[] = [{ name: 'open', body: openSkill }];

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -22,7 +22,9 @@ describe('runCli', () => {
 
   it.each<{ argv: string[]; contains: string }>([
     { argv: ['--help'], contains: 'plan' },
+    { argv: ['--help'], contains: 'open' },
     { argv: ['plan', '--help'], contains: '[path]' },
+    { argv: ['open', '--help'], contains: '[path]' },
   ])('$argv renders help text containing "$contains"', async ({ argv, contains }) => {
     const { context, io } = createStubContext();
     const exitCode = await runCli(context, argv);
@@ -36,6 +38,16 @@ describe('runCli', () => {
   it('routes argv into the plan subcommand', async () => {
     const { context, io } = createStubContext();
     const exitCode = await runCli(context, ['plan', '--bogus']);
+    expect(exitCode).not.toBe(0);
+    expect(io.stderr.text()).toContain('--bogus');
+  });
+
+  // Open-handler behavior lives in open.test.ts. Here we only verify argv
+  // routes into the open subcommand — an unknown flag on `open` surfaces as
+  // a CommanderError with a non-zero exit.
+  it('routes argv into the open subcommand', async () => {
+    const { context, io } = createStubContext();
+    const exitCode = await runCli(context, ['open', '--bogus']);
     expect(exitCode).not.toBe(0);
     expect(io.stderr.text()).toContain('--bogus');
   });

--- a/packages/cli/src/commands/abort.ts
+++ b/packages/cli/src/commands/abort.ts
@@ -1,0 +1,18 @@
+import { CommanderError } from 'commander';
+import type { CliContext } from '#src/context.ts';
+
+/**
+ * Log and throw a CommanderError for a user-recoverable ('input') or runtime
+ * failure inside a subcommand handler.
+ */
+export function abort(ctx: CliContext, command: string, kind: 'input' | 'runtime', message: string): never {
+  const { logger } = ctx;
+  // 'input' is user-recoverable — logged at warn so Sentry's pinoIntegration
+  // (error/fatal only) doesn't forward it. 'runtime' is a genuine failure.
+  if (kind === 'input') {
+    logger.warn(message);
+  } else {
+    logger.error(message);
+  }
+  throw new CommanderError(1, `contextbridge.${command}.${kind}Error`, message);
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -4,6 +4,7 @@ import type { CliContext } from '#src/context.ts';
 import { registerHookClaude } from './hookClaude.ts';
 import { registerHookCodex } from './hookCodex.ts';
 import { registerInstall } from './install.ts';
+import { registerOpen } from './open.ts';
 import { registerPlan } from './plan.ts';
 import { registerUninstall } from './uninstall.ts';
 import { registerUpdate } from './update.ts';
@@ -22,6 +23,7 @@ export function createProgram(ctx: CliContext): Command {
     .addHelpText('after', `\nDocs: ${QUICKSTART_URL}`);
 
   registerPlan(ctx, program);
+  registerOpen(ctx, program);
   registerUpdate(ctx, program);
 
   const hookCommand = program

--- a/packages/cli/src/commands/open.test.ts
+++ b/packages/cli/src/commands/open.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
+import { annotationSubmission } from '@contextbridge/shared/testFactories';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { CommanderError } from 'commander';
+import { formatAgentResponse } from '#src/formatters/annotation/markdown.ts';
+import { DOCUMENT_TEMPLATES } from '#src/formatters/document/templates.ts';
+import {
+  createAnnotationDependencies,
+  createDeferred,
+  createStubContext,
+  readErrorLogs,
+  readWarnLogs,
+} from '#src/testHelpers/index.ts';
+import { runOpen } from './open.ts';
+
+describe('open handler', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'cb-open-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('reads content from stdin and emits the formatted submission to stdout', async () => {
+    const { context, io } = createStubContext();
+    const submission = annotationSubmission.build();
+    const deps = createAnnotationDependencies({ submission });
+    io.stdin.write('# From stdin\n');
+    io.stdin.end();
+
+    await runOpen(context, {}, deps);
+
+    expect(io.stdout.text()).toBe(formatAgentResponse(DOCUMENT_TEMPLATES, submission, deps.payloads[0]!.content));
+    expect(deps.payloads[0]?.contentKind).toBe('document');
+    expect(deps.payloads[0]?.metadata?.entrypoint).toBe('open_command');
+    expect(deps.payloads[0]?.metadata?.sourcePath).toBeUndefined();
+  });
+
+  it('reads content from a positional path and includes resolved sourcePath in metadata + stdout', async () => {
+    const file = join(tmp, 'doc.md');
+    writeFileSync(file, '# A doc\n');
+
+    const { context, io } = createStubContext();
+    const submission = annotationSubmission.build();
+    const deps = createAnnotationDependencies({ submission });
+    io.stdin.isTTY = true;
+
+    await runOpen(context, { path: file }, deps);
+
+    expect(deps.payloads[0]?.metadata?.sourcePath).toBe(resolve(file));
+    expect(io.stdout.text()).toBe(
+      formatAgentResponse(DOCUMENT_TEMPLATES, submission, deps.payloads[0]!.content, { sourcePath: resolve(file) }),
+    );
+  });
+
+  it('resolves a relative path to absolute for sourcePath', async () => {
+    const file = join(tmp, 'rel.md');
+    writeFileSync(file, '# rel\n');
+
+    const { context, io } = createStubContext();
+    const deps = createAnnotationDependencies();
+    io.stdin.isTTY = true;
+
+    await runOpen(context, { path: file }, deps);
+    expect(deps.payloads[0]?.metadata?.sourcePath).toBe(resolve(file));
+  });
+
+  it('errors cleanly when neither a path nor piped stdin is supplied', () => {
+    const { context, io, logs } = createStubContext();
+    io.stdin.isTTY = true;
+
+    expect(runOpen(context, {})).rejects.toBeInstanceOf(CommanderError);
+    expect(io.stdout.text()).toBe('');
+    expect(readWarnLogs(logs).some((r) => r.msg.includes('provide content via stdin'))).toBe(true);
+  });
+
+  it('errors cleanly when the file does not exist', () => {
+    const { context, io, logs } = createStubContext();
+    io.stdin.isTTY = true;
+
+    expect(runOpen(context, { path: join(tmp, 'missing.md') })).rejects.toBeInstanceOf(CommanderError);
+    expect(io.stdout.text()).toBe('');
+    expect(readWarnLogs(logs).some((r) => r.msg.includes('failed to read content from file'))).toBe(true);
+  });
+
+  it('errors when content is empty', () => {
+    const file = join(tmp, 'empty.md');
+    writeFileSync(file, '   \n\n');
+
+    const { context, io, logs } = createStubContext();
+    io.stdin.isTTY = true;
+
+    expect(runOpen(context, { path: file })).rejects.toBeInstanceOf(CommanderError);
+    expect(io.stdout.text()).toBe('');
+    expect(readWarnLogs(logs).some((r) => r.msg.includes('content is empty'))).toBe(true);
+  });
+
+  it('closes the server and exits cleanly (without error-level logs) when SIGINT is received', async () => {
+    const { context, io, logs } = createStubContext();
+    const deps = createAnnotationDependencies({ result: createDeferred<AnnotationSubmission>().promise });
+    io.stdin.write('# Open\n');
+    io.stdin.end();
+
+    const openPromise = runOpen(context, {}, deps);
+    await deps.sigintHandlerRegistered;
+    deps.triggerSigint();
+
+    expect(openPromise).rejects.toBeInstanceOf(CommanderError);
+    expect(io.stdout.text()).toBe('');
+    expect(deps.closed).toBe(true);
+    // Interrupt path logs at info level so pinoIntegration doesn't forward it to Sentry.
+    expect(readErrorLogs(logs)).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/open.test.ts
+++ b/packages/cli/src/commands/open.test.ts
@@ -36,10 +36,13 @@ describe('open handler', () => {
 
     await runOpen(context, {}, deps);
 
-    expect(io.stdout.text()).toBe(formatAgentResponse(DOCUMENT_TEMPLATES, submission, deps.payloads[0]!.content));
-    expect(deps.payloads[0]?.contentKind).toBe('document');
-    expect(deps.payloads[0]?.metadata?.entrypoint).toBe('open_command');
-    expect(deps.payloads[0]?.metadata?.sourcePath).toBeUndefined();
+    const [payload] = deps.payloads;
+    expect(payload).toMatchObject({
+      contentKind: 'document',
+      metadata: { entrypoint: 'open_command' },
+    });
+    expect(payload?.metadata?.sourcePath).toBeUndefined();
+    expect(io.stdout.text()).toBe(formatAgentResponse(DOCUMENT_TEMPLATES, submission, payload!.content));
   });
 
   it('reads content from a positional path and includes resolved sourcePath in metadata + stdout', async () => {
@@ -53,9 +56,10 @@ describe('open handler', () => {
 
     await runOpen(context, { path: file }, deps);
 
-    expect(deps.payloads[0]?.metadata?.sourcePath).toBe(resolve(file));
+    const [payload] = deps.payloads;
+    expect(payload).toMatchObject({ metadata: { sourcePath: resolve(file) } });
     expect(io.stdout.text()).toBe(
-      formatAgentResponse(DOCUMENT_TEMPLATES, submission, deps.payloads[0]!.content, { sourcePath: resolve(file) }),
+      formatAgentResponse(DOCUMENT_TEMPLATES, submission, payload!.content, { sourcePath: resolve(file) }),
     );
   });
 
@@ -68,7 +72,8 @@ describe('open handler', () => {
     io.stdin.isTTY = true;
 
     await runOpen(context, { path: file }, deps);
-    expect(deps.payloads[0]?.metadata?.sourcePath).toBe(resolve(file));
+    const [payload] = deps.payloads;
+    expect(payload).toMatchObject({ metadata: { sourcePath: resolve(file) } });
   });
 
   it('errors cleanly when neither a path nor piped stdin is supplied', () => {

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -1,0 +1,74 @@
+import { resolve as resolvePath } from 'node:path';
+import { getErrorMessage } from '@contextbridge/shared/errors';
+import { type Command, CommanderError } from 'commander';
+import {
+  type AnnotationDependencies,
+  AnnotationInterruptedError,
+  runAnnotation,
+} from '#src/annotation/runAnnotation.ts';
+import type { CliContext } from '#src/context.ts';
+import { formatAgentResponse } from '#src/formatters/annotation/markdown.ts';
+import { DOCUMENT_TEMPLATES } from '#src/formatters/document/templates.ts';
+import { readStreamToString } from '#src/streams.ts';
+import { abort } from './abort.ts';
+
+export interface OpenArgs {
+  path?: string;
+}
+
+export async function runOpen(ctx: CliContext, args: OpenArgs, deps?: AnnotationDependencies): Promise<void> {
+  const { io, logger } = ctx;
+  const { path: argPath } = args;
+
+  if (!argPath && io.stdin.isTTY === true) {
+    abort(
+      ctx,
+      'open',
+      'input',
+      'provide content via stdin (e.g. `cat doc.md | contextbridge open`) or a file path via [path]',
+    );
+  }
+
+  const source: 'file' | 'stdin' = argPath ? 'file' : 'stdin';
+  let content: string;
+  try {
+    content = argPath ? await Bun.file(argPath).text() : await readStreamToString(io.stdin);
+  } catch (err) {
+    abort(ctx, 'open', 'input', `failed to read content from ${source}: ${getErrorMessage(err)}`);
+  }
+
+  if (content.trim().length === 0) {
+    abort(ctx, 'open', 'input', 'content is empty');
+  }
+
+  const sourcePath = argPath ? resolvePath(argPath) : undefined;
+
+  logger.info({ source, bytes: Buffer.byteLength(content, 'utf8') }, 'open received');
+
+  try {
+    const submission = await runAnnotation(
+      ctx,
+      { content, contentKind: 'document', entrypoint: 'open_command', sourcePath },
+      deps,
+    );
+    io.stdout.write(formatAgentResponse(DOCUMENT_TEMPLATES, submission, content, { sourcePath }));
+  } catch (err) {
+    if (err instanceof AnnotationInterruptedError) {
+      logger.info('open session interrupted');
+      throw new CommanderError(130, 'contextbridge.open.sigint', 'open session interrupted');
+    }
+    abort(ctx, 'open', 'runtime', getErrorMessage(err));
+  }
+}
+
+export function registerOpen(ctx: CliContext, program: Command): void {
+  program
+    .command('open')
+    .description(
+      "Open a markdown file or piped content in the PlanBridge browser UI for human annotation. Reads from [path] or stdin, opens a local browser UI, and writes the human's feedback to stdout as markdown.",
+    )
+    .argument('[path]', 'path to a file containing the content to annotate (alternative to stdin)')
+    .action(async (path: string | undefined) => {
+      await runOpen(ctx, { path });
+    });
+}

--- a/packages/cli/src/commands/plan.test.ts
+++ b/packages/cli/src/commands/plan.test.ts
@@ -1,14 +1,20 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { AnnotationPayload, AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
+import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
 import { annotationSubmission } from '@contextbridge/shared/testFactories';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { CommanderError } from 'commander';
-import type { AnnotationDependencies } from '#src/annotation/runAnnotation.ts';
 import { formatAgentResponse } from '#src/formatters/annotation/markdown.ts';
 import { PLAN_TEMPLATES } from '#src/formatters/plan/templates.ts';
-import { createStubContext, readErrorLogs, readLogs, readWarnLogs } from '#src/testHelpers/index.ts';
+import {
+  createAnnotationDependencies,
+  createDeferred,
+  createStubContext,
+  readErrorLogs,
+  readLogs,
+  readWarnLogs,
+} from '#src/testHelpers/index.ts';
 import { runPlan } from './plan.ts';
 
 describe('plan handler', () => {
@@ -26,7 +32,7 @@ describe('plan handler', () => {
     const openedUrls: string[] = [];
     const { context, io } = createStubContext({ openUrl: (url) => (openedUrls.push(url), Promise.resolve()) });
     const expectedSubmission = annotationSubmission.build();
-    const deps = createPlanDependencies({ submission: expectedSubmission });
+    const deps = createAnnotationDependencies({ submission: expectedSubmission });
     io.stdin.write('# My plan\n\nStep 1.\n');
     io.stdin.end();
 
@@ -42,7 +48,7 @@ describe('plan handler', () => {
     writeFileSync(planPath, '# From positional path\n');
 
     const { context, io } = createStubContext();
-    const deps = createPlanDependencies();
+    const deps = createAnnotationDependencies();
     io.stdin.isTTY = true;
 
     await runPlan(context, { path: planPath }, deps);
@@ -56,7 +62,7 @@ describe('plan handler', () => {
     writeFileSync(planPath, 'from positional path');
 
     const { context, io } = createStubContext();
-    const deps = createPlanDependencies();
+    const deps = createAnnotationDependencies();
     io.stdin.write('from stdin');
     io.stdin.end();
 
@@ -95,7 +101,7 @@ describe('plan handler', () => {
 
   it('closes the server and surfaces a runtime error when the browser open fails', () => {
     const { context, io, logs } = createStubContext({ openUrl: () => Promise.reject(new Error('open failed')) });
-    const deps = createPlanDependencies();
+    const deps = createAnnotationDependencies();
     io.stdin.write('# Plan\n');
     io.stdin.end();
 
@@ -107,7 +113,7 @@ describe('plan handler', () => {
 
   it('closes the server and exits cleanly (without error-level logs) when SIGINT is received', async () => {
     const { context, io, logs } = createStubContext();
-    const deps = createPlanDependencies({ result: createDeferred<AnnotationSubmission>().promise });
+    const deps = createAnnotationDependencies({ result: createDeferred<AnnotationSubmission>().promise });
     io.stdin.write('# Plan\n');
     io.stdin.end();
 
@@ -125,7 +131,7 @@ describe('plan handler', () => {
 
   it('captures plan_review_started and plan_review_submitted analytics events', async () => {
     const { context, analytics, io } = createStubContext();
-    const deps = createPlanDependencies();
+    const deps = createAnnotationDependencies();
     io.stdin.write('# My plan\n\nStep 1.\n');
     io.stdin.end();
 
@@ -144,7 +150,7 @@ describe('plan handler', () => {
 
   it('does not report SIGINT to telemetry', async () => {
     const { context, analytics, telemetry, io } = createStubContext();
-    const deps = createPlanDependencies({ result: createDeferred<AnnotationSubmission>().promise });
+    const deps = createAnnotationDependencies({ result: createDeferred<AnnotationSubmission>().promise });
     io.stdin.write('# Plan\n');
     io.stdin.end();
 
@@ -157,73 +163,3 @@ describe('plan handler', () => {
     expect(analytics.captures.some((c) => c.event === 'plan_review_submitted')).toBe(false);
   });
 });
-
-function createPlanDependencies(
-  options: {
-    submission?: AnnotationSubmission;
-    result?: Promise<AnnotationSubmission>;
-  } = {},
-): AnnotationDependencies & {
-  payloads: AnnotationPayload[];
-  closed: boolean;
-  sigintHandlerRegistered: Promise<void>;
-  submission: AnnotationSubmission;
-  triggerSigint(): void;
-} {
-  const payloads: AnnotationPayload[] = [];
-  const submission = options.submission ?? annotationSubmission.build();
-  const sigintRegistration = createDeferred<void>();
-  let closed = false;
-  let sigintHandler: (() => void) | null = null;
-
-  return {
-    payloads,
-    sigintHandlerRegistered: sigintRegistration.promise,
-    get closed() {
-      return closed;
-    },
-    submission,
-    triggerSigint() {
-      if (!sigintHandler) {
-        throw new Error('SIGINT handler was not registered');
-      }
-
-      sigintHandler();
-    },
-    loadHtml: () => Promise.resolve('<html><body>annotation</body></html>'),
-    startReviewServer: (_ctx, { payload }) => {
-      payloads.push(payload);
-      return {
-        port: 4312,
-        url: 'http://localhost:4312',
-        result: options.result ?? Promise.resolve(submission),
-        close: () => {
-          closed = true;
-          return Promise.resolve();
-        },
-      };
-    },
-    registerSigintHandler: (handler) => {
-      sigintHandler = handler;
-      sigintRegistration.resolve();
-      return () => {
-        sigintHandler = null;
-      };
-    },
-  };
-}
-
-function createDeferred<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: unknown) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve;
-    reject = promiseReject;
-  });
-
-  return { promise, resolve, reject };
-}

--- a/packages/cli/src/commands/plan.ts
+++ b/packages/cli/src/commands/plan.ts
@@ -9,6 +9,7 @@ import type { CliContext } from '#src/context.ts';
 import { formatAgentResponse } from '#src/formatters/annotation/markdown.ts';
 import { PLAN_TEMPLATES } from '#src/formatters/plan/templates.ts';
 import { readStreamToString } from '#src/streams.ts';
+import { abort } from './abort.ts';
 
 export interface PlanArgs {
   path?: string;
@@ -21,6 +22,7 @@ export async function runPlan(ctx: CliContext, args: PlanArgs, deps?: Annotation
   if (!path && io.stdin.isTTY === true) {
     abort(
       ctx,
+      'plan',
       'input',
       'provide plan content via stdin (e.g. `cat plan.md | contextbridge plan`) or a file path via [path]',
     );
@@ -31,11 +33,11 @@ export async function runPlan(ctx: CliContext, args: PlanArgs, deps?: Annotation
   try {
     content = path ? await Bun.file(path).text() : await readStreamToString(io.stdin);
   } catch (err) {
-    abort(ctx, 'input', `failed to read plan from ${source}: ${getErrorMessage(err)}`);
+    abort(ctx, 'plan', 'input', `failed to read plan from ${source}: ${getErrorMessage(err)}`);
   }
 
   if (content.trim().length === 0) {
-    abort(ctx, 'input', 'plan content is empty');
+    abort(ctx, 'plan', 'input', 'plan content is empty');
   }
 
   logger.info({ source, bytes: Buffer.byteLength(content, 'utf8') }, 'plan received');
@@ -48,7 +50,7 @@ export async function runPlan(ctx: CliContext, args: PlanArgs, deps?: Annotation
       logger.info('plan review interrupted');
       throw new CommanderError(130, 'contextbridge.plan.sigint', 'plan review interrupted');
     }
-    abort(ctx, 'runtime', getErrorMessage(err));
+    abort(ctx, 'plan', 'runtime', getErrorMessage(err));
   }
 }
 
@@ -62,16 +64,4 @@ export function registerPlan(ctx: CliContext, program: Command): void {
     .action(async (path: string | undefined) => {
       await runPlan(ctx, { path });
     });
-}
-
-function abort(ctx: CliContext, kind: 'input' | 'runtime', message: string): never {
-  const { logger } = ctx;
-  // 'input' is user-recoverable — logged at warn so Sentry's pinoIntegration
-  // (error/fatal only) doesn't forward it. 'runtime' is a genuine failure.
-  if (kind === 'input') {
-    logger.warn(message);
-  } else {
-    logger.error(message);
-  }
-  throw new CommanderError(1, `contextbridge.plan.${kind}Error`, message);
 }

--- a/packages/cli/src/formatters/annotation/markdown.test.ts
+++ b/packages/cli/src/formatters/annotation/markdown.test.ts
@@ -271,6 +271,29 @@ describe('formatAgentResponse (annotation engine)', () => {
     expect(result).not.toMatch(/HIGHLIGHTED<.+>/);
   });
 
+  it('threads opts.sourcePath into the approved and changesRequested templates as `source`', () => {
+    const captured: Array<{ name: string; data: Record<string, unknown> }> = [];
+    const recordingTemplate =
+      (name: string): Handlebars.TemplateDelegate<Record<string, unknown>> =>
+      (data: Record<string, unknown>) => {
+        captured.push({ name, data });
+        return name;
+      };
+
+    const stubTemplates: AnnotationTemplates = {
+      approved: recordingTemplate('approved'),
+      changesRequested: recordingTemplate('changesRequested'),
+      annotationSection: recordingTemplate('annotationSection'),
+      generalFeedbackSection: recordingTemplate('generalFeedbackSection'),
+    };
+
+    formatAgentResponse(stubTemplates, { status: 'approved', threads: [] }, '# doc', { sourcePath: '/abs/doc.md' });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.name).toBe('approved');
+    expect(captured[0]?.data).toEqual({ source: '/abs/doc.md' });
+  });
+
   it('renders thread messages in chronological order regardless of input order', () => {
     const submission: AnnotationSubmission = {
       status: 'changes_requested',

--- a/packages/cli/src/formatters/annotation/markdown.ts
+++ b/packages/cli/src/formatters/annotation/markdown.ts
@@ -16,9 +16,10 @@ export function formatAgentResponse(
   templates: AnnotationTemplates,
   submission: AnnotationSubmission,
   content: string,
+  opts: { sourcePath?: string } = {},
 ): string {
   if (submission.status === 'approved') {
-    return templates.approved({});
+    return templates.approved({ source: opts.sourcePath });
   }
 
   const contentLines = content.split('\n');
@@ -45,7 +46,7 @@ export function formatAgentResponse(
   }
 
   const body = sections.map((section) => section.trimEnd()).join('\n\n');
-  return `${templates.changesRequested({ body }).trimEnd()}\n`;
+  return `${templates.changesRequested({ body, source: opts.sourcePath }).trimEnd()}\n`;
 }
 
 function renderThreadsAsBlockquotes(threads: CommentThread[]): string {

--- a/packages/cli/src/formatters/annotation/templates.ts
+++ b/packages/cli/src/formatters/annotation/templates.ts
@@ -3,8 +3,8 @@ import type Handlebars from 'handlebars';
 type HandlebarsTemplateDelegate<T> = Handlebars.TemplateDelegate<T>;
 
 export interface AnnotationTemplates {
-  approved: HandlebarsTemplateDelegate<Record<string, never>>;
-  changesRequested: HandlebarsTemplateDelegate<{ body: string }>;
+  approved: HandlebarsTemplateDelegate<{ source?: string }>;
+  changesRequested: HandlebarsTemplateDelegate<{ body: string; source?: string }>;
   annotationSection: HandlebarsTemplateDelegate<{
     range: string;
     sourceSlice: string;

--- a/packages/cli/src/formatters/document/markdown.test.ts
+++ b/packages/cli/src/formatters/document/markdown.test.ts
@@ -5,7 +5,12 @@ import { formatAgentResponse } from '#src/formatters/annotation/markdown.ts';
 import { DOCUMENT_TEMPLATES } from './templates.ts';
 
 describe('formatAgentResponse with DOCUMENT_TEMPLATES', () => {
-  const content = '# Heading\n\nSome paragraph.\n\nAnother paragraph.\n';
+  const content = `# Heading
+
+Some paragraph.
+
+Another paragraph.
+`;
 
   it('renders approved with no annotations and no sourcePath', () => {
     const submission: AnnotationSubmission = { status: 'approved', threads: [] };

--- a/packages/cli/src/formatters/document/markdown.test.ts
+++ b/packages/cli/src/formatters/document/markdown.test.ts
@@ -1,0 +1,114 @@
+import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
+import { annotationAnchor, annotationThread, commentMessage, globalThread } from '@contextbridge/shared/testFactories';
+import { describe, expect, it } from 'bun:test';
+import { formatAgentResponse } from '#src/formatters/annotation/markdown.ts';
+import { DOCUMENT_TEMPLATES } from './templates.ts';
+
+describe('formatAgentResponse with DOCUMENT_TEMPLATES', () => {
+  const content = '# Heading\n\nSome paragraph.\n\nAnother paragraph.\n';
+
+  it('renders approved with no annotations and no sourcePath', () => {
+    const submission: AnnotationSubmission = { status: 'approved', threads: [] };
+    const output = formatAgentResponse(DOCUMENT_TEMPLATES, submission, content);
+    expect(output).toContain('# Review submitted');
+    expect(output).toContain('the content');
+    expect(output).toContain('no annotations');
+    expect(output).not.toContain('`'); // No backticked path
+  });
+
+  it('renders approved with sourcePath', () => {
+    const submission: AnnotationSubmission = { status: 'approved', threads: [] };
+    const output = formatAgentResponse(DOCUMENT_TEMPLATES, submission, content, { sourcePath: '/abs/doc.md' });
+    expect(output).toContain('`/abs/doc.md`');
+    expect(output).toContain('no annotations');
+  });
+
+  it('renders changes_requested with a general feedback thread', () => {
+    const submission: AnnotationSubmission = {
+      status: 'changes_requested',
+      threads: [globalThread.build({ messages: [commentMessage.build({ body: 'Please clarify section 2.' })] })],
+    };
+    const output = formatAgentResponse(DOCUMENT_TEMPLATES, submission, content);
+    expect(output).toContain('# Review submitted');
+    expect(output).toContain('the following comments');
+    expect(output).toContain('## General feedback');
+    expect(output).toContain('Please clarify section 2.');
+  });
+
+  it('renders changes_requested with an annotation thread (single line)', () => {
+    const submission: AnnotationSubmission = {
+      status: 'changes_requested',
+      threads: [
+        annotationThread.build({
+          subject: {
+            kind: 'annotation',
+            anchor: annotationAnchor.build({
+              sourceLines: { start: 1, end: 1 },
+              quote: { exact: 'Heading', prefix: '# ', suffix: '\n' },
+            }),
+          },
+          messages: [commentMessage.build({ body: 'Title is too generic.' })],
+        }),
+      ],
+    };
+    const output = formatAgentResponse(DOCUMENT_TEMPLATES, submission, content);
+    expect(output).toContain('## Comment (line 1)');
+    expect(output).toContain('Within that section, the reviewer specifically highlighted: `Heading`');
+    expect(output).toContain('Title is too generic.');
+  });
+
+  it('renders changes_requested with a multi-line annotation (no highlight)', () => {
+    const submission: AnnotationSubmission = {
+      status: 'changes_requested',
+      threads: [
+        annotationThread.build({
+          subject: {
+            kind: 'annotation',
+            anchor: annotationAnchor.build({
+              sourceLines: { start: 3, end: 5 },
+              quote: { exact: 'Some paragraph.\n\nAnother paragraph.', prefix: '\n', suffix: '\n' },
+            }),
+          },
+          messages: [commentMessage.build({ body: 'Tighten these two paragraphs.' })],
+        }),
+      ],
+    };
+    const output = formatAgentResponse(DOCUMENT_TEMPLATES, submission, content);
+    expect(output).toContain('## Comment (lines 3–5)');
+    expect(output).not.toContain('specifically highlighted'); // multi-line skips the inline-code call-out
+    expect(output).toContain('Tighten these two paragraphs.');
+  });
+
+  it('renders changes_requested with both general feedback and annotations', () => {
+    const submission: AnnotationSubmission = {
+      status: 'changes_requested',
+      threads: [
+        globalThread.build({ messages: [commentMessage.build({ body: 'Overall tone is off.' })] }),
+        annotationThread.build({
+          subject: {
+            kind: 'annotation',
+            anchor: annotationAnchor.build({
+              sourceLines: { start: 1, end: 1 },
+              quote: { exact: 'Heading', prefix: '# ', suffix: '\n' },
+            }),
+          },
+          messages: [commentMessage.build({ body: 'Rewrite this line.' })],
+        }),
+      ],
+    };
+    const output = formatAgentResponse(DOCUMENT_TEMPLATES, submission, content);
+    expect(output).toContain('## General feedback');
+    expect(output).toContain('Overall tone is off.');
+    expect(output).toContain('## Comment (line 1)');
+    expect(output).toContain('Rewrite this line.');
+  });
+
+  it('renders changes_requested with sourcePath in the header', () => {
+    const submission: AnnotationSubmission = {
+      status: 'changes_requested',
+      threads: [globalThread.build({ messages: [commentMessage.build({ body: 'A note.' })] })],
+    };
+    const output = formatAgentResponse(DOCUMENT_TEMPLATES, submission, content, { sourcePath: '/abs/draft.md' });
+    expect(output).toContain('`/abs/draft.md`');
+  });
+});

--- a/packages/cli/src/formatters/document/templates.ts
+++ b/packages/cli/src/formatters/document/templates.ts
@@ -1,0 +1,13 @@
+import Handlebars from 'handlebars';
+import type { AnnotationTemplates } from '#src/formatters/annotation/templates.ts';
+import annotationSectionSource from './templates/annotationSection.hbs' with { type: 'text' };
+import approvedSource from './templates/approved.hbs' with { type: 'text' };
+import changesRequestedSource from './templates/changesRequested.hbs' with { type: 'text' };
+import generalFeedbackSectionSource from './templates/generalFeedbackSection.hbs' with { type: 'text' };
+
+export const DOCUMENT_TEMPLATES: AnnotationTemplates = {
+  approved: Handlebars.compile(approvedSource, { noEscape: true }),
+  changesRequested: Handlebars.compile(changesRequestedSource, { noEscape: true }),
+  annotationSection: Handlebars.compile(annotationSectionSource, { noEscape: true }),
+  generalFeedbackSection: Handlebars.compile(generalFeedbackSectionSource, { noEscape: true }),
+};

--- a/packages/cli/src/formatters/document/templates/annotationSection.hbs
+++ b/packages/cli/src/formatters/document/templates/annotationSection.hbs
@@ -1,0 +1,13 @@
+## Comment ({{range}})
+
+This comment applies to the following section:
+
+````md
+{{{sourceSlice}}}
+````
+{{#if highlighted}}
+
+Within that section, the reviewer specifically highlighted: {{{highlighted}}}
+{{/if}}
+
+{{{comments}}}

--- a/packages/cli/src/formatters/document/templates/approved.hbs
+++ b/packages/cli/src/formatters/document/templates/approved.hbs
@@ -1,0 +1,3 @@
+# Review submitted
+
+The human reviewed {{#if source}}`{{source}}`{{else}}the content{{/if}} and left no annotations.

--- a/packages/cli/src/formatters/document/templates/changesRequested.hbs
+++ b/packages/cli/src/formatters/document/templates/changesRequested.hbs
@@ -1,0 +1,5 @@
+# Review submitted
+
+The human reviewed {{#if source}}`{{source}}`{{else}}the content{{/if}} and left the following comments. Read the comments and respond to the human conversationally — they may want edits, may want discussion, may be flagging things for later. Do not assume edits are required unless the human's comments make that clear.
+
+{{{body}}}

--- a/packages/cli/src/formatters/document/templates/generalFeedbackSection.hbs
+++ b/packages/cli/src/formatters/document/templates/generalFeedbackSection.hbs
@@ -1,0 +1,3 @@
+## General feedback
+
+{{{comments}}}

--- a/packages/cli/src/harnesses/CodexInstaller.test.ts
+++ b/packages/cli/src/harnesses/CodexInstaller.test.ts
@@ -1,14 +1,17 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { CommanderError } from 'commander';
+import { bundledSkills } from '#src/bundledSkills.ts';
 import { environment } from '#src/testFactories.ts';
 import { createStubContext, readErrorLogs, readWarnLogs } from '#src/testHelpers/index.ts';
 import { CodexInstaller } from './CodexInstaller.ts';
 import { getDescriptor } from './registry.ts';
 
 const CODEX_BINARY = getDescriptor('codex').binaryName;
+const bundledOpenSkill = bundledSkills.find((skill) => skill.name === 'open')?.body ?? '';
 
 describe('CodexInstaller', () => {
   let tmp: string;
@@ -169,6 +172,37 @@ describe('CodexInstaller', () => {
         ),
       ).toBe(true);
     });
+
+    it('writes the skill to ~/.agents/skills/planbridge-open/SKILL.md on user-scope install', async () => {
+      const { installer, context } = createCodexInstallerContext(tmp);
+
+      await installer.install(context, { yes: true });
+
+      const skillPath = join(tmp, '.agents', 'skills', 'planbridge-open', 'SKILL.md');
+      expect(existsSync(skillPath)).toBe(true);
+      expect(readFileSync(skillPath, 'utf8')).toBe(bundledOpenSkill);
+    });
+
+    it('writes the skill at user level even on project-scope install', async () => {
+      const project = join(tmp, 'project');
+      const { installer, context } = createCodexInstallerContext(tmp, { projectRoot: project });
+
+      await installer.install(context, { yes: true, scope: 'project' });
+
+      const skillPath = join(tmp, '.agents', 'skills', 'planbridge-open', 'SKILL.md');
+      expect(existsSync(skillPath)).toBe(true);
+      expect(readFileSync(skillPath, 'utf8')).toBe(bundledOpenSkill);
+    });
+
+    it('skill install is idempotent', async () => {
+      const { installer, context } = createCodexInstallerContext(tmp);
+
+      await installer.install(context, { yes: true });
+      await installer.install(context, { yes: true });
+
+      const skillPath = join(tmp, '.agents', 'skills', 'planbridge-open', 'SKILL.md');
+      expect(readFileSync(skillPath, 'utf8')).toBe(bundledOpenSkill);
+    });
   });
 
   describe('uninstall', () => {
@@ -208,6 +242,36 @@ describe('CodexInstaller', () => {
       expect(installer.uninstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
       expect(readFileSync(hooksPath, 'utf8')).toBe('{"hooks":[]}');
     });
+
+    it('user-scope uninstall removes planbridge-open/ but leaves sibling skill dirs intact', async () => {
+      const skillsDir = join(tmp, '.agents', 'skills');
+      await mkdir(join(skillsDir, 'some-other-tool'), { recursive: true });
+      await writeFile(join(skillsDir, 'some-other-tool', 'SKILL.md'), 'other tool skill');
+      const { installer, context } = createCodexInstallerContext(tmp);
+      await installer.install(context, { yes: true });
+
+      await installer.uninstall(context, { yes: true });
+
+      expect(existsSync(join(skillsDir, 'planbridge-open'))).toBe(false);
+      expect(readFileSync(join(skillsDir, 'some-other-tool', 'SKILL.md'), 'utf8')).toBe('other tool skill');
+    });
+
+    it('project-scope uninstall does not remove the skill', async () => {
+      const project = join(tmp, 'project');
+      const { installer, context } = createCodexInstallerContext(tmp, { projectRoot: project });
+      await installer.install(context, { yes: true, scope: 'project' });
+
+      await installer.uninstall(context, { yes: true, scope: 'project' });
+
+      const skillPath = join(tmp, '.agents', 'skills', 'planbridge-open', 'SKILL.md');
+      expect(existsSync(skillPath)).toBe(true);
+    });
+
+    it('user-scope uninstall is idempotent when skill is already gone', async () => {
+      const { installer, context } = createCodexInstallerContext(tmp);
+
+      await installer.uninstall(context, { yes: true });
+    });
   });
 
   describe('status', () => {
@@ -225,7 +289,7 @@ describe('CodexInstaller', () => {
       });
     });
 
-    it('reports an installed hook when hooks.json is present and Codex is supported', async () => {
+    it('reports an installed hook and skill when both are present', async () => {
       const { installer, context } = createCodexInstallerContext(tmp);
       await installer.install(context, { yes: true });
 
@@ -234,7 +298,10 @@ describe('CodexInstaller', () => {
         descriptor: { id: 'codex' },
         detected: true,
         installed: true,
-        managed: [{ kind: 'hook', identifier: 'contextbridge hook codex', scope: 'user' }],
+        managed: [
+          { kind: 'hook', identifier: 'contextbridge hook codex', scope: 'user' },
+          { kind: 'skill', identifier: 'planbridge-open', scope: 'user' },
+        ],
       });
     });
 
@@ -285,6 +352,24 @@ describe('CodexInstaller', () => {
       const { installer, context } = createCodexInstallerContext(tmp, {}, { versionStdout: 'codex-cli 0.128.0\n' });
 
       expect(installer.status(context)).rejects.toBeInstanceOf(CommanderError);
+    });
+
+    it('reports the skill as a ManagedEntry when installed', async () => {
+      const { installer, context } = createCodexInstallerContext(tmp);
+      await installer.install(context, { yes: true });
+
+      const status = await installer.status(context);
+
+      expect(status.managed).toContainEqual({ kind: 'skill', identifier: 'planbridge-open', scope: 'user' });
+      expect(status.installed).toBe(true);
+    });
+
+    it('does not report the skill when not installed', async () => {
+      const { installer, context } = createCodexInstallerContext(tmp);
+
+      const status = await installer.status(context);
+
+      expect(status.managed.some((m) => m.kind === 'skill')).toBe(false);
     });
   });
 });

--- a/packages/cli/src/harnesses/CodexInstaller.ts
+++ b/packages/cli/src/harnesses/CodexInstaller.ts
@@ -1,10 +1,11 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { getErrorMessage, hasErrorCode } from '@contextbridge/shared/errors';
 import { safeJsonParse } from '@contextbridge/shared/json';
 import { isRecord } from '@contextbridge/shared/typeGuards';
 import { CommanderError } from 'commander';
 import semver from 'semver';
+import { type BundledSkill, bundledSkills } from '#src/bundledSkills.ts';
 import type { CliContext } from '#src/context.ts';
 import { detectHarness } from './detect.ts';
 import { type HarnessStatus, type ManagedEntry } from './HarnessInstaller.ts';
@@ -19,6 +20,8 @@ const CODEX_HOOK_STATUS_MESSAGE = 'Opening PlanBridge';
 const MINIMUM_CODEX_VERSION = '0.129.0';
 
 const STOP_HOOK_KEY = 'Stop';
+const SKILL_ID_PREFIX = 'planbridge-';
+const AGENTS_SKILLS_DIR = '.agents/skills';
 
 const PLANBRIDGE_STOP_HOOK = {
   type: 'command',
@@ -52,6 +55,13 @@ export class CodexInstaller extends ScopedHarnessInstaller {
       installed = installed || hookInstalled;
     }
 
+    for (const skill of bundledSkills) {
+      if (await isSkillInstalled(ctx, skill)) {
+        managed.push({ kind: 'skill', identifier: skillId(skill.name), scope: 'user' });
+        installed = true;
+      }
+    }
+
     return { descriptor: this.descriptor, detected: true, installed, managed };
   }
 
@@ -67,6 +77,9 @@ export class CodexInstaller extends ScopedHarnessInstaller {
     const nextHooks = upsertPlanBridgeHookJson(hooksSource);
     await writeFile(hooksPath, nextHooks);
     await enableCodexHookFeatureFlags(ctx, this.descriptor.binaryName);
+    for (const skill of bundledSkills) {
+      await writeSkill(ctx, skill);
+    }
 
     io.stderr.write(`✓ PlanBridge hook installed for Codex CLI (scope: ${scope}).\n`);
     io.stderr.write(`Action required: PlanBridge will not run in Codex until this hook is trusted.\n`);
@@ -74,6 +87,10 @@ export class CodexInstaller extends ScopedHarnessInstaller {
       `Restart Codex CLI, open /hooks, verify the Stop hook runs \`${CODEX_HOOK_COMMAND}\`, and press t.\n`,
     );
     io.stderr.write(`Walkthrough: https://plan.contextbridge.ai/usage/codex/#trust-the-codex-hook\n`);
+    for (const { name } of bundledSkills) {
+      io.stderr.write(`✓ PlanBridge skill installed at ~/${AGENTS_SKILLS_DIR}/${skillId(name)}/SKILL.md.\n`);
+      io.stderr.write(`Invoke in Codex as $${skillId(name)}.\n`);
+    }
   }
 
   protected async runUninstall(ctx: CliContext, scope: InstallScope): Promise<void> {
@@ -85,6 +102,13 @@ export class CodexInstaller extends ScopedHarnessInstaller {
     }
 
     io.stderr.write(`✓ PlanBridge hook removed from Codex CLI (scope: ${scope}).\n`);
+
+    if (scope === 'user') {
+      for (const { name } of bundledSkills) {
+        await removeSkill(ctx, name);
+        io.stderr.write(`✓ PlanBridge skill removed from ~/${AGENTS_SKILLS_DIR}/${skillId(name)}/.\n`);
+      }
+    }
   }
 }
 
@@ -367,4 +391,41 @@ function parseCodexVersion(source: string): string | null {
     }
   }
   return null;
+}
+
+function skillId(name: string): string {
+  return `${SKILL_ID_PREFIX}${name}`;
+}
+
+function getAgentsSkillsDir(ctx: CliContext): string {
+  return join(ctx.env.HOME ?? '', AGENTS_SKILLS_DIR);
+}
+
+function getSkillDir(ctx: CliContext, name: string): string {
+  return join(getAgentsSkillsDir(ctx), skillId(name));
+}
+
+function getSkillPath(ctx: CliContext, name: string): string {
+  return join(getSkillDir(ctx, name), 'SKILL.md');
+}
+
+async function isSkillInstalled(ctx: CliContext, { name, body }: BundledSkill): Promise<boolean> {
+  const skillPath = getSkillPath(ctx, name);
+  try {
+    const existing = await readFile(skillPath, 'utf8');
+    return existing === body;
+  } catch (err) {
+    if (hasErrorCode(err, 'ENOENT')) return false;
+    throw err;
+  }
+}
+
+async function writeSkill(ctx: CliContext, { name, body }: BundledSkill): Promise<void> {
+  const skillPath = getSkillPath(ctx, name);
+  await mkdir(dirname(skillPath), { recursive: true });
+  await writeFile(skillPath, body);
+}
+
+async function removeSkill(ctx: CliContext, name: string): Promise<void> {
+  await rm(getSkillDir(ctx, name), { recursive: true, force: true });
 }

--- a/packages/cli/src/testHelpers/annotationFakes.ts
+++ b/packages/cli/src/testHelpers/annotationFakes.ts
@@ -1,16 +1,84 @@
-import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
+import type { AnnotationPayload, AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
+import { annotationSubmission } from '@contextbridge/shared/testFactories';
 import type { AnnotationDependencies } from '#src/annotation/runAnnotation.ts';
+import { createDeferred } from './createDeferred.ts';
 
-export function createAnnotationDependencies(options: { submission: AnnotationSubmission }): AnnotationDependencies {
-  const { submission } = options;
+export interface TrackedAnnotationDependencies extends AnnotationDependencies {
+  /** Payloads passed to startReviewServer in invocation order. */
+  payloads: AnnotationPayload[];
+  /** Submission the fake server resolves with (unless `result` overrides it). */
+  submission: AnnotationSubmission;
+  /** Number of times the server's close() has been invoked. */
+  closeCount: number;
+  /** Convenience: true iff closeCount > 0. */
+  closed: boolean;
+  /** Resolves when registerSigintHandler has been called at least once. */
+  sigintHandlerRegistered: Promise<void>;
+  /** Set when the un-register function returned by registerSigintHandler is invoked. */
+  sigintHandlerRemoved: boolean;
+  /** Fires the most-recently-registered SIGINT handler. Throws if none registered. */
+  triggerSigint(): void;
+}
+
+/**
+ * Tracked `AnnotationDependencies` stub for handler tests. Captures payloads,
+ * close counts, and SIGINT lifecycle so tests can assert on the orchestration
+ * boundary without spinning up a real browser session.
+ */
+export function createAnnotationDependencies(
+  options: {
+    submission?: AnnotationSubmission;
+    result?: Promise<AnnotationSubmission>;
+  } = {},
+): TrackedAnnotationDependencies {
+  const payloads: AnnotationPayload[] = [];
+  const submission = options.submission ?? annotationSubmission.build();
+  const sigintRegistration = createDeferred<void>();
+  let closeCount = 0;
+  let sigintHandler: (() => void) | null = null;
+  let sigintHandlerRemoved = false;
+
   return {
+    payloads,
+    submission,
+    sigintHandlerRegistered: sigintRegistration.promise,
+    get closeCount() {
+      return closeCount;
+    },
+    get closed() {
+      return closeCount > 0;
+    },
+    get sigintHandlerRemoved() {
+      return sigintHandlerRemoved;
+    },
+    triggerSigint() {
+      if (!sigintHandler) {
+        throw new Error('SIGINT handler was not registered');
+      }
+
+      sigintHandler();
+    },
     loadHtml: () => Promise.resolve('<html><body>annotation</body></html>'),
-    startReviewServer: () => ({
-      port: 4312,
-      url: 'http://localhost:4312',
-      result: Promise.resolve(submission),
-      close: () => Promise.resolve(),
-    }),
-    registerSigintHandler: () => () => {},
+    startReviewServer: (_ctx, { payload }) => {
+      payloads.push(payload);
+      return {
+        port: 4312,
+        url: 'http://localhost:4312',
+        result: options.result ?? Promise.resolve(submission),
+        close: () => {
+          closeCount += 1;
+          return Promise.resolve();
+        },
+      };
+    },
+    registerSigintHandler: (handler) => {
+      sigintHandler = handler;
+      sigintHandlerRemoved = false;
+      sigintRegistration.resolve();
+      return () => {
+        sigintHandlerRemoved = true;
+        sigintHandler = null;
+      };
+    },
   };
 }

--- a/packages/cli/src/testHelpers/createDeferred.ts
+++ b/packages/cli/src/testHelpers/createDeferred.ts
@@ -1,0 +1,16 @@
+export interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+export function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}

--- a/packages/cli/src/testHelpers/index.ts
+++ b/packages/cli/src/testHelpers/index.ts
@@ -14,5 +14,6 @@ export { FakeUpdater } from './FakeUpdater.ts';
 export { MemoryStream } from './MemoryStream.ts';
 export { type TestContext, createStubContext } from './createStubContext.ts';
 export { parseStdoutJson } from './parseStdoutJson.ts';
-export { createAnnotationDependencies } from './annotationFakes.ts';
+export { createAnnotationDependencies, type TrackedAnnotationDependencies } from './annotationFakes.ts';
+export { createDeferred, type Deferred } from './createDeferred.ts';
 export { type LogRecord, readErrorLogs, readLogs, readWarnLogs } from './readLogs.ts';

--- a/packages/cli/src/types/md.d.ts
+++ b/packages/cli/src/types/md.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md' {
+  const content: string;
+  export default content;
+}

--- a/packages/shared/src/annotationSchema.test.ts
+++ b/packages/shared/src/annotationSchema.test.ts
@@ -122,17 +122,68 @@ describe('AnnotationPayloadSchema', () => {
   });
 
   it('rejects an unknown contentKind', () => {
-    expect(() => AnnotationPayloadSchema.parse({ content: 'x', contentKind: 'document' })).toThrow();
+    expect(() => AnnotationPayloadSchema.parse({ content: 'x', contentKind: 'file' })).toThrow();
   });
 
   it('rejects a missing contentKind', () => {
     expect(() => AnnotationPayloadSchema.parse({ content: 'x' })).toThrow();
   });
+
+  it('accepts contentKind: document', () => {
+    const parsed = AnnotationPayloadSchema.parse({ content: '# doc', contentKind: 'document' });
+    expect(parsed.contentKind).toBe('document');
+  });
+
+  it('accepts open_command entrypoint metadata', () => {
+    const parsed = AnnotationPayloadSchema.parse({
+      content: '# doc',
+      contentKind: 'document',
+      metadata: { entrypoint: 'open_command' },
+    });
+    expect(parsed.metadata?.entrypoint).toBe('open_command');
+  });
+
+  it('accepts metadata.sourcePath', () => {
+    const parsed = AnnotationPayloadSchema.parse({
+      content: '# doc',
+      contentKind: 'document',
+      metadata: { entrypoint: 'open_command', sourcePath: '/abs/path/to/doc.md' },
+    });
+    expect(parsed.metadata?.sourcePath).toBe('/abs/path/to/doc.md');
+  });
+
+  it('rejects an empty sourcePath', () => {
+    expect(() =>
+      AnnotationPayloadSchema.parse({
+        content: '# doc',
+        contentKind: 'document',
+        metadata: { entrypoint: 'open_command', sourcePath: '' },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a whitespace-only sourcePath', () => {
+    expect(() =>
+      AnnotationPayloadSchema.parse({
+        content: '# doc',
+        contentKind: 'document',
+        metadata: { entrypoint: 'open_command', sourcePath: '   ' },
+      }),
+    ).toThrow();
+  });
 });
 
 describe('ContentKindSchema', () => {
-  it("accepts 'plan'", () => {
+  it('parses plan', () => {
     expect(ContentKindSchema.parse('plan')).toBe('plan');
+  });
+
+  it('parses document', () => {
+    expect(ContentKindSchema.parse('document')).toBe('document');
+  });
+
+  it('rejects unknown kinds', () => {
+    expect(() => ContentKindSchema.parse('file')).toThrow();
   });
 });
 

--- a/packages/shared/src/annotationSchema.ts
+++ b/packages/shared/src/annotationSchema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { instantFromString } from './time.ts';
 
-export const ContentKindSchema = z.enum(['plan']);
+export const ContentKindSchema = z.enum(['plan', 'document']);
 export type ContentKind = z.infer<typeof ContentKindSchema>;
 
 export const AnnotationStatusSchema = z.enum(['approved', 'changes_requested']);
@@ -130,7 +130,7 @@ export const AnnotationSubmissionSchema = z.object({
 });
 export type AnnotationSubmission = z.infer<typeof AnnotationSubmissionSchema>;
 
-export const AnnotationEntrypointSchema = z.enum(['plan_command', 'hook_claude', 'hook_codex']);
+export const AnnotationEntrypointSchema = z.enum(['plan_command', 'hook_claude', 'hook_codex', 'open_command']);
 export type AnnotationEntrypoint = z.infer<typeof AnnotationEntrypointSchema>;
 
 export const AnnotationPayloadSchema = z.object({
@@ -144,6 +144,7 @@ export const AnnotationPayloadSchema = z.object({
   metadata: z
     .object({
       entrypoint: AnnotationEntrypointSchema,
+      sourcePath: z.string().trim().nonempty().optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
## Summary

Adds a new `contextbridge open` CLI subcommand and a `planbridge-open` skill that opens an arbitrary markdown file (or piped content) in the PlanBridge browser UI for human annotation. The skill ships to Claude via the existing plugin and to Codex via a small registry-driven installer — adding a future Claude skill is now a one-line registration; the Codex side picks it up automatically. The user invokes the skill, the LLM resolves the path, calls the CLI, and surfaces the human's annotations on stdout as markdown for the LLM to act on conversationally. Closes #51.

## Review focus

- **Engine boundary extension** — schema gains `'document'` ContentKind, `'open_command'` entrypoint, and optional `metadata.sourcePath`. `runAnnotation` and `formatAgentResponse` thread `sourcePath` through; payload metadata also drives the frontend page title (basename of the source path when present). The plan flow is byte-identical to before — PLAN_TEMPLATES callers don't pass `sourcePath` and the plan `.hbs` files never reference `{{source}}`.
- **Shared `abort` helper** — the per-command `abort()` in `plan.ts` and `open.ts` was byte-for-byte identical; extracted to `packages/cli/src/commands/abort.ts`. `hookClaude.ts` and `hookCodex.ts` have a different abort contract (always log at error level) and were intentionally NOT consolidated.
- **Shared test helpers** — `createDeferred<T>` and the rich tracked `createAnnotationDependencies` stub were duplicated across `runAnnotation.test.ts`, `plan.test.ts`, and `open.test.ts`. Both are now exported from `testHelpers/`. The hook tests' existing `createAnnotationDependencies({ submission })` calls continue to work — the richer return type is assignable to the bare `AnnotationDependencies` interface.
- **Skill registry & Codex auto-distribution** — `packages/cli/src/bundledSkills.ts` exports a `bundledSkills` array of `{ name, body }` entries; the Claude SKILL.md is the single source of truth, with the embedded copy validated by a per-skill sync test. CodexInstaller iterates over this registry for install / uninstall / status, so adding a new Claude skill requires zero installer changes (just create the SKILL.md and add one line to the registry). A `.claude/rules/claude-plugin-skills.md` rule (auto-loaded when editing `SKILL.md` or `bundledSkills.ts`) documents the workflow.
- **Codex install layout** — skills go to `~/.agents/skills/planbridge-<name>/SKILL.md` (cross-harness convention also used by crit/OpenCode/Pi/etc.). Skills are always installed at user level regardless of hook scope. User-scope uninstall removes only `planbridge-<name>/`; project-scope uninstall leaves them alone. The installer touches only its own subdirectories under the shared `.agents/skills/` tree.
- **UI generalization** — visible strings became neutral (`Loading…`, `Approved.`, `Review — PlanBridge`); internals (CSS classes, React state, analytics events) intentionally unchanged to avoid PostHog dashboard churn. Chromatic baselines need re-approval for the string changes.
- **Codex plugin marketplace distribution** is intentionally deferred — `plugin_hooks` is `Stage::UnderDevelopment` in Codex, so adopting plugins only for skills would split the install model. Tracked in #55.

## Commits

- [`ca6e2ce`](https://github.com/contextbridge/planbridge/commit/ca6e2ce) — feat(cli): extend annotation engine for 'document' contentKind with sourcePath plumbing (includes shared test helpers)
- [`7906a78`](https://github.com/contextbridge/planbridge/commit/7906a78) — feat(cli): add 'contextbridge open' subcommand (includes shared abort helper and the plan/open test refactor to shared helpers)
- [`a946e5a`](https://github.com/contextbridge/planbridge/commit/a946e5a) — feat(annotation): generalize UI copy and surface sourcePath-aware title
- [`b939586`](https://github.com/contextbridge/planbridge/commit/b939586) — feat(harness): ship Claude-plugin skills via Codex installer (registry + auto-loaded rule for the skill-addition workflow)
- [`2a19fd5`](https://github.com/contextbridge/planbridge/commit/2a19fd5) — docs(cli): note 'contextbridge open' as a sibling entrypoint