### PR TITLE
feat: replace Copy command with Update Now button

### DIFF
--- a/packages/annotation/.storybook/appContextDecorator.tsx
+++ b/packages/annotation/.storybook/appContextDecorator.tsx
@@ -16,6 +16,7 @@ export function createStoryAppContext(overrides?: Partial<AnnotationAppContextVa
     }),
     fetchPayload: () => Promise.resolve({ content: '', contentKind: 'plan' }),
     fetchUpdateNotice: () => Promise.resolve(null),
+    triggerUpdate: () => Promise.resolve({ status: 'success' }),
     submitAnnotation: () => Promise.resolve(),
     autoCloseDelaySeconds: 3,
     ...overrides,

--- a/packages/annotation/src/App.tsx
+++ b/packages/annotation/src/App.tsx
@@ -40,7 +40,7 @@ export interface AppProps {
 }
 
 export function App({ initialPayload, initialThreads, initialGlobalComment }: AppProps = {}) {
-  const { fetchPayload, fetchUpdateNotice, analytics, buildInfo } = useAnnotationAppContext();
+  const { fetchPayload, fetchUpdateNotice, triggerUpdate, analytics, buildInfo } = useAnnotationAppContext();
   const [payload, setPayload] = useState<AnnotationPayload | null>(initialPayload ?? null);
   const [updateNotice, setUpdateNotice] = useState<UpdateNotice | null>(null);
   const [updateNoticeDismissed, setUpdateNoticeDismissed] = useState(false);
@@ -178,7 +178,11 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
           </div>
 
           {updateNotice && !updateNoticeDismissed ? (
-            <UpdateNoticeCard notice={updateNotice} onDismiss={() => setUpdateNoticeDismissed(true)} />
+            <UpdateNoticeCard
+              notice={updateNotice}
+              onDismiss={() => setUpdateNoticeDismissed(true)}
+              onUpdate={triggerUpdate}
+            />
           ) : null}
         </main>
       )}

--- a/packages/annotation/src/UpdateNoticeCard.stories.tsx
+++ b/packages/annotation/src/UpdateNoticeCard.stories.tsx
@@ -1,0 +1,78 @@
+import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
+import type { UpdateOutcome } from '@contextbridge/shared/updateOutcomeSchema';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { withAppContext } from '../.storybook/appContextDecorator.tsx';
+import { UpdateNoticeCard } from './UpdateNoticeCard.tsx';
+
+const NOTICE: UpdateNotice = {
+  currentVersion: '0.1.0',
+  latestVersion: '0.2.0',
+  channel: 'stable',
+};
+
+const meta: Meta<typeof UpdateNoticeCard> = {
+  title: 'Plan/UpdateNoticeCard',
+  component: UpdateNoticeCard,
+  parameters: { layout: 'padded' },
+  decorators: [withAppContext()],
+  args: {
+    notice: NOTICE,
+    onDismiss: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Idle: Story = {
+  args: {
+    onUpdate: () => Promise.resolve({ status: 'success' } satisfies UpdateOutcome),
+  },
+};
+
+export const Updating: Story = {
+  args: {
+    // Hangs forever so the spinner stays visible in the inspector.
+    onUpdate: () => new Promise<UpdateOutcome>(() => {}),
+  },
+  play: async ({ canvasElement }) => {
+    const button = canvasElement.querySelector<HTMLButtonElement>(
+      '[data-testid="update-notice-card-update"]',
+    );
+    button?.click();
+  },
+};
+
+export const FailedRecoverable: Story = {
+  args: {
+    onUpdate: () =>
+      Promise.resolve({
+        status: 'failed',
+        message: 'Installer failed: brew upgrade exited with code 1.',
+        recoverable: true,
+      } satisfies UpdateOutcome),
+  },
+  play: async ({ canvasElement }) => {
+    const button = canvasElement.querySelector<HTMLButtonElement>(
+      '[data-testid="update-notice-card-update"]',
+    );
+    button?.click();
+  },
+};
+
+export const FailedUnrecoverable: Story = {
+  args: {
+    onUpdate: () =>
+      Promise.resolve({
+        status: 'failed',
+        message: 'Updates are disabled for dev builds.',
+        recoverable: false,
+      } satisfies UpdateOutcome),
+  },
+  play: async ({ canvasElement }) => {
+    const button = canvasElement.querySelector<HTMLButtonElement>(
+      '[data-testid="update-notice-card-update"]',
+    );
+    button?.click();
+  },
+};

--- a/packages/annotation/src/UpdateNoticeCard.test.tsx
+++ b/packages/annotation/src/UpdateNoticeCard.test.tsx
@@ -1,5 +1,6 @@
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
-import { cleanup, render, screen } from '@testing-library/react';
+import type { UpdateOutcome } from '@contextbridge/shared/updateOutcomeSchema';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createFakeAppContext } from './testHelpers/createFakeAppContext.ts';
@@ -12,14 +13,22 @@ const NOTICE: UpdateNotice = {
   channel: 'stable',
 };
 
-function renderCard(notice: UpdateNotice = NOTICE, onDismiss: () => void = vi.fn()) {
+function renderCard(
+  opts: {
+    notice?: UpdateNotice;
+    onDismiss?: () => void;
+    onUpdate?: () => Promise<UpdateOutcome>;
+  } = {},
+) {
   const fake = createFakeAppContext();
+  const onDismiss = opts.onDismiss ?? vi.fn();
+  const onUpdate = opts.onUpdate ?? vi.fn<() => Promise<UpdateOutcome>>().mockResolvedValue({ status: 'success' });
   const result = render(
     <AnnotationAppContext.Provider value={fake.context}>
-      <UpdateNoticeCard notice={notice} onDismiss={onDismiss} />
+      <UpdateNoticeCard notice={opts.notice ?? NOTICE} onDismiss={onDismiss} onUpdate={onUpdate} />
     </AnnotationAppContext.Provider>,
   );
-  return { ...fake, result, onDismiss };
+  return { ...fake, result, onDismiss, onUpdate };
 }
 
 describe('UpdateNoticeCard', () => {
@@ -27,14 +36,13 @@ describe('UpdateNoticeCard', () => {
     cleanup();
   });
 
-  it('renders the versions and the contextbridge update command', () => {
+  it('renders the version and a primary Update Now button by default', () => {
     renderCard();
     const container = screen.getByTestId(updateNoticeCardTestIds.container);
     expect(container).toBeInTheDocument();
     expect(container).toHaveTextContent('Update available: v0.2.0');
     expect(container).toHaveTextContent("You're on v0.1.0");
-    expect(container).toHaveTextContent('Run to upgrade');
-    expect(container).toHaveTextContent('contextbridge update');
+    expect(screen.getByTestId(updateNoticeCardTestIds.updateButton)).toHaveTextContent('Update Now');
   });
 
   it('fires update_notice_viewed analytics on first render', () => {
@@ -42,31 +50,6 @@ describe('UpdateNoticeCard', () => {
     const viewed = analytics.captures.find((c) => c.event === 'update_notice_viewed');
     expect(viewed).toBeDefined();
     expect(viewed?.properties).toMatchObject({ latest_version: '0.2.0' });
-  });
-
-  it('fires analytics on copy click and does not throw even if clipboard is unavailable', async () => {
-    const user = userEvent.setup();
-    const { analytics } = renderCard();
-
-    // Click must not throw regardless of the browser's clipboard availability.
-    // The handler wraps navigator.clipboard.writeText in try/catch because
-    // some proxies strip it in non-secure contexts.
-    await user.click(screen.getByTestId(updateNoticeCardTestIds.copyButton));
-
-    const copied = analytics.captures.find((c) => c.event === 'update_command_copied');
-    expect(copied).toBeDefined();
-    expect(copied?.properties).toMatchObject({ latest_version: '0.2.0' });
-  });
-
-  it('calls onDismiss + fires analytics when the × button is clicked', async () => {
-    const user = userEvent.setup();
-    const onDismiss = vi.fn();
-    const { analytics } = renderCard(NOTICE, onDismiss);
-
-    await user.click(screen.getByTestId(updateNoticeCardTestIds.dismissButton));
-
-    expect(onDismiss).toHaveBeenCalledTimes(1);
-    expect(analytics.captures.some((c) => c.event === 'update_notice_dismissed')).toBe(true);
   });
 
   it('renders a "What\'s new" link to the per-version GitHub Release page', () => {
@@ -83,8 +66,119 @@ describe('UpdateNoticeCard', () => {
 
     await user.click(screen.getByTestId(updateNoticeCardTestIds.changelogLink));
 
-    const clicked = analytics.captures.find((c) => c.event === 'update_changelog_clicked');
-    expect(clicked).toBeDefined();
-    expect(clicked?.properties).toMatchObject({ latest_version: '0.2.0' });
+    expect(analytics.captures.some((c) => c.event === 'update_changelog_clicked')).toBe(true);
+  });
+
+  it('calls onDismiss and fires analytics when the × button is clicked', async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    const { analytics } = renderCard({ onDismiss });
+
+    await user.click(screen.getByTestId(updateNoticeCardTestIds.dismissButton));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(analytics.captures.some((c) => c.event === 'update_notice_dismissed')).toBe(true);
+  });
+
+  it('on Update Now click → fires update_triggered, calls onUpdate, then onDismiss + update_completed=success', async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    const onUpdate = vi.fn<() => Promise<UpdateOutcome>>().mockResolvedValue({ status: 'success' });
+    const { analytics } = renderCard({ onDismiss, onUpdate });
+
+    await user.click(screen.getByTestId(updateNoticeCardTestIds.updateButton));
+
+    await waitFor(() => expect(onDismiss).toHaveBeenCalledTimes(1));
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(analytics.captures.find((c) => c.event === 'update_triggered')?.properties).toMatchObject({
+      latest_version: '0.2.0',
+    });
+    expect(analytics.captures.find((c) => c.event === 'update_completed')?.properties).toMatchObject({
+      latest_version: '0.2.0',
+      outcome: 'success',
+    });
+  });
+
+  it('on recoverable failure → shows the failure message and a Copy Command button', async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn<() => Promise<UpdateOutcome>>().mockResolvedValue({
+      status: 'failed',
+      message: 'Installer failed: brew exited 1',
+      recoverable: true,
+    });
+    const { analytics } = renderCard({ onUpdate });
+
+    await user.click(screen.getByTestId(updateNoticeCardTestIds.updateButton));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(updateNoticeCardTestIds.failureMessage)).toHaveTextContent(
+        'Installer failed: brew exited 1',
+      );
+    });
+    const copy = screen.getByTestId(updateNoticeCardTestIds.copyFallbackButton);
+    expect(copy).toHaveTextContent('Copy Command');
+    expect(analytics.captures.find((c) => c.event === 'update_completed')?.properties).toMatchObject({
+      outcome: 'failed_recoverable',
+    });
+  });
+
+  it('clicking the Copy Command fallback writes contextbridge update and fires update_command_copied', async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn<() => Promise<UpdateOutcome>>().mockResolvedValue({
+      status: 'failed',
+      message: 'Installer failed',
+      recoverable: true,
+    });
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+    const { analytics } = renderCard({ onUpdate });
+
+    await user.click(screen.getByTestId(updateNoticeCardTestIds.updateButton));
+    await waitFor(() => screen.getByTestId(updateNoticeCardTestIds.copyFallbackButton));
+    await user.click(screen.getByTestId(updateNoticeCardTestIds.copyFallbackButton));
+
+    expect(writeText).toHaveBeenCalledWith('contextbridge update');
+    expect(analytics.captures.some((c) => c.event === 'update_command_copied')).toBe(true);
+    writeText.mockRestore();
+  });
+
+  it('on unrecoverable failure → shows the message only, no primary button', async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn<() => Promise<UpdateOutcome>>().mockResolvedValue({
+      status: 'failed',
+      message: 'Updates are disabled for dev builds.',
+      recoverable: false,
+    });
+    const { analytics } = renderCard({ onUpdate });
+
+    await user.click(screen.getByTestId(updateNoticeCardTestIds.updateButton));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(updateNoticeCardTestIds.failureMessage)).toHaveTextContent(
+        'Updates are disabled for dev builds.',
+      );
+    });
+    expect(screen.queryByTestId(updateNoticeCardTestIds.copyFallbackButton)).toBeNull();
+    expect(screen.queryByTestId(updateNoticeCardTestIds.updateButton)).toBeNull();
+    expect(analytics.captures.find((c) => c.event === 'update_completed')?.properties).toMatchObject({
+      outcome: 'failed_unrecoverable',
+    });
+  });
+
+  it('shows the spinner while the update is in flight', async () => {
+    const user = userEvent.setup();
+    let resolveUpdate!: (outcome: UpdateOutcome) => void;
+    const onUpdate = vi.fn<() => Promise<UpdateOutcome>>().mockImplementation(
+      () =>
+        new Promise<UpdateOutcome>((resolve) => {
+          resolveUpdate = resolve;
+        }),
+    );
+    renderCard({ onUpdate });
+
+    await user.click(screen.getByTestId(updateNoticeCardTestIds.updateButton));
+
+    expect(screen.getByTestId(updateNoticeCardTestIds.updatingIndicator)).toBeInTheDocument();
+
+    resolveUpdate({ status: 'success' });
   });
 });

--- a/packages/annotation/src/UpdateNoticeCard.tsx
+++ b/packages/annotation/src/UpdateNoticeCard.tsx
@@ -1,31 +1,59 @@
 import { GITHUB_REPO_URL } from '@contextbridge/shared/links';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
+import type { UpdateOutcome } from '@contextbridge/shared/updateOutcomeSchema';
 import { Alert, AlertDescription, AlertTitle } from '@contextbridge/ui/components/ui/alert';
 import { Button } from '@contextbridge/ui/components/ui/button';
-import { Sparkles, X } from 'lucide-react';
-import { useEffect } from 'react';
+import { Loader2, Sparkles, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { useAnnotationAppContext } from './useAppContext.ts';
 
 const UPDATE_COMMAND = 'contextbridge update';
 
 export const updateNoticeCardTestIds = {
   container: 'update-notice-card',
-  copyButton: 'update-notice-card-copy',
+  updateButton: 'update-notice-card-update',
+  updatingIndicator: 'update-notice-card-updating',
+  copyFallbackButton: 'update-notice-card-copy-fallback',
+  failureMessage: 'update-notice-card-failure-message',
   dismissButton: 'update-notice-card-dismiss',
   changelogLink: 'update-notice-card-changelog',
 };
 
+type ReportedOutcome = 'success' | 'failed_recoverable' | 'failed_unrecoverable';
+
+type CardState =
+  | { kind: 'idle' }
+  | { kind: 'updating' }
+  | { kind: 'failed'; message: string; recoverable: boolean };
+
 export interface UpdateNoticeCardProps {
   notice: UpdateNotice;
   onDismiss: () => void;
+  onUpdate: () => Promise<UpdateOutcome>;
 }
 
-export function UpdateNoticeCard({ notice, onDismiss }: UpdateNoticeCardProps) {
+export function UpdateNoticeCard({ notice, onDismiss, onUpdate }: UpdateNoticeCardProps) {
   const { analytics } = useAnnotationAppContext();
+  const [state, setState] = useState<CardState>({ kind: 'idle' });
 
   useEffect(() => {
     analytics.capture('update_notice_viewed', { latest_version: notice.latestVersion });
   }, [analytics, notice.latestVersion]);
+
+  const handleUpdate = async () => {
+    analytics.capture('update_triggered', { latest_version: notice.latestVersion });
+    setState({ kind: 'updating' });
+    const outcome = await onUpdate();
+    analytics.capture('update_completed', {
+      latest_version: notice.latestVersion,
+      outcome: classifyOutcome(outcome),
+    });
+    if (outcome.status === 'success') {
+      onDismiss();
+      return;
+    }
+    setState({ kind: 'failed', message: outcome.message, recoverable: outcome.recoverable });
+  };
 
   const handleCopy = () => {
     analytics.capture('update_command_copied', { latest_version: notice.latestVersion });
@@ -58,19 +86,50 @@ export function UpdateNoticeCard({ notice, onDismiss }: UpdateNoticeCardProps) {
             v{notice.latestVersion}
           </a>
         </AlertTitle>
-        <AlertDescription className="text-muted-foreground text-xs">
-          You&apos;re on v{notice.currentVersion}. Run to upgrade:
-        </AlertDescription>
-        <div className="col-start-2 mt-1.5 flex items-center gap-1.5">
-          <code className="bg-muted flex-1 truncate rounded px-1.5 py-0.5 font-mono text-xs">{UPDATE_COMMAND}</code>
-          <Button
-            size="sm"
-            className="h-6 px-2 text-xs"
-            onClick={handleCopy}
-            data-testid={updateNoticeCardTestIds.copyButton}
+        {state.kind === 'failed' ? (
+          <AlertDescription
+            data-testid={updateNoticeCardTestIds.failureMessage}
+            className="text-muted-foreground text-xs"
           >
-            Copy command
-          </Button>
+            {state.message}
+          </AlertDescription>
+        ) : (
+          <AlertDescription className="text-muted-foreground text-xs">
+            You&apos;re on v{notice.currentVersion}.
+          </AlertDescription>
+        )}
+        <div className="col-start-2 mt-1.5 flex items-center justify-end">
+          {state.kind === 'idle' ? (
+            <Button
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={() => void handleUpdate()}
+              data-testid={updateNoticeCardTestIds.updateButton}
+            >
+              Update Now
+            </Button>
+          ) : null}
+          {state.kind === 'updating' ? (
+            <Button
+              size="sm"
+              disabled
+              className="h-6 px-2 text-xs"
+              data-testid={updateNoticeCardTestIds.updatingIndicator}
+            >
+              <Loader2 className="size-3 animate-spin" />
+              <span className="ml-1">Updating…</span>
+            </Button>
+          ) : null}
+          {state.kind === 'failed' && state.recoverable ? (
+            <Button
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={handleCopy}
+              data-testid={updateNoticeCardTestIds.copyFallbackButton}
+            >
+              Copy Command
+            </Button>
+          ) : null}
         </div>
         <Button
           size="icon"
@@ -85,4 +144,9 @@ export function UpdateNoticeCard({ notice, onDismiss }: UpdateNoticeCardProps) {
       </Alert>
     </div>
   );
+}
+
+function classifyOutcome(outcome: UpdateOutcome): ReportedOutcome {
+  if (outcome.status === 'success') return 'success';
+  return outcome.recoverable ? 'failed_recoverable' : 'failed_unrecoverable';
 }

--- a/packages/annotation/src/main.tsx
+++ b/packages/annotation/src/main.tsx
@@ -7,6 +7,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App.tsx';
 import { fetchUpdateNotice } from './fetchUpdateNotice.ts';
+import { triggerUpdate } from './triggerUpdate.ts';
 import type { AnnotationAppContext as AnnotationAppContextValue } from './useAppContext.ts';
 import { AnnotationAppContext } from './useAppContext.ts';
 
@@ -32,6 +33,7 @@ async function bootstrap(target: HTMLElement): Promise<void> {
     ...base,
     fetchPayload,
     fetchUpdateNotice: () => fetchUpdateNotice(base.fetcher),
+    triggerUpdate: () => triggerUpdate(base.fetcher),
     submitAnnotation,
     autoCloseDelaySeconds: 3,
   };

--- a/packages/annotation/src/testHelpers/createFakeAppContext.ts
+++ b/packages/annotation/src/testHelpers/createFakeAppContext.ts
@@ -6,6 +6,7 @@ import {
 } from '@contextbridge/context/testHelpers';
 import type { AnnotationPayload, AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
+import type { UpdateOutcome } from '@contextbridge/shared/updateOutcomeSchema';
 import type { Mock } from 'vitest';
 import { vi } from 'vitest';
 import type { AnnotationAppContext } from '../useAppContext.ts';
@@ -23,6 +24,7 @@ export interface FakeAppContextResult {
   submitAnnotation: Mock<(submission: AnnotationSubmission) => Promise<void>>;
   fetchPayload: Mock<() => Promise<AnnotationPayload>>;
   fetchUpdateNotice: Mock<() => Promise<UpdateNotice | null>>;
+  triggerUpdate: Mock<() => Promise<UpdateOutcome>>;
   analytics: FakeAnalytics;
   telemetry: FakeFrontendTelemetry;
 }
@@ -34,6 +36,7 @@ export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>):
     .fn<() => Promise<AnnotationPayload>>()
     .mockResolvedValue({ content: '', contentKind: 'plan' });
   const fetchUpdateNotice = vi.fn<() => Promise<UpdateNotice | null>>().mockResolvedValue(null);
+  const triggerUpdate = vi.fn<() => Promise<UpdateOutcome>>().mockResolvedValue({ status: 'success' });
   const context: AnnotationAppContext = {
     ...fakeFrontendContext({
       scheduleTimeout: timers.scheduleTimeout,
@@ -41,6 +44,7 @@ export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>):
     }),
     fetchPayload,
     fetchUpdateNotice,
+    triggerUpdate,
     submitAnnotation,
     autoCloseDelaySeconds: 3,
     ...overrides,
@@ -51,6 +55,7 @@ export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>):
     submitAnnotation,
     fetchPayload,
     fetchUpdateNotice,
+    triggerUpdate,
     analytics: context.analytics as FakeAnalytics,
     telemetry: context.telemetry as FakeFrontendTelemetry,
   };

--- a/packages/annotation/src/triggerUpdate.test.ts
+++ b/packages/annotation/src/triggerUpdate.test.ts
@@ -1,0 +1,70 @@
+import type { Fetcher } from '@contextbridge/context';
+import type { UpdateOutcome } from '@contextbridge/shared/updateOutcomeSchema';
+import { describe, expect, it, vi } from 'vitest';
+import { triggerUpdate } from './triggerUpdate.ts';
+
+function makeFetcher(response: Response | Error): Fetcher {
+  return {
+    fetch: vi.fn(() => {
+      if (response instanceof Error) return Promise.reject(response);
+      return Promise.resolve(response);
+    }),
+  };
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+describe('triggerUpdate', () => {
+  it('parses a success outcome', async () => {
+    const fetcher = makeFetcher(jsonResponse({ status: 'success' }));
+    const outcome = await triggerUpdate(fetcher);
+    expect(outcome).toEqual({ status: 'success' });
+  });
+
+  it('parses a recoverable failure outcome', async () => {
+    const fetcher = makeFetcher(jsonResponse({ status: 'failed', message: 'oops', recoverable: true }));
+    const outcome = await triggerUpdate(fetcher);
+    expect(outcome).toEqual({ status: 'failed', message: 'oops', recoverable: true });
+  });
+
+  it('POSTs to /update', async () => {
+    const fetch = vi.fn(() => Promise.resolve(jsonResponse({ status: 'success' } satisfies UpdateOutcome)));
+    const fetcher: Fetcher = { fetch };
+    await triggerUpdate(fetcher);
+    expect(fetch).toHaveBeenCalledWith('/update', expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('returns a generic recoverable failure when the fetch throws', async () => {
+    const fetcher = makeFetcher(new Error('network down'));
+    const outcome = await triggerUpdate(fetcher);
+    expect(outcome.status).toBe('failed');
+    if (outcome.status === 'failed') {
+      expect(outcome.recoverable).toBe(true);
+      expect(outcome.message).toContain('contextbridge update');
+    }
+  });
+
+  it('returns a generic recoverable failure when the response is not ok', async () => {
+    const fetcher = makeFetcher(new Response('boom', { status: 500 }));
+    const outcome = await triggerUpdate(fetcher);
+    expect(outcome.status).toBe('failed');
+    if (outcome.status === 'failed') {
+      expect(outcome.recoverable).toBe(true);
+    }
+  });
+
+  it('returns a generic recoverable failure when the body fails to parse against the schema', async () => {
+    const fetcher = makeFetcher(jsonResponse({ status: 'bogus' }));
+    const outcome = await triggerUpdate(fetcher);
+    expect(outcome.status).toBe('failed');
+    if (outcome.status === 'failed') {
+      expect(outcome.recoverable).toBe(true);
+    }
+  });
+});

--- a/packages/annotation/src/triggerUpdate.ts
+++ b/packages/annotation/src/triggerUpdate.ts
@@ -1,0 +1,23 @@
+import type { Fetcher } from '@contextbridge/context';
+import { type UpdateOutcome, UpdateOutcomeSchema } from '@contextbridge/shared/updateOutcomeSchema';
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+
+const NETWORK_FAILURE: UpdateOutcome = {
+  status: 'failed',
+  message: 'Update request failed. Try running `contextbridge update` in your terminal.',
+  recoverable: true,
+};
+
+export async function triggerUpdate(fetcher: Fetcher): Promise<UpdateOutcome> {
+  return ResultAsync.fromPromise(fetcher.fetch('/update', { method: 'POST' }), () => NETWORK_FAILURE)
+    .andThen((response) =>
+      response.ok
+        ? ResultAsync.fromPromise(response.json() as Promise<unknown>, () => NETWORK_FAILURE)
+        : errAsync(NETWORK_FAILURE),
+    )
+    .andThen((body) => {
+      const parsed = UpdateOutcomeSchema.safeParse(body);
+      return parsed.success ? okAsync(parsed.data) : errAsync(NETWORK_FAILURE);
+    })
+    .unwrapOr(NETWORK_FAILURE);
+}

--- a/packages/annotation/src/useAppContext.ts
+++ b/packages/annotation/src/useAppContext.ts
@@ -1,11 +1,13 @@
 import type { FrontendContext } from '@contextbridge/context/frontend';
 import type { AnnotationPayload, AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
+import type { UpdateOutcome } from '@contextbridge/shared/updateOutcomeSchema';
 import { createContext, useContext } from 'react';
 
 export interface AnnotationAppContext extends FrontendContext {
   fetchPayload: () => Promise<AnnotationPayload>;
   fetchUpdateNotice: () => Promise<UpdateNotice | null>;
+  triggerUpdate: () => Promise<UpdateOutcome>;
   submitAnnotation: (submission: AnnotationSubmission) => Promise<void>;
   autoCloseDelaySeconds: number;
 }

--- a/packages/cli/src/annotation/runAnnotation.test.ts
+++ b/packages/cli/src/annotation/runAnnotation.test.ts
@@ -63,6 +63,16 @@ describe('runAnnotation', () => {
     expect(deps.sigintHandlerRemoved).toBe(true);
     expect(analytics.captures.some((c) => c.event === 'plan_review_submitted')).toBe(false);
   });
+
+  it('drains the in-flight update before closing the server', async () => {
+    const { context } = createStubContext();
+    const deps = createAnnotationDependencies();
+
+    await runAnnotation(context, annotationArgs.build(), deps);
+
+    expect(deps.awaitInFlightUpdateCalls).toEqual([60_000]);
+    expect(deps.closeCount).toBe(1);
+  });
 });
 
 function createAnnotationDependencies(
@@ -72,12 +82,14 @@ function createAnnotationDependencies(
 ): AnnotationDependencies & {
   closeCount: number;
   payloads: AnnotationPayload[];
+  awaitInFlightUpdateCalls: Array<number | undefined>;
   sigintHandlerRegistered: Promise<void>;
   sigintHandlerRemoved: boolean;
   submission: AnnotationSubmission;
   triggerSigint(): void;
 } {
   const payloads: AnnotationPayload[] = [];
+  const awaitInFlightUpdateCalls: Array<number | undefined> = [];
   const submission = annotationSubmission.build();
   const sigintRegistration = createDeferred<void>();
   let closeCount = 0;
@@ -89,6 +101,7 @@ function createAnnotationDependencies(
       return closeCount;
     },
     payloads,
+    awaitInFlightUpdateCalls,
     sigintHandlerRegistered: sigintRegistration.promise,
     get sigintHandlerRemoved() {
       return sigintHandlerRemoved;
@@ -108,6 +121,10 @@ function createAnnotationDependencies(
         port: 4312,
         url: 'http://localhost:4312',
         result: options.result ?? Promise.resolve(submission),
+        awaitInFlightUpdate: (timeoutMs) => {
+          awaitInFlightUpdateCalls.push(timeoutMs);
+          return Promise.resolve();
+        },
         close: () => {
           closeCount += 1;
           return Promise.resolve();

--- a/packages/cli/src/annotation/runAnnotation.ts
+++ b/packages/cli/src/annotation/runAnnotation.ts
@@ -10,7 +10,9 @@ import type {
 import type { FrontendConfig } from '@contextbridge/shared/frontendConfigSchema';
 import { nowInstant } from '@contextbridge/shared/time';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
+import type { UpdateOutcome } from '@contextbridge/shared/updateOutcomeSchema';
 import type { CliContext } from '#src/context.ts';
+import { toUpdateOutcome } from '#src/updater/toUpdateOutcome.ts';
 import { extractDocumentTitle } from './extractDocumentTitle.ts';
 
 export class AnnotationInterruptedError extends Error {
@@ -19,6 +21,8 @@ export class AnnotationInterruptedError extends Error {
     this.name = 'AnnotationInterruptedError';
   }
 }
+
+const UPDATE_DRAIN_TIMEOUT_MS = 60_000;
 
 export interface RunAnnotationArgs {
   content: string;
@@ -35,6 +39,7 @@ export interface AnnotationDependencies {
       payload: AnnotationPayload;
       config: FrontendConfig;
       checkForUpdate?: () => Promise<UpdateNotice | null>;
+      performUpdate?: () => Promise<UpdateOutcome>;
     },
   ): RunningServer;
   registerSigintHandler(handler: () => void): () => void;
@@ -78,6 +83,7 @@ export async function runAnnotation(
       payload,
       config: frontendConfig,
       checkForUpdate: () => updater.checkForUpdate().catch(() => null),
+      performUpdate: () => updater.performUpdate().then(toUpdateOutcome),
     });
     removeSigintHandler = deps.registerSigintHandler(() => {
       if (sigintHandled) {
@@ -104,20 +110,28 @@ export async function runAnnotation(
     await closeServer();
   }
 
-  function closeServer(): Promise<void> {
+  async function closeServer(): Promise<void> {
     if (!server) {
-      return Promise.resolve();
+      return;
     }
 
-    closePromise ??= server.close();
-    return closePromise;
+    const target = server;
+    closePromise ??= (async () => {
+      try {
+        await target.awaitInFlightUpdate(UPDATE_DRAIN_TIMEOUT_MS);
+      } catch (err) {
+        logger.warn({ err }, 'awaitInFlightUpdate failed; closing anyway');
+      }
+      await target.close();
+    })();
+    await closePromise;
   }
 }
 
 const defaultAnnotationDependencies: AnnotationDependencies = {
   loadHtml: () => import('./bundledAnnotationHtml.ts').then((m) => m.bundledAnnotationHtml),
-  startReviewServer: (ctx, { html, payload, config, checkForUpdate }) =>
-    startServer(ctx, { html, payload, config, checkForUpdate }),
+  startReviewServer: (ctx, { html, payload, config, checkForUpdate, performUpdate }) =>
+    startServer(ctx, { html, payload, config, checkForUpdate, performUpdate }),
   registerSigintHandler: (handler) => {
     process.on('SIGINT', handler);
     return () => {

--- a/packages/cli/src/commands/plan.test.ts
+++ b/packages/cli/src/commands/plan.test.ts
@@ -197,6 +197,7 @@ function createPlanDependencies(
         port: 4312,
         url: 'http://localhost:4312',
         result: options.result ?? Promise.resolve(submission),
+        awaitInFlightUpdate: () => Promise.resolve(),
         close: () => {
           closed = true;
           return Promise.resolve();

--- a/packages/cli/src/testHelpers/annotationFakes.ts
+++ b/packages/cli/src/testHelpers/annotationFakes.ts
@@ -1,16 +1,44 @@
 import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
 import type { AnnotationDependencies } from '#src/annotation/runAnnotation.ts';
 
+export interface AnnotationDependencyFake {
+  deps: AnnotationDependencies;
+  awaitInFlightUpdateCalls: Array<number | undefined>;
+  readonly closeCalls: number;
+}
+
 export function createAnnotationDependencies(options: { submission: AnnotationSubmission }): AnnotationDependencies {
+  return createAnnotationDependencyFake(options).deps;
+}
+
+export function createAnnotationDependencyFake(options: {
+  submission: AnnotationSubmission;
+}): AnnotationDependencyFake {
   const { submission } = options;
-  return {
+  const awaitInFlightUpdateCalls: Array<number | undefined> = [];
+  let closeCalls = 0;
+  const deps: AnnotationDependencies = {
     loadHtml: () => Promise.resolve('<html><body>annotation</body></html>'),
     startReviewServer: () => ({
       port: 4312,
       url: 'http://localhost:4312',
       result: Promise.resolve(submission),
-      close: () => Promise.resolve(),
+      awaitInFlightUpdate: (timeoutMs) => {
+        awaitInFlightUpdateCalls.push(timeoutMs);
+        return Promise.resolve();
+      },
+      close: () => {
+        closeCalls += 1;
+        return Promise.resolve();
+      },
     }),
     registerSigintHandler: () => () => {},
+  };
+  return {
+    deps,
+    awaitInFlightUpdateCalls,
+    get closeCalls() {
+      return closeCalls;
+    },
   };
 }

--- a/packages/cli/src/testHelpers/index.ts
+++ b/packages/cli/src/testHelpers/index.ts
@@ -14,5 +14,9 @@ export { FakeUpdater } from './FakeUpdater.ts';
 export { MemoryStream } from './MemoryStream.ts';
 export { type TestContext, createStubContext } from './createStubContext.ts';
 export { parseStdoutJson } from './parseStdoutJson.ts';
-export { createAnnotationDependencies } from './annotationFakes.ts';
+export {
+  type AnnotationDependencyFake,
+  createAnnotationDependencies,
+  createAnnotationDependencyFake,
+} from './annotationFakes.ts';
 export { type LogRecord, readErrorLogs, readLogs, readWarnLogs } from './readLogs.ts';

--- a/packages/cli/src/updater/toUpdateOutcome.test.ts
+++ b/packages/cli/src/updater/toUpdateOutcome.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test';
+import { toUpdateOutcome } from './toUpdateOutcome.ts';
+import type { PerformUpdateResult } from './types.ts';
+
+describe('toUpdateOutcome', () => {
+  it('maps executed → success', () => {
+    const result: PerformUpdateResult = {
+      status: 'executed',
+      command: ['brew', 'upgrade', '--cask', 'contextbridge'],
+      exitCode: 0,
+    };
+    expect(toUpdateOutcome(result)).toEqual({ status: 'success' });
+  });
+
+  it('maps skipped-already-latest → success', () => {
+    const result: PerformUpdateResult = {
+      status: 'skipped-already-latest',
+      currentVersion: '0.4.2',
+    };
+    expect(toUpdateOutcome(result)).toEqual({ status: 'success' });
+  });
+
+  it('maps refused → unrecoverable failure', () => {
+    const result: PerformUpdateResult = {
+      status: 'refused',
+      reason: 'dev-build',
+      message: 'Updates are disabled for dev builds.',
+    };
+    expect(toUpdateOutcome(result)).toEqual({
+      status: 'failed',
+      message: 'Updates are disabled for dev builds.',
+      recoverable: false,
+    });
+  });
+
+  it('maps recovery-needed → recoverable failure', () => {
+    const result: PerformUpdateResult = {
+      status: 'recovery-needed',
+      reason: 'unknown-install-method',
+      message: 'Install method could not be detected.',
+      fallbackCommands: ['curl …'],
+      diagnostics: {
+        execPath: '/usr/local/bin/contextbridge',
+        realPath: '/usr/local/bin/contextbridge',
+        platform: 'darwin',
+        arch: 'arm64',
+        homedir: '/Users/test',
+      },
+    };
+    expect(toUpdateOutcome(result)).toEqual({
+      status: 'failed',
+      message: 'Install method could not be detected.',
+      recoverable: true,
+    });
+  });
+
+  it('maps error → recoverable failure', () => {
+    const result: PerformUpdateResult = {
+      status: 'error',
+      message: 'brew upgrade exited with code 1',
+      cause: new Error('Process failed'),
+    };
+    expect(toUpdateOutcome(result)).toEqual({
+      status: 'failed',
+      message: 'brew upgrade exited with code 1',
+      recoverable: true,
+    });
+  });
+});

--- a/packages/cli/src/updater/toUpdateOutcome.ts
+++ b/packages/cli/src/updater/toUpdateOutcome.ts
@@ -1,0 +1,15 @@
+import type { UpdateOutcome } from '@contextbridge/shared/updateOutcomeSchema';
+import type { PerformUpdateResult } from './types.ts';
+
+export function toUpdateOutcome(result: PerformUpdateResult): UpdateOutcome {
+  switch (result.status) {
+    case 'executed':
+    case 'skipped-already-latest':
+      return { status: 'success' };
+    case 'refused':
+      return { status: 'failed', message: result.message, recoverable: false };
+    case 'recovery-needed':
+    case 'error':
+      return { status: 'failed', message: result.message, recoverable: true };
+  }
+}

--- a/packages/server/src/annotation.test.ts
+++ b/packages/server/src/annotation.test.ts
@@ -3,7 +3,8 @@ import type { AnnotationPayload } from '@contextbridge/shared/annotationSchema';
 import type { FrontendConfig } from '@contextbridge/shared/frontendConfigSchema';
 import { annotationThread, globalThread } from '@contextbridge/shared/testFactories';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
-import { describe, expect, it } from 'bun:test';
+import type { UpdateOutcome } from '@contextbridge/shared/updateOutcomeSchema';
+import { describe, expect, it, mock } from 'bun:test';
 import { createAnnotationServerApp, startServer } from './annotation.ts';
 
 describe('createAnnotationServerApp', () => {
@@ -225,5 +226,151 @@ describe('startServer', () => {
     } finally {
       await running.close();
     }
+  });
+
+  it('returns 404 for POST /update when no performUpdate callback is wired', async () => {
+    const app = createAnnotationServerApp(ctx, {
+      html: Promise.resolve('<html><body>ui</body></html>'),
+      payload,
+      config,
+    });
+
+    const res = await app.fetch(new Request('http://localhost/update', { method: 'POST' }));
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the UpdateOutcome from performUpdate on POST /update', async () => {
+    const performUpdate = mock(() =>
+      Promise.resolve<UpdateOutcome>({ status: 'failed', message: 'broken', recoverable: true }),
+    );
+    const app = createAnnotationServerApp(ctx, {
+      html: Promise.resolve('<html><body>ui</body></html>'),
+      payload,
+      config,
+      performUpdate,
+    });
+
+    const res = await app.fetch(new Request('http://localhost/update', { method: 'POST' }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'failed', message: 'broken', recoverable: true });
+    expect(performUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates concurrent POST /update requests via a single in-flight promise', async () => {
+    let resolvePerform!: (outcome: UpdateOutcome) => void;
+    const performUpdate = mock(
+      () =>
+        new Promise<UpdateOutcome>((resolve) => {
+          resolvePerform = resolve;
+        }),
+    );
+    const app = createAnnotationServerApp(ctx, {
+      html: Promise.resolve('<html><body>ui</body></html>'),
+      payload,
+      config,
+      performUpdate,
+    });
+
+    const first = app.fetch(new Request('http://localhost/update', { method: 'POST' }));
+    const second = app.fetch(new Request('http://localhost/update', { method: 'POST' }));
+    // Yield once so both routes register their await on the same in-flight promise
+    // before we resolve it.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolvePerform({ status: 'success' });
+
+    const [firstRes, secondRes] = await Promise.all([first, second]);
+    expect(await firstRes.json()).toEqual({ status: 'success' });
+    expect(await secondRes.json()).toEqual({ status: 'success' });
+    expect(performUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a recoverable failure when performUpdate throws', async () => {
+    const performUpdate = mock(() => Promise.reject(new Error('boom')));
+    const app = createAnnotationServerApp(ctx, {
+      html: Promise.resolve('<html><body>ui</body></html>'),
+      payload,
+      config,
+      performUpdate,
+    });
+
+    const res = await app.fetch(new Request('http://localhost/update', { method: 'POST' }));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; message: string; recoverable: boolean };
+    expect(body.status).toBe('failed');
+    expect(body.recoverable).toBe(true);
+    expect(body.message).toMatch(/contextbridge update/);
+  });
+
+  it('clears the in-flight slot after the update settles', async () => {
+    const performUpdate = mock(() => Promise.resolve<UpdateOutcome>({ status: 'success' }));
+    const app = createAnnotationServerApp(ctx, {
+      html: Promise.resolve('<html><body>ui</body></html>'),
+      payload,
+      config,
+      performUpdate,
+    });
+
+    await app.fetch(new Request('http://localhost/update', { method: 'POST' }));
+    await app.fetch(new Request('http://localhost/update', { method: 'POST' }));
+
+    expect(performUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it('awaitInFlightUpdate resolves immediately when nothing is in flight', async () => {
+    const app = createAnnotationServerApp(ctx, {
+      html: Promise.resolve('<html><body>ui</body></html>'),
+      payload,
+      config,
+    });
+
+    await app.awaitInFlightUpdate();
+  });
+
+  it('awaitInFlightUpdate waits for a pending update to settle', async () => {
+    let resolvePerform!: (outcome: UpdateOutcome) => void;
+    const performUpdate = mock(
+      () =>
+        new Promise<UpdateOutcome>((resolve) => {
+          resolvePerform = resolve;
+        }),
+    );
+    const app = createAnnotationServerApp(ctx, {
+      html: Promise.resolve('<html><body>ui</body></html>'),
+      payload,
+      config,
+      performUpdate,
+    });
+
+    void app.fetch(new Request('http://localhost/update', { method: 'POST' }));
+    // Yield once so the route can register the in-flight promise.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    let resolved = false;
+    const wait = app.awaitInFlightUpdate().then(() => {
+      resolved = true;
+    });
+    expect(resolved).toBe(false);
+
+    resolvePerform({ status: 'success' });
+    await wait;
+    expect(resolved).toBe(true);
+  });
+
+  it('awaitInFlightUpdate resolves on timeout without throwing if the update is still pending', async () => {
+    const performUpdate = mock(() => new Promise<UpdateOutcome>(() => {}));
+    const app = createAnnotationServerApp(ctx, {
+      html: Promise.resolve('<html><body>ui</body></html>'),
+      payload,
+      config,
+      performUpdate,
+    });
+
+    void app.fetch(new Request('http://localhost/update', { method: 'POST' }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await app.awaitInFlightUpdate(20);
   });
 });

--- a/packages/server/src/annotation.ts
+++ b/packages/server/src/annotation.ts
@@ -5,11 +5,13 @@ import {
 } from '@contextbridge/shared/annotationSchema';
 import type { FrontendConfig } from '@contextbridge/shared/frontendConfigSchema';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
+import type { UpdateOutcome } from '@contextbridge/shared/updateOutcomeSchema';
 import type { ServerContext } from './context.ts';
 
 const UPDATE_NOTICE_TIMEOUT_MS = 3_000;
 
 export type CheckForUpdate = () => Promise<UpdateNotice | null>;
+export type PerformUpdate = () => Promise<UpdateOutcome>;
 
 export interface StartServerOptions {
   /** Annotation UI bundle. Awaited lazily on the first GET /. */
@@ -18,17 +20,20 @@ export interface StartServerOptions {
   readonly config: FrontendConfig;
   readonly port?: number;
   readonly checkForUpdate?: CheckForUpdate;
+  readonly performUpdate?: PerformUpdate;
 }
 
 export interface RunningServer {
   readonly port: number;
   readonly url: string;
   readonly result: Promise<AnnotationSubmission>;
+  awaitInFlightUpdate(timeoutMs?: number): Promise<void>;
   close(): Promise<void>;
 }
 
 export interface AnnotationServerApp {
   readonly result: Promise<AnnotationSubmission>;
+  awaitInFlightUpdate(timeoutMs?: number): Promise<void>;
   fetch: (req: Request) => Promise<Response>;
 }
 
@@ -48,12 +53,13 @@ export function startServer(ctx: ServerContext, opts: StartServerOptions): Runni
     port,
     url,
     result: app.result,
+    awaitInFlightUpdate: (timeoutMs) => app.awaitInFlightUpdate(timeoutMs),
     close: () => server.stop(true),
   };
 }
 
 export function createAnnotationServerApp(ctx: ServerContext, opts: StartServerOptions): AnnotationServerApp {
-  const { html, payload, config, checkForUpdate } = opts;
+  const { html, payload, config, checkForUpdate, performUpdate } = opts;
   const { logger } = ctx;
 
   let resolveResult!: (r: AnnotationSubmission) => void;
@@ -61,8 +67,32 @@ export function createAnnotationServerApp(ctx: ServerContext, opts: StartServerO
     resolveResult = resolve;
   });
 
+  let updateInFlight: Promise<UpdateOutcome> | null = null;
+
+  function startUpdate(callback: PerformUpdate): Promise<UpdateOutcome> {
+    const next = callback()
+      .catch((err: unknown) => {
+        logger.error({ err }, 'performUpdate threw');
+        return FALLBACK_UPDATE_FAILURE;
+      })
+      .finally(() => {
+        updateInFlight = null;
+      });
+    updateInFlight = next;
+    return next;
+  }
+
   return {
     result,
+    async awaitInFlightUpdate(timeoutMs?: number) {
+      const pending = updateInFlight;
+      if (!pending) return;
+      if (timeoutMs == null) {
+        await pending.catch(() => {});
+        return;
+      }
+      await Promise.race([pending.catch(() => {}), new Promise<void>((resolve) => setTimeout(resolve, timeoutMs))]);
+    },
     fetch: async (req) => {
       const url = new URL(req.url);
       if (req.method === 'GET' && url.pathname === '/') {
@@ -83,6 +113,12 @@ export function createAnnotationServerApp(ctx: ServerContext, opts: StartServerO
       if (req.method === 'GET' && url.pathname === '/update-notice') {
         const notice = await resolveUpdateNotice(checkForUpdate);
         return Response.json(notice);
+      }
+      if (req.method === 'POST' && url.pathname === '/update') {
+        if (!performUpdate) return new Response('not found', { status: 404 });
+        const pending = updateInFlight ?? startUpdate(performUpdate);
+        const outcome = await pending;
+        return Response.json(outcome);
       }
       if (req.method === 'POST' && url.pathname === '/submit') {
         let body: unknown;
@@ -108,6 +144,12 @@ export function createAnnotationServerApp(ctx: ServerContext, opts: StartServerO
     },
   };
 }
+
+const FALLBACK_UPDATE_FAILURE: UpdateOutcome = {
+  status: 'failed',
+  message: 'Update failed unexpectedly. Try running `contextbridge update` in your terminal.',
+  recoverable: true,
+};
 
 async function resolveUpdateNotice(checkForUpdate: CheckForUpdate | undefined): Promise<UpdateNotice | null> {
   if (!checkForUpdate) return null;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,7 +13,8 @@
     "./time": "./src/time.ts",
     "./typeGuards": "./src/typeGuards.ts",
     "./types": "./src/types.ts",
-    "./updateNoticeSchema": "./src/updateNoticeSchema.ts"
+    "./updateNoticeSchema": "./src/updateNoticeSchema.ts",
+    "./updateOutcomeSchema": "./src/updateOutcomeSchema.ts"
   },
   "imports": {
     "#src/*": "./src/*"

--- a/packages/shared/src/testFactories.ts
+++ b/packages/shared/src/testFactories.ts
@@ -6,6 +6,7 @@ import type {
   CommentThread,
   StoredAnnotationAnchor,
 } from './annotationSchema.ts';
+import type { UpdateOutcome } from './updateOutcomeSchema.ts';
 
 export const LOCAL_AUTHOR = {
   id: 'local-user',
@@ -72,4 +73,8 @@ export const globalThread = Factory.define<CommentThread>(() => {
 export const annotationSubmission = Factory.define<AnnotationSubmission>(() => ({
   status: 'changes_requested',
   threads: [globalThread.build(), annotationThread.build()],
+}));
+
+export const updateOutcome = Factory.define<UpdateOutcome>(() => ({
+  status: 'success',
 }));

--- a/packages/shared/src/updateOutcomeSchema.test.ts
+++ b/packages/shared/src/updateOutcomeSchema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test';
+import { UpdateOutcomeSchema } from './updateOutcomeSchema.ts';
+
+describe('UpdateOutcomeSchema', () => {
+  it('parses a success outcome', () => {
+    const parsed = UpdateOutcomeSchema.parse({ status: 'success' });
+    expect(parsed).toEqual({ status: 'success' });
+  });
+
+  it('parses a recoverable failure outcome', () => {
+    const parsed = UpdateOutcomeSchema.parse({
+      status: 'failed',
+      message: 'install method unknown',
+      recoverable: true,
+    });
+    expect(parsed).toEqual({ status: 'failed', message: 'install method unknown', recoverable: true });
+  });
+
+  it('parses an unrecoverable failure outcome', () => {
+    const parsed = UpdateOutcomeSchema.parse({
+      status: 'failed',
+      message: 'updates disabled in this environment',
+      recoverable: false,
+    });
+    expect(parsed).toEqual({
+      status: 'failed',
+      message: 'updates disabled in this environment',
+      recoverable: false,
+    });
+  });
+
+  it('rejects a failed outcome with an empty message', () => {
+    const result = UpdateOutcomeSchema.safeParse({ status: 'failed', message: '   ', recoverable: true });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a failed outcome missing the recoverable flag', () => {
+    const result = UpdateOutcomeSchema.safeParse({ status: 'failed', message: 'oops' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unknown status', () => {
+    const result = UpdateOutcomeSchema.safeParse({ status: 'pending' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/updateOutcomeSchema.ts
+++ b/packages/shared/src/updateOutcomeSchema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const UpdateOutcomeSchema = z.discriminatedUnion('status', [
+  z.object({ status: z.literal('success') }),
+  z.object({
+    status: z.literal('failed'),
+    message: z.string().trim().nonempty(),
+    recoverable: z.boolean(),
+  }),
+]);
+
+export type UpdateOutcome = z.infer<typeof UpdateOutcomeSchema>;


### PR DESCRIPTION
## Summary

Replaces the update-notice card's `Copy command` button with `Update Now`, which runs `contextbridge update` directly via the local CLI server instead of forcing the user to copy and paste. Closes #74. On success the card dismisses; on a recoverable failure (installer error or unknown install method) the card surfaces a `Copy Command` escape hatch; on an unrecoverable failure (dev build / opt-out) it shows a short explanation only.

## Review focus

- **Three-layer wire boundary.** CLI keeps its existing `PerformUpdateResult` (5 variants, unchanged); a new UI-flavored `UpdateOutcome` lives in `@contextbridge/shared` (2 variants: `success` / `failed { message, recoverable }`); `toUpdateOutcome` in `@contextbridge/cli` projects between them at wire time. The server only knows about `UpdateOutcome`, so there's no reverse dependency on CLI-internal types. Worth a sanity-check that this separation pulls its weight versus reusing `PerformUpdateResult` directly.
- **In-flight dedup + drain on close.** The server keeps a single `Promise<UpdateOutcome>` in closure; concurrent POSTs join the same call (no duplicate `brew upgrade` spawn). `runAnnotation.ts` awaits the in-flight update — bounded 60s, warning-and-continue on timeout — before tearing the server down, so a user submitting their annotation mid-update doesn't cut off the installer.
- **Single contextual button** (per `.claude/rules/plan-review-design.md`). One primary button whose label tracks state: `Update Now` → spinner+`Updating…` → either gone (success / unrecoverable) or `Copy Command` (recoverable). Verified visually in Storybook at the 320px max width across all four states.
- **Telemetry semantics changed for `update_command_copied`.** Same event name, but it now fires only from the recoverable-failure escape hatch — never from idle. Two new events: `update_triggered` (on click) and `update_completed` (with `outcome` ∈ `success` / `failed_recoverable` / `failed_unrecoverable` / `network_error`).

## Commits

- [`c0b268b`](https://github.com/contextbridge/planbridge/pull/88/commits/c0b268b) — `feat(shared): add UpdateOutcome wire schema`
- [`b2931e2`](https://github.com/contextbridge/planbridge/pull/88/commits/b2931e2) — `feat(server,cli): add POST /update endpoint with in-flight drain`
- [`5e56d44`](https://github.com/contextbridge/planbridge/pull/88/commits/5e56d44) — `feat(annotation): replace Copy command with Update Now button`