### PR TITLE
fix: let plain link clicks navigate instead of opening the annotation popover

### DIFF
--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -282,6 +282,88 @@ describe('App', () => {
     expect(link).toHaveAttribute('rel', 'noreferrer');
   });
 
+  it('lets a plain click on a link navigate without opening the annotation popover', async () => {
+    const user = userEvent.setup();
+    renderApp({
+      initialPayload: { contentKind: 'plan', content: 'Check [the docs](https://example.com) for details.' },
+    });
+
+    const link = await screen.findByRole('link', { name: 'the docs' });
+    await waitFor(() => {
+      expect(link).toHaveAttribute('data-target-id');
+    });
+
+    let defaultPrevented: boolean | undefined;
+    link.addEventListener(
+      'click',
+      (event) => {
+        defaultPrevented = event.defaultPrevented;
+        event.preventDefault();
+      },
+      { once: true },
+    );
+
+    await user.click(link);
+
+    expect(defaultPrevented).toBe(false);
+    expect(screen.queryByTestId(annotationPopoverTestIds.container)).not.toBeInTheDocument();
+  });
+
+  it('opens the annotation popover when text inside a link is drag-selected', async () => {
+    renderApp({
+      initialPayload: { contentKind: 'plan', content: 'Check [the docs](https://example.com) for details.' },
+    });
+
+    const link = await screen.findByRole('link', { name: 'the docs' });
+    const text = link.firstChild as Text;
+
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, text.length);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    fireEvent.mouseUp(screen.getByTestId(annotatedMarkdownTestIds.container));
+
+    expect(await screen.findByTestId(annotationPopoverTestIds.container)).toBeInTheDocument();
+  });
+
+  it('clicking a link that already has an annotation opens the editor instead of navigating', async () => {
+    const user = userEvent.setup();
+    renderApp({
+      initialPayload: { contentKind: 'plan', content: 'Check [the docs](https://example.com) for details.' },
+    });
+
+    const link = await screen.findByRole('link', { name: 'the docs' });
+    const text = link.firstChild as Text;
+
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, text.length);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    fireEvent.mouseUp(screen.getByTestId(annotatedMarkdownTestIds.container));
+    await screen.findByTestId(annotationPopoverTestIds.container);
+
+    await user.type(screen.getByTestId(annotationPopoverTestIds.textarea), 'Link comment');
+    await user.click(screen.getByTestId(annotationPopoverTestIds.saveButton));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(annotationPopoverTestIds.container)).not.toBeInTheDocument();
+    });
+
+    const rect = link.getBoundingClientRect();
+    fireEvent.click(link, {
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + rect.height / 2,
+    });
+
+    expect(await screen.findByTestId(annotationPopoverTestIds.container)).toBeInTheDocument();
+    expect(screen.getByTestId(annotationPopoverTestIds.textarea)).toHaveValue('Link comment');
+  });
+
   it('sets the document title from the payload title', async () => {
     renderApp({
       initialPayload: { contentKind: 'plan', content: '# My Plan\n\nbody', title: 'My Plan' },

--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -10,7 +10,7 @@ import { annotationPopoverTestIds } from './AnnotationPopover.tsx';
 import { appTestIds } from './App.tsx';
 import { globalCommentComposerTestIds } from './GlobalCommentComposer.tsx';
 import { submitBarTestIds } from './SubmitBar.tsx';
-import { renderApp } from './testHelpers/renderApp.tsx';
+import { drag, renderApp } from './testHelpers/index.tsx';
 import { updateNoticeCardTestIds } from './UpdateNoticeCard.tsx';
 
 describe('App', () => {
@@ -219,14 +219,7 @@ describe('App', () => {
     const stringToken = document.querySelector<HTMLElement>('pre code.hljs .hljs-string')!;
     const text = stringToken.firstChild as Text;
 
-    const range = document.createRange();
-    range.setStart(text, 3);
-    range.setEnd(text, 5);
-    const selection = window.getSelection()!;
-    selection.removeAllRanges();
-    selection.addRange(range);
-
-    fireEvent.mouseUp(screen.getByTestId(annotatedMarkdownTestIds.container));
+    drag({ target: text, from: 3, to: 5 });
 
     await screen.findByTestId(annotationPopoverTestIds.container);
 
@@ -317,14 +310,7 @@ describe('App', () => {
     const link = await screen.findByRole('link', { name: 'the docs' });
     const text = link.firstChild as Text;
 
-    const range = document.createRange();
-    range.setStart(text, 0);
-    range.setEnd(text, text.length);
-    const selection = window.getSelection()!;
-    selection.removeAllRanges();
-    selection.addRange(range);
-
-    fireEvent.mouseUp(screen.getByTestId(annotatedMarkdownTestIds.container));
+    drag({ target: text, from: 0, to: text.length });
 
     expect(await screen.findByTestId(annotationPopoverTestIds.container)).toBeInTheDocument();
   });
@@ -338,13 +324,7 @@ describe('App', () => {
     const link = await screen.findByRole('link', { name: 'the docs' });
     const text = link.firstChild as Text;
 
-    const range = document.createRange();
-    range.setStart(text, 0);
-    range.setEnd(text, text.length);
-    const selection = window.getSelection()!;
-    selection.removeAllRanges();
-    selection.addRange(range);
-    fireEvent.mouseUp(screen.getByTestId(annotatedMarkdownTestIds.container));
+    drag({ target: text, from: 0, to: text.length });
     await screen.findByTestId(annotationPopoverTestIds.container);
 
     await user.type(screen.getByTestId(annotationPopoverTestIds.textarea), 'Link comment');

--- a/packages/annotation/src/demo/samplePlans.ts
+++ b/packages/annotation/src/demo/samplePlans.ts
@@ -5,7 +5,7 @@ This change consolidates our session-token handling into a single well-tested mo
 ## Goals
 
 - Eliminate the three duplicated JWT-parsing code paths that drifted over the last year.
-- Introduce a Zod-validated cookie schema so malformed tokens surface with actionable errors.
+- Introduce a [Zod](https://zod.dev)-validated cookie schema so malformed tokens surface with actionable errors.
 - Give the security team a single integration point for future changes (rotation, revocation, audit logging).
 
 ## Non-goals

--- a/packages/annotation/src/testHelpers/index.tsx
+++ b/packages/annotation/src/testHelpers/index.tsx
@@ -1,5 +1,6 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { RenderResult } from '@testing-library/react';
+import { annotatedMarkdownTestIds } from '../AnnotatedMarkdown.tsx';
 import type { AppProps } from '../App.tsx';
 import { App } from '../App.tsx';
 import type { AnnotationAppContext as AnnotationAppContextValue } from '../useAppContext.ts';
@@ -23,4 +24,25 @@ export function renderApp(
     </ErrorBoundary>,
   );
   return { result, ...fake };
+}
+
+type DragArgs = {
+  target: Text;
+  from: number;
+  to: number;
+};
+
+export function drag({ target, from, to }: DragArgs): void {
+  const range = document.createRange();
+  range.setStart(target, from);
+  range.setEnd(target, to);
+
+  const selection = window.getSelection();
+  if (!selection) {
+    throw new Error('Expected browser selection API to be available.');
+  }
+
+  selection.removeAllRanges();
+  selection.addRange(range);
+  fireEvent.mouseUp(screen.getByTestId(annotatedMarkdownTestIds.container));
 }

--- a/packages/annotation/src/useTargetActivation.ts
+++ b/packages/annotation/src/useTargetActivation.ts
@@ -69,6 +69,10 @@ export function useTargetActivation(args: {
         return;
       }
 
+      if (shouldDeferToDefaultAction(source)) {
+        return;
+      }
+
       const range = resolveTokenRange(source, container) ?? index.targetToRange(target.id);
       if (!range) {
         return;
@@ -135,6 +139,22 @@ function resolveTokenRange(source: EventTarget | null, container: HTMLElement): 
   const range = document.createRange();
   range.selectNodeContents(token);
   return range;
+}
+
+function shouldDeferToDefaultAction(source: EventTarget | null): boolean {
+  if (!(source instanceof Element)) {
+    return false;
+  }
+  return isLink(source) && hasCollapsedSelection();
+}
+
+function isLink(element: Element): boolean {
+  return element.closest('a[href]') !== null;
+}
+
+function hasCollapsedSelection(): boolean {
+  const selection = window.getSelection();
+  return !selection || selection.isCollapsed;
 }
 
 function clearTargetActivationState(container: HTMLElement | null): void {


### PR DESCRIPTION
## Summary

In the annotation UI, clicking a rendered markdown link opened the comment popover instead of following the link, because every annotatable element — links included — was being intercepted by the activation hook. This fix adds a single bail-out in `useTargetActivation.activate()`: when the click/keypress source is inside an `<a href>` and there is no active text selection, return early so the browser runs its native navigation. Drag-selecting across link text still opens the annotation popover via the existing `mouseUp` selection path, and clicking a link that already carries an annotation still opens the editor (via the unrelated `handleClickCapture` in `useAnnotationInteractions`).

Closes #90.

## Review focus

- **The bail-out predicate.** `shouldDeferToDefaultAction` is structured as positive composition (`isLink(source) && hasCollapsedSelection()`) so a future GFM checkbox / `<details>` case can slot in as a sibling predicate. Today it only matches `a[href]`.
- **Why a selection check at all.** Browsers don't fire `click` after a drag with different mousedown/mouseup targets, so in practice the collapsed-selection guard isn't strictly necessary for the drag-to-annotate path — but it's the honest expression of intent ("step aside only when the user appears to want navigation, not annotation") and cheap.
- **Test coverage gap exposed.** The new "click on an already-annotated link opens the editor" test is the first case to exercise `useAnnotationInteractions.handleClickCapture` end-to-end. It needed `fireEvent.click` with explicit bounding-rect coords rather than `user.click(link)`, because `user.click` wasn't pinning `caretPositionFromPoint` into the link's text node in the headless vitest/Chromium environment. Flagged here in case anyone has a cleaner way.
- **Keyboard accessibility.** The activate path is shared with `handleKeyDown` (Enter/Space), so a focused link's Enter key now navigates rather than annotating — matching the native `<a href>` behavior. This removes the only keyboard-driven way to annotate a bare link; the design direction in the issue accepts that ("drag across the link to annotate").
- **Manual test fixture.** Adds a single markdown link to `samplePlans.ts` (Goals section, "Zod") so the `Plan/App > Default` Storybook story exercises the three scenarios end-to-end: click navigates, drag-select annotates, click on the now-annotated link reopens the editor.

## Commits

- [\`4bb4ce2\`](https://github.com/contextbridge/planbridge/commit/4bb4ce2b08bc2ecb4cec1c8d609e297e8b98e9ab) — fix: let plain link clicks navigate instead of opening the annotation popover
- [\`56fdc35\`](https://github.com/contextbridge/planbridge/commit/56fdc35535e65bf609dad2a1d4f04a4f115279d0) — chore(annotation): add a markdown link to samplePlan for manual testing