### PR TITLE
refactor: narrow cli io surface

### DIFF
--- a/packages/cli/src/IoImpl.ts
+++ b/packages/cli/src/IoImpl.ts
@@ -1,24 +1,58 @@
 import type { Readable, Writable } from 'node:stream';
-import type { Public } from '@contextbridge/shared/types';
+import { readStreamToString } from '#src/streams.ts';
 
-export type Io = Public<IoImpl>;
+export interface Io {
+  readonly stdinIsTTY?: boolean;
+  readStdin(): Promise<string>;
+  writeStdout(chunk: string): void;
+  writeStderr(chunk: string): void;
+}
 
-export class IoImpl {
+type IoStreams = {
+  readonly stdout: Writable & Writer;
+  readonly stderr: Writable & Writer;
+  readonly stdin: Readable & Reader;
+};
+
+export interface Writer {
+  write(chunk: string): boolean | void;
+  readonly isTTY?: boolean;
+}
+
+export interface Reader extends AsyncIterable<string | Buffer> {
+  readonly isTTY?: boolean;
+}
+
+export class IoImpl implements Io, IoStreams {
   readonly stdout: Writable & { isTTY?: boolean };
   readonly stderr: Writable & { isTTY?: boolean };
   readonly stdin: Readable & { isTTY?: boolean };
 
-  constructor() {
+  constructor(streams: Partial<IoStreams> = {}) {
     // This is the one place that's allowed to touch the real process streams —
     // everything downstream receives them through ctx.io.
     /* eslint-disable no-restricted-properties */
-    const stdout = process.stdout;
-    const stderr = process.stderr;
-    const stdin = process.stdin;
+    const { stdout = process.stdout, stderr = process.stderr, stdin = process.stdin } = streams;
     /* eslint-enable no-restricted-properties */
 
     this.stdout = stdout;
     this.stderr = stderr;
     this.stdin = stdin;
+  }
+
+  get stdinIsTTY(): boolean | undefined {
+    return this.stdin.isTTY;
+  }
+
+  readStdin(): Promise<string> {
+    return readStreamToString(this.stdin);
+  }
+
+  writeStdout(chunk: string): void {
+    this.stdout.write(chunk);
+  }
+
+  writeStderr(chunk: string): void {
+    this.stderr.write(chunk);
   }
 }

--- a/packages/cli/src/IoImpl.ts
+++ b/packages/cli/src/IoImpl.ts
@@ -1,34 +1,41 @@
-import type { Readable, Writable } from 'node:stream';
+import { type Readable, type Writable } from 'node:stream';
 import { readStreamToString } from '#src/streams.ts';
 
+export interface Writer extends Writable {
+  readonly isTTY?: boolean;
+}
+
+export interface Reader extends Readable {
+  readonly isTTY?: boolean;
+}
+
 export interface Io {
+  /**
+   * Raw stdout stream. Prefer `writeStdout(chunk)` — this field exists for
+   * library adapters (clack, pino, CommandRunner wiring) and tests that need
+   * stream-level access. Handler code should not reach into it.
+   */
+  readonly stdout: Writer;
+  /**
+   * Raw stderr stream. Prefer `writeStderr(chunk)` — same rationale as `stdout`.
+   */
+  readonly stderr: Writer;
+  /**
+   * Raw stdin stream. Prefer `readStdin()` — same rationale as `stdout`.
+   */
+  readonly stdin: Reader;
   readonly stdinIsTTY?: boolean;
   readStdin(): Promise<string>;
   writeStdout(chunk: string): void;
   writeStderr(chunk: string): void;
 }
 
-type IoStreams = {
-  readonly stdout: Writable & Writer;
-  readonly stderr: Writable & Writer;
-  readonly stdin: Readable & Reader;
-};
+export class IoImpl implements Io {
+  readonly stdout: Writer;
+  readonly stderr: Writer;
+  readonly stdin: Reader;
 
-export interface Writer {
-  write(chunk: string): boolean | void;
-  readonly isTTY?: boolean;
-}
-
-export interface Reader extends AsyncIterable<string | Buffer> {
-  readonly isTTY?: boolean;
-}
-
-export class IoImpl implements Io, IoStreams {
-  readonly stdout: Writable & { isTTY?: boolean };
-  readonly stderr: Writable & { isTTY?: boolean };
-  readonly stdin: Readable & { isTTY?: boolean };
-
-  constructor(streams: Partial<IoStreams> = {}) {
+  constructor(streams: Partial<Pick<Io, 'stdout' | 'stderr' | 'stdin'>> = {}) {
     // This is the one place that's allowed to touch the real process streams —
     // everything downstream receives them through ctx.io.
     /* eslint-disable no-restricted-properties */

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -47,7 +47,7 @@ export function resolveCbCommand(program: Command, argv: string[]): string {
 function handleCommanderError(ctx: CliContext, err: CommanderError): number {
   const { io } = ctx;
   if (shouldPrintCommanderError(err)) {
-    io.stderr.write(`${err.message}\n`);
+    io.writeStderr(`${err.message}\n`);
   }
   return err.exitCode;
 }

--- a/packages/cli/src/commands/harnessOperation.ts
+++ b/packages/cli/src/commands/harnessOperation.ts
@@ -65,7 +65,7 @@ export async function runHarnessOperation(
   for (const installer of ALL_INSTALLERS) {
     const detection = detectHarness(ctx, installer.descriptor);
     if (!detection.binaryOnPath) {
-      io.stderr.write(
+      io.writeStderr(
         `${formatStatusLine({ descriptor: installer.descriptor, detected: false, installed: false, managed: [] })}\n`,
       );
       continue;
@@ -73,13 +73,13 @@ export async function runHarnessOperation(
 
     try {
       const status = await installer.status(ctx);
-      io.stderr.write(`${formatStatusLine(status)}\n`);
+      io.writeStderr(`${formatStatusLine(status)}\n`);
       if (status.detected) {
         detected.push({ installer, status });
       }
     } catch (err) {
       const { displayName, id } = installer.descriptor;
-      io.stderr.write(`${formatStatusFailureLine(displayName, err)}\n`);
+      io.writeStderr(`${formatStatusFailureLine(displayName, err)}\n`);
       if (!(err instanceof CommanderError)) {
         logger.error({ err, harness: id }, 'status failed');
       }
@@ -116,7 +116,7 @@ export async function runHarnessOperation(
         default: true,
       });
       if (!proceed) {
-        io.stderr.write(`${displayName}: skipped\n`);
+        io.writeStderr(`${displayName}: skipped\n`);
         continue;
       }
     }
@@ -137,7 +137,7 @@ export async function runHarnessOperation(
 
   const detectedNoun = `detected harness${detected.length === 1 ? '' : 'es'}`;
   const skippedSuffix = skippedCount > 0 ? ` (${skippedCount} ${labels.skippedNote}, skipped)` : '';
-  io.stderr.write(`${labels.pastTense} ${completedCount} of ${detected.length} ${detectedNoun}${skippedSuffix}.\n`);
+  io.writeStderr(`${labels.pastTense} ${completedCount} of ${detected.length} ${detectedNoun}${skippedSuffix}.\n`);
 
   if (failures.length > 0) {
     throw new CommanderError(1, labels.failureCode, `${labels.failureMessagePrefix}: ${failures.join(', ')}`);

--- a/packages/cli/src/commands/hookClaude.ts
+++ b/packages/cli/src/commands/hookClaude.ts
@@ -4,7 +4,6 @@ import { type Command, CommanderError } from 'commander';
 import { type RunAnnotationArgs, runAnnotation } from '#src/annotation/runAnnotation.ts';
 import type { CliContext } from '#src/context.ts';
 import { type ClaudeHookResponse, claudeHookResponse } from '#src/formatters/plan/claudeHookResponse.ts';
-import { readStreamToString } from '#src/streams.ts';
 import { type ClaudeHookPayload, ClaudeHookPayloadSchema } from './claudeHookSchema.ts';
 
 export interface HookClaudeDependencies {
@@ -17,7 +16,7 @@ export async function runHookClaude(ctx: CliContext, deps: HookClaudeDependencie
   const payload = await readAndValidatePayload(ctx);
   const response = await dispatchHookEvent(ctx, payload, deps);
 
-  io.stdout.write(`${JSON.stringify(response)}\n`);
+  io.writeStdout(`${JSON.stringify(response)}\n`);
 }
 
 export function registerHookClaude(ctx: CliContext, hookCommand: Command): void {
@@ -33,7 +32,7 @@ export function registerHookClaude(ctx: CliContext, hookCommand: Command): void 
 
 async function readAndValidatePayload(ctx: CliContext): Promise<ClaudeHookPayload> {
   const { io } = ctx;
-  const raw = await readStreamToString(io.stdin);
+  const raw = await io.readStdin();
 
   let parsed: unknown;
   try {

--- a/packages/cli/src/commands/hookCodex.ts
+++ b/packages/cli/src/commands/hookCodex.ts
@@ -6,7 +6,6 @@ import { ResultAsync, err, ok } from 'neverthrow';
 import { type RunAnnotationArgs, runAnnotation } from '#src/annotation/runAnnotation.ts';
 import type { CliContext } from '#src/context.ts';
 import { type CodexStopResponse, codexStopResponse } from '#src/formatters/plan/codexStopResponse.ts';
-import { readStreamToString } from '#src/streams.ts';
 import {
   type CodexStopHookPayload,
   CodexStopHookPayloadSchema,
@@ -32,7 +31,7 @@ export async function runHookCodex(ctx: CliContext, deps: HookCodexDependencies 
   const payload = await readAndValidatePayload(ctx);
   const response = await handleStop(ctx, payload, deps);
 
-  io.stdout.write(`${JSON.stringify(response ?? {})}\n`);
+  io.writeStdout(`${JSON.stringify(response ?? {})}\n`);
 }
 
 export function registerHookCodex(ctx: CliContext, hookCommand: Command): void {
@@ -66,7 +65,7 @@ export function extractLatestPlanFromTranscript(transcript: string, turnId: stri
 
 async function readAndValidatePayload(ctx: CliContext): Promise<CodexStopHookPayload> {
   const { io } = ctx;
-  const raw = await readStreamToString(io.stdin);
+  const raw = await io.readStdin();
 
   return safeJsonParse(raw)
     .mapErr((e) => `failed to parse hook event JSON: ${getErrorMessage(e)}`)

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -17,8 +17,8 @@ export function createProgram(ctx: CliContext): Command {
     .version(buildInfo.version)
     .exitOverride()
     .configureOutput({
-      writeOut: (s) => io.stdout.write(s),
-      writeErr: (s) => io.stderr.write(s),
+      writeOut: (s) => io.writeStdout(s),
+      writeErr: (s) => io.writeStderr(s),
     })
     .addHelpText('after', `\nDocs: ${QUICKSTART_URL}`);
 

--- a/packages/cli/src/commands/installStatus.ts
+++ b/packages/cli/src/commands/installStatus.ts
@@ -17,12 +17,12 @@ export async function runInstallStatus(ctx: CliContext, options: InstallStatusOp
   }
 
   if (json) {
-    io.stdout.write(`${JSON.stringify(statuses, null, 2)}\n`);
+    io.writeStdout(`${JSON.stringify(statuses, null, 2)}\n`);
     return;
   }
 
   for (const status of statuses) {
-    io.stderr.write(`${formatStatusLine(status)}\n`);
+    io.writeStderr(`${formatStatusLine(status)}\n`);
   }
 }
 

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -9,7 +9,6 @@ import {
 import type { CliContext } from '#src/context.ts';
 import { formatAgentResponse } from '#src/formatters/annotation/markdown.ts';
 import { DOCUMENT_TEMPLATES } from '#src/formatters/document/templates.ts';
-import { readStreamToString } from '#src/streams.ts';
 import { abort } from './abort.ts';
 
 export interface OpenArgs {
@@ -20,7 +19,7 @@ export async function runOpen(ctx: CliContext, args: OpenArgs, deps?: Annotation
   const { io, logger } = ctx;
   const { path: argPath } = args;
 
-  if (!argPath && io.stdin.isTTY === true) {
+  if (!argPath && io.stdinIsTTY === true) {
     abort(
       ctx,
       'open',
@@ -32,7 +31,7 @@ export async function runOpen(ctx: CliContext, args: OpenArgs, deps?: Annotation
   const source: 'file' | 'stdin' = argPath ? 'file' : 'stdin';
   let content: string;
   try {
-    content = argPath ? await Bun.file(argPath).text() : await readStreamToString(io.stdin);
+    content = argPath ? await Bun.file(argPath).text() : await io.readStdin();
   } catch (err) {
     abort(ctx, 'open', 'input', `failed to read content from ${source}: ${getErrorMessage(err)}`);
   }
@@ -51,7 +50,7 @@ export async function runOpen(ctx: CliContext, args: OpenArgs, deps?: Annotation
       { content, contentKind: 'document', entrypoint: 'open_command', sourcePath },
       deps,
     );
-    io.stdout.write(formatAgentResponse(DOCUMENT_TEMPLATES, submission, content, { sourcePath }));
+    io.writeStdout(formatAgentResponse(DOCUMENT_TEMPLATES, submission, content, { sourcePath }));
   } catch (err) {
     if (err instanceof AnnotationInterruptedError) {
       logger.info('open session interrupted');

--- a/packages/cli/src/commands/plan.ts
+++ b/packages/cli/src/commands/plan.ts
@@ -8,7 +8,6 @@ import {
 import type { CliContext } from '#src/context.ts';
 import { formatAgentResponse } from '#src/formatters/annotation/markdown.ts';
 import { PLAN_TEMPLATES } from '#src/formatters/plan/templates.ts';
-import { readStreamToString } from '#src/streams.ts';
 import { abort } from './abort.ts';
 
 export interface PlanArgs {
@@ -19,7 +18,7 @@ export async function runPlan(ctx: CliContext, args: PlanArgs, deps?: Annotation
   const { io, logger } = ctx;
   const { path } = args;
 
-  if (!path && io.stdin.isTTY === true) {
+  if (!path && io.stdinIsTTY === true) {
     abort(
       ctx,
       'plan',
@@ -31,7 +30,7 @@ export async function runPlan(ctx: CliContext, args: PlanArgs, deps?: Annotation
   const source: 'file' | 'stdin' = path ? 'file' : 'stdin';
   let content: string;
   try {
-    content = path ? await Bun.file(path).text() : await readStreamToString(io.stdin);
+    content = path ? await Bun.file(path).text() : await io.readStdin();
   } catch (err) {
     abort(ctx, 'plan', 'input', `failed to read plan from ${source}: ${getErrorMessage(err)}`);
   }
@@ -44,7 +43,7 @@ export async function runPlan(ctx: CliContext, args: PlanArgs, deps?: Annotation
 
   try {
     const submission = await runAnnotation(ctx, { content, contentKind: 'plan', entrypoint: 'plan_command' }, deps);
-    io.stdout.write(formatAgentResponse(PLAN_TEMPLATES, submission, content));
+    io.writeStdout(formatAgentResponse(PLAN_TEMPLATES, submission, content));
   } catch (err) {
     if (err instanceof AnnotationInterruptedError) {
       logger.info('plan review interrupted');

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -9,39 +9,39 @@ export async function runUpdate(ctx: CliContext): Promise<void> {
 
   const notice = await updater.checkForUpdate({ forceRefresh: true });
   if (!notice) {
-    io.stderr.write('contextbridge is up to date.\n');
+    io.writeStderr('contextbridge is up to date.\n');
     return;
   }
 
-  io.stderr.write(`A new version is available: v${notice.latestVersion} (you're on v${notice.currentVersion}).\n`);
-  io.stderr.write(`What's new: ${GITHUB_REPO_URL}/releases/tag/v${notice.latestVersion}\n`);
+  io.writeStderr(`A new version is available: v${notice.latestVersion} (you're on v${notice.currentVersion}).\n`);
+  io.writeStderr(`What's new: ${GITHUB_REPO_URL}/releases/tag/v${notice.latestVersion}\n`);
 
   const result = await updater.performUpdate();
   switch (result.status) {
     case 'refused':
-      io.stderr.write(`${result.message}\n`);
+      io.writeStderr(`${result.message}\n`);
       throw new CommanderError(1, `contextbridge.update.${result.reason}`, result.message);
 
     case 'recovery-needed':
       logger.warn(result.diagnostics, 'update: could not detect install method');
-      io.stderr.write(`${result.message}\n\n`);
+      io.writeStderr(`${result.message}\n\n`);
       for (const command of result.fallbackCommands) {
-        io.stdout.write(`${command}\n`);
+        io.writeStdout(`${command}\n`);
       }
       throw new CommanderError(1, `contextbridge.update.${result.reason}`, result.message);
 
     case 'skipped-already-latest':
-      io.stderr.write(`contextbridge is up to date (v${result.currentVersion}).\n`);
+      io.writeStderr(`contextbridge is up to date (v${result.currentVersion}).\n`);
       return;
 
     case 'executed':
       await refreshInstalledHarnesses(ctx);
-      io.stderr.write('✓ update complete.\n');
+      io.writeStderr('✓ update complete.\n');
       return;
 
     case 'error':
       logger.error({ cause: result.cause }, result.message);
-      io.stderr.write(`${result.message}\n`);
+      io.writeStderr(`${result.message}\n`);
       throw new CommanderError(1, 'contextbridge.update.unexpected', result.message);
 
     default:

--- a/packages/cli/src/harnesses/ClaudeInstaller.ts
+++ b/packages/cli/src/harnesses/ClaudeInstaller.ts
@@ -84,13 +84,13 @@ export class ClaudeInstaller extends ScopedHarnessInstaller {
         '--scope',
         scope,
       ]);
-      io.stderr.write(
+      io.writeStderr(
         `PlanBridge plugin renamed from ${CLAUDE_LEGACY_PLUGIN_ID} to ${CLAUDE_PLUGIN_ID} — migrated automatically.\n`,
       );
     }
 
-    io.stderr.write(`✓ PlanBridge plugin installed for Claude Code (scope: ${scope}).\n`);
-    io.stderr.write(`Restart Claude Code for the plugin to load.\n`);
+    io.writeStderr(`✓ PlanBridge plugin installed for Claude Code (scope: ${scope}).\n`);
+    io.writeStderr(`Restart Claude Code for the plugin to load.\n`);
   }
 
   protected async runUninstall(ctx: CliContext, scope: InstallScope): Promise<void> {
@@ -120,7 +120,7 @@ export class ClaudeInstaller extends ScopedHarnessInstaller {
       logger.info(`${CLAUDE_MARKETPLACE_NAME} marketplace is not configured; skipping marketplace remove`);
     }
 
-    io.stderr.write(`✓ PlanBridge plugin removed from Claude Code (scope: ${scope}).\n`);
+    io.writeStderr(`✓ PlanBridge plugin removed from Claude Code (scope: ${scope}).\n`);
   }
 }
 

--- a/packages/cli/src/harnesses/CodexInstaller.ts
+++ b/packages/cli/src/harnesses/CodexInstaller.ts
@@ -81,15 +81,15 @@ export class CodexInstaller extends ScopedHarnessInstaller {
       await writeSkill(ctx, skill);
     }
 
-    io.stderr.write(`✓ PlanBridge hook installed for Codex CLI (scope: ${scope}).\n`);
-    io.stderr.write(`Action required: PlanBridge will not run in Codex until this hook is trusted.\n`);
-    io.stderr.write(
+    io.writeStderr(`✓ PlanBridge hook installed for Codex CLI (scope: ${scope}).\n`);
+    io.writeStderr(`Action required: PlanBridge will not run in Codex until this hook is trusted.\n`);
+    io.writeStderr(
       `Restart Codex CLI, open /hooks, verify the Stop hook runs \`${CODEX_HOOK_COMMAND}\`, and press t.\n`,
     );
-    io.stderr.write(`Walkthrough: https://plan.contextbridge.ai/usage/codex/#trust-the-codex-hook\n`);
+    io.writeStderr(`Walkthrough: https://plan.contextbridge.ai/usage/codex/#trust-the-codex-hook\n`);
     for (const { name } of bundledSkills) {
-      io.stderr.write(`✓ PlanBridge skill installed at ~/${AGENTS_SKILLS_DIR}/${skillId(name)}/SKILL.md.\n`);
-      io.stderr.write(`Invoke in Codex as $${skillId(name)}.\n`);
+      io.writeStderr(`✓ PlanBridge skill installed at ~/${AGENTS_SKILLS_DIR}/${skillId(name)}/SKILL.md.\n`);
+      io.writeStderr(`Invoke in Codex as $${skillId(name)}.\n`);
     }
   }
 
@@ -101,12 +101,12 @@ export class CodexInstaller extends ScopedHarnessInstaller {
       await removePlanBridgeHook(join(configDir, 'hooks.json'));
     }
 
-    io.stderr.write(`✓ PlanBridge hook removed from Codex CLI (scope: ${scope}).\n`);
+    io.writeStderr(`✓ PlanBridge hook removed from Codex CLI (scope: ${scope}).\n`);
 
     if (scope === 'user') {
       for (const { name } of bundledSkills) {
         await removeSkill(ctx, name);
-        io.stderr.write(`✓ PlanBridge skill removed from ~/${AGENTS_SKILLS_DIR}/${skillId(name)}/.\n`);
+        io.writeStderr(`✓ PlanBridge skill removed from ~/${AGENTS_SKILLS_DIR}/${skillId(name)}/.\n`);
       }
     }
   }

--- a/packages/cli/src/prompter.ts
+++ b/packages/cli/src/prompter.ts
@@ -5,7 +5,7 @@ import {
   select as clackSelect,
 } from '@clack/prompts';
 import { CommanderError } from 'commander';
-import type { Io } from '#src/IoImpl.ts';
+import type { Io, IoImpl } from '#src/IoImpl.ts';
 
 export const PROMPTER_CANCELLED_CODE = 'contextbridge.prompter.cancelled';
 export const PROMPTER_NON_TTY_CODE = 'contextbridge.prompter.nonTty';
@@ -34,7 +34,7 @@ export interface Prompter {
   select<T extends SelectValue>(options: SelectOptions<T>): Promise<T>;
 }
 
-export function createClackPrompter(io: Io): Prompter {
+export function createClackPrompter(io: IoImpl): Prompter {
   return {
     async confirm({ message, default: defaultValue = true }) {
       assertTty(io);
@@ -72,7 +72,7 @@ export function createClackPrompter(io: Io): Prompter {
 }
 
 function assertTty(io: Io): void {
-  if (!io.stdin.isTTY) {
+  if (io.stdinIsTTY !== true) {
     throw new CommanderError(
       1,
       PROMPTER_NON_TTY_CODE,

--- a/packages/cli/src/prompter.ts
+++ b/packages/cli/src/prompter.ts
@@ -5,7 +5,7 @@ import {
   select as clackSelect,
 } from '@clack/prompts';
 import { CommanderError } from 'commander';
-import type { Io, IoImpl } from '#src/IoImpl.ts';
+import type { Io } from '#src/IoImpl.ts';
 
 export const PROMPTER_CANCELLED_CODE = 'contextbridge.prompter.cancelled';
 export const PROMPTER_NON_TTY_CODE = 'contextbridge.prompter.nonTty';
@@ -34,7 +34,7 @@ export interface Prompter {
   select<T extends SelectValue>(options: SelectOptions<T>): Promise<T>;
 }
 
-export function createClackPrompter(io: IoImpl): Prompter {
+export function createClackPrompter(io: Io): Prompter {
   return {
     async confirm({ message, default: defaultValue = true }) {
       assertTty(io);

--- a/packages/cli/src/streams.ts
+++ b/packages/cli/src/streams.ts
@@ -1,4 +1,4 @@
-export async function readStreamToString(stream: NodeJS.ReadableStream): Promise<string> {
+export async function readStreamToString(stream: AsyncIterable<string | Buffer>): Promise<string> {
   const chunks: Buffer[] = [];
   for await (const chunk of stream) {
     chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk);

--- a/packages/cli/src/testHelpers/FakeIo.ts
+++ b/packages/cli/src/testHelpers/FakeIo.ts
@@ -1,19 +1,17 @@
 import { PassThrough } from 'node:stream';
-import type { Io } from '#src/IoImpl.ts';
-import { MemoryStream } from './index.ts';
+import { IoImpl } from '#src/IoImpl.ts';
+import { MemoryStream } from './MemoryStream.ts';
 
-export class FakeIo implements Io {
-  readonly stdout: MemoryStream;
-  readonly stderr: MemoryStream;
-  readonly stdin: PassThrough & { isTTY?: boolean };
+export class FakeIo extends IoImpl {
+  declare readonly stdout: MemoryStream;
+  declare readonly stderr: MemoryStream;
+  declare readonly stdin: PassThrough & { isTTY?: boolean };
 
   constructor() {
     const stdout = new MemoryStream();
     const stderr = new MemoryStream();
     const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
 
-    this.stdout = stdout;
-    this.stderr = stderr;
-    this.stdin = stdin;
+    super({ stdout, stderr, stdin });
   }
 }

--- a/packages/cli/src/testHelpers/FakeIo.ts
+++ b/packages/cli/src/testHelpers/FakeIo.ts
@@ -1,17 +1,32 @@
 import { PassThrough } from 'node:stream';
-import { IoImpl } from '#src/IoImpl.ts';
+import { type Io } from '#src/IoImpl.ts';
+import { readStreamToString } from '#src/streams.ts';
 import { MemoryStream } from './MemoryStream.ts';
 
-export class FakeIo extends IoImpl {
-  declare readonly stdout: MemoryStream;
-  declare readonly stderr: MemoryStream;
-  declare readonly stdin: PassThrough & { isTTY?: boolean };
+export class FakeIo implements Io {
+  readonly stdout: MemoryStream;
+  readonly stderr: MemoryStream;
+  readonly stdin: PassThrough & { isTTY?: boolean };
 
   constructor() {
-    const stdout = new MemoryStream();
-    const stderr = new MemoryStream();
-    const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+    this.stdout = new MemoryStream();
+    this.stderr = new MemoryStream();
+    this.stdin = new PassThrough();
+  }
 
-    super({ stdout, stderr, stdin });
+  get stdinIsTTY(): boolean | undefined {
+    return this.stdin.isTTY;
+  }
+
+  readStdin(): Promise<string> {
+    return readStreamToString(this.stdin);
+  }
+
+  writeStdout(chunk: string): void {
+    this.stdout.write(chunk);
+  }
+
+  writeStderr(chunk: string): void {
+    this.stderr.write(chunk);
   }
 }


### PR DESCRIPTION
## Summary

Narrow the handler-facing CLI IO contract so command code depends on explicit stdin/stdout/stderr helpers instead of the full Node stream surface. Keep full streams available at the library-glue boundaries for pino, clack, and child-process wiring.

## Review focus

The main trade-off is that createClackPrompter accepts the concrete IoImpl because clack needs real stream objects, while CliContext.io exposes only the narrow public Io interface to handlers. FakeIo remains stream-backed by extending IoImpl, which avoids duplicate adapter behavior while preserving realistic tests.

## Commits

- [363cf0c](https://github.com/contextbridge/planbridge/commit/363cf0cba6ef1e8ceec3b54ded7b5c42eb5ad59e) — narrow the CLI IO surface and simplify the fake