### PR TITLE
feat: align prompt reviewer noun with LLM user/assistant parlance

### DIFF
--- a/packages/annotation/src/App.stories.tsx
+++ b/packages/annotation/src/App.stories.tsx
@@ -70,7 +70,7 @@ const seededThreads = [
         id: 'msg_story_01',
         author: {
           id: 'local-user',
-          kind: 'human' as const,
+          kind: 'user' as const,
           displayName: 'You',
         },
         body: 'Why does the doc step happen after the verifier swap instead of before it?',

--- a/packages/annotation/src/commentModel.ts
+++ b/packages/annotation/src/commentModel.ts
@@ -8,7 +8,7 @@ import type { AnnotationCommentThread } from './annotationTypes.ts';
 
 const LOCAL_AUTHOR = {
   id: 'local-user',
-  kind: 'human' as const,
+  kind: 'user' as const,
   displayName: 'You',
 };
 

--- a/packages/annotation/src/useAnnotationState.test.ts
+++ b/packages/annotation/src/useAnnotationState.test.ts
@@ -205,7 +205,7 @@ describe('useAnnotationState', () => {
               messages: [
                 {
                   id: 'msg_global',
-                  author: { id: 'local-user', kind: 'human', displayName: 'You' },
+                  author: { id: 'local-user', kind: 'user', displayName: 'You' },
                   body: 'ignored seed',
                   createdAt: '2026-04-20T12:34:56.000Z',
                 },

--- a/packages/cli/src/formatters/document/templates/approved.hbs
+++ b/packages/cli/src/formatters/document/templates/approved.hbs
@@ -1,3 +1,3 @@
 # Review submitted
 
-The human reviewed {{#if source}}`{{source}}`{{else}}the content{{/if}} and left no annotations.
+The user reviewed {{#if source}}`{{source}}`{{else}}the content{{/if}} and left no annotations.

--- a/packages/cli/src/formatters/document/templates/changesRequested.hbs
+++ b/packages/cli/src/formatters/document/templates/changesRequested.hbs
@@ -1,5 +1,5 @@
 # Review submitted
 
-The human reviewed {{#if source}}`{{source}}`{{else}}the content{{/if}} and left the following comments. Read the comments and respond to the human conversationally — they may want edits, may want discussion, may be flagging things for later. Do not assume edits are required unless the human's comments make that clear.
+The user reviewed {{#if source}}`{{source}}`{{else}}the content{{/if}} and left the following comments. Read the comments and respond to the user conversationally — they may want edits, may want discussion, may be flagging things for later. Do not assume edits are required unless the user's comments make that clear.
 
 {{{body}}}

--- a/packages/cli/src/formatters/plan/templates.test.ts
+++ b/packages/cli/src/formatters/plan/templates.test.ts
@@ -16,7 +16,7 @@ describe('PLAN_TEMPLATES (plan-flavored formatAgentResponse output)', () => {
     expect(output).toMatchInlineSnapshot(`
 "# Plan review: approved
 
-The human reviewed this plan and approved it with no changes. Proceed to implement the plan as written — do not re-plan, re-summarize, or ask for further confirmation.
+The user reviewed this plan and approved it with no changes. Proceed to implement the plan as written — do not re-plan, re-summarize, or ask for further confirmation.
 "
 `);
   });
@@ -96,7 +96,7 @@ The human reviewed this plan and approved it with no changes. Proceed to impleme
     expect(output).toMatchInlineSnapshot(`
 "# Plan review: changes requested
 
-The human reviewed this plan and **did not approve it**. You MUST revise the plan to address every comment below, then submit the revised plan for another review before starting any implementation work.
+The user reviewed this plan and **did not approve it**. You MUST revise the plan to address every comment below, then submit the revised plan for another review before starting any implementation work.
 
 Rules:
 
@@ -108,10 +108,10 @@ Rules:
 ## General feedback
 
 > General guidance first.
-> — human, 2026-04-20T12:33:56Z
+> — user, 2026-04-20T12:33:56Z
 
 > Another global thread.
-> — human, 2026-04-20T12:36:56Z
+> — user, 2026-04-20T12:36:56Z
 
 ## Annotation (lines 9–12)
 
@@ -125,10 +125,10 @@ The comment below applies to the following section of the plan:
 \`\`\`\`
 
 > Let's add Stage C.
-> — human, 2026-04-20T12:34:56Z
+> — user, 2026-04-20T12:34:56Z
 
 > Reply: Agreed.
-> — human, 2026-04-20T12:35:56Z
+> — user, 2026-04-20T12:35:56Z
 "
 `);
   });

--- a/packages/cli/src/formatters/plan/templates/approved.hbs
+++ b/packages/cli/src/formatters/plan/templates/approved.hbs
@@ -1,3 +1,3 @@
 # Plan review: approved
 
-The human reviewed this plan and approved it with no changes. Proceed to implement the plan as written — do not re-plan, re-summarize, or ask for further confirmation.
+The user reviewed this plan and approved it with no changes. Proceed to implement the plan as written — do not re-plan, re-summarize, or ask for further confirmation.

--- a/packages/cli/src/formatters/plan/templates/changesRequested.hbs
+++ b/packages/cli/src/formatters/plan/templates/changesRequested.hbs
@@ -1,6 +1,6 @@
 # Plan review: changes requested
 
-The human reviewed this plan and **did not approve it**. You MUST revise the plan to address every comment below, then submit the revised plan for another review before starting any implementation work.
+The user reviewed this plan and **did not approve it**. You MUST revise the plan to address every comment below, then submit the revised plan for another review before starting any implementation work.
 
 Rules:
 

--- a/packages/shared/src/annotationSchema.ts
+++ b/packages/shared/src/annotationSchema.ts
@@ -76,7 +76,7 @@ export type StoredAnnotationAnchor = z.infer<typeof StoredAnnotationAnchorSchema
 
 export const CommentAuthorSchema = z.object({
   id: z.string().nonempty(),
-  kind: z.enum(['human', 'agent']),
+  kind: z.enum(['user', 'agent']),
   displayName: z.string().trim().nonempty(),
 });
 export type CommentAuthor = z.infer<typeof CommentAuthorSchema>;

--- a/packages/shared/src/testFactories.ts
+++ b/packages/shared/src/testFactories.ts
@@ -9,13 +9,13 @@ import type {
 
 export const LOCAL_AUTHOR = {
   id: 'local-user',
-  kind: 'human' as const,
+  kind: 'user' as const,
   displayName: 'You',
 };
 
 export const reviewer = Factory.define<CommentAuthor>(() => ({
   id: 'reviewer',
-  kind: 'human',
+  kind: 'user',
   displayName: 'Reviewer',
 }));
 


### PR DESCRIPTION
## Summary

The CLI's prompt templates referred to the in-the-loop reviewer as **"the human"**, which diverges from the `user` role label that Anthropic Messages, OpenAI chat completions, and most LLM training data use. This PR swaps "the human" → "the user" in the four `.hbs` templates fed to the model, and renames the underlying `CommentAuthor.kind` enum value `'human'` → `'user'` so the rendered `— <kind>, <timestamp>` attribution line — also part of the prompt — picks up the new noun.

Closes #84.

## Review focus

- **Enum rename scope.** Issue #84 originally scoped this narrowly to the 4 `.hbs` templates. During planning we extended it to the schema enum so the attribution line that `packages/cli/src/formatters/annotation/markdown.ts:62` interpolates from `author.kind` doesn't leave a residual "human" in prompt output. The enum has only two variants (`'human' | 'agent'`) and no runtime code branches on the value — but it's still a wire-format change in `@contextbridge/shared/annotationSchema`. No persisted JSON fixtures use the old value; if anything reads pre-existing serialized submissions, that's worth flagging.
- **Intentional omissions.** Commander `description` strings in `packages/cli/src/commands/{open,index,plan}.ts` still say "human" — they're CLI help text printed to a terminal, not prompts fed to a model, so they're out-of-scope per the issue's "non-prompt context" exclusion.

## Commits

- [`f07058f`](https://github.com/contextbridge/planbridge/pull/89/commits/f07058fb7799ed6a50650d5fd790ab28b3835965) — 4 `.hbs` templates, 6 enum sites (`annotationSchema.ts`, two test factories, runtime `LOCAL_AUTHOR`, Storybook story, one inline test fixture), and the `plan/templates.test.ts` inline snapshots (prose + 4 attribution lines).