### PR TITLE
chore: include .tsx in prettier format scripts and sweep existing drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "typecheck": "bun run --filter '*' typecheck",
     "lint": "eslint . --max-warnings 0 --cache --ignore-pattern 'tools/**'",
     "lint:fix": "eslint . --fix --cache --ignore-pattern 'tools/**'",
-    "format": "prettier --write \"**/*.{ts,md,json}\"",
-    "format:check": "prettier --check \"**/*.{ts,md,json}\"",
+    "format": "prettier --write \"**/*.{ts,tsx,md,json}\"",
+    "format:check": "prettier --check \"**/*.{ts,tsx,md,json}\"",
     "synth:projen": "test -f tools/projen/package.json || (echo 'Private tools submodule is not initialized. Run: just tools-init' >&2; exit 1); bun run --cwd tools/projen synth"
   },
   "prettier": "@contextbridge-ai/prettier-config",

--- a/packages/annotation/src/App.stories.tsx
+++ b/packages/annotation/src/App.stories.tsx
@@ -136,7 +136,10 @@ export const Default: Story = {
       {...rest}
       initialPayload={
         initialPayload
-          ? { ...initialPayload, metadata: { entrypoint: source ?? initialPayload.metadata?.entrypoint ?? 'plan_command' } }
+          ? {
+              ...initialPayload,
+              metadata: { entrypoint: source ?? initialPayload.metadata?.entrypoint ?? 'plan_command' },
+            }
           : undefined
       }
     />

--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -151,7 +151,9 @@ describe('App', () => {
 
   it('shows Codex-specific handoff notice on approval when source is hook_codex', async () => {
     const user = userEvent.setup();
-    renderApp({ initialPayload: { contentKind: 'plan', content: '# Ship it', metadata: { entrypoint: 'hook_codex' } } });
+    renderApp({
+      initialPayload: { contentKind: 'plan', content: '# Ship it', metadata: { entrypoint: 'hook_codex' } },
+    });
 
     await user.click(screen.getByTestId(submitBarTestIds.button));
 
@@ -161,7 +163,9 @@ describe('App', () => {
 
   it('shows default countdown for hook_codex when changes are requested', async () => {
     const user = userEvent.setup();
-    renderApp({ initialPayload: { contentKind: 'plan', content: '# Ship it', metadata: { entrypoint: 'hook_codex' } } });
+    renderApp({
+      initialPayload: { contentKind: 'plan', content: '# Ship it', metadata: { entrypoint: 'hook_codex' } },
+    });
 
     await user.type(screen.getByTestId(globalCommentComposerTestIds.textarea), 'Needs work');
     await user.click(screen.getByTestId(submitBarTestIds.button));
@@ -174,7 +178,9 @@ describe('App', () => {
 
   it('shows default countdown for hook_claude approval', async () => {
     const user = userEvent.setup();
-    renderApp({ initialPayload: { contentKind: 'plan', content: '# Ship it', metadata: { entrypoint: 'hook_claude' } } });
+    renderApp({
+      initialPayload: { contentKind: 'plan', content: '# Ship it', metadata: { entrypoint: 'hook_claude' } },
+    });
 
     await user.click(screen.getByTestId(submitBarTestIds.button));
 
@@ -336,10 +342,12 @@ describe('App', () => {
   it('does not let a long fenced code block overflow into the sidebar', async () => {
     const longLine = 'x'.repeat(500);
     renderApp({
-      initialPayload: { contentKind: 'plan', content: `# Plan
+      initialPayload: {
+        contentKind: 'plan',
+        content: `# Plan
 
 \`\`\`ts
-const a = "${longLine }";
+const a = "${longLine}";
 \`\`\`
 `,
       },
@@ -356,9 +364,11 @@ const a = "${longLine }";
   it('does not let a long inline code span overflow into the sidebar', async () => {
     const longCode = 'x'.repeat(500);
     renderApp({
-      initialPayload: { contentKind: 'plan', content: `# Plan
+      initialPayload: {
+        contentKind: 'plan',
+        content: `# Plan
 
-Run \`${longCode }\` now.
+Run \`${longCode}\` now.
 `,
       },
     });

--- a/packages/annotation/src/SubmitBar.tsx
+++ b/packages/annotation/src/SubmitBar.tsx
@@ -39,9 +39,7 @@ export function SubmitBar({ submission, source }: SubmitBarProps) {
               <strong className="block" data-testid={submitBarTestIds.codexHandoffNotice}>
                 Return to Codex to confirm implementation.
               </strong>
-              <span>
-                This window will close in {formatCountdownLabel(submission.closeCountdownSeconds)}.
-              </span>
+              <span>This window will close in {formatCountdownLabel(submission.closeCountdownSeconds)}.</span>
             </>
           ) : (
             `This window will close in ${formatCountdownLabel(submission.closeCountdownSeconds)}.`

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -37,12 +37,7 @@ export function Header({ version, docsHref, feedbackHref, githubRepoHref, slackH
         <span className="text-xs tabular-nums text-muted-foreground" data-testid={headerTestIds.version}>
           v{version}
         </span>
-        <Button
-          asChild
-          data-testid={headerTestIds.feedbackButton}
-          size="xs"
-          variant="default"
-        >
+        <Button asChild data-testid={headerTestIds.feedbackButton} size="xs" variant="default">
           <a href={feedbackHref} rel="noopener noreferrer" target="_blank">
             <MessageSquare className="size-3" />
             Feedback


### PR DESCRIPTION
## Summary

The root `format` / `format:check` scripts globbed `**/*.{ts,md,json}` — no `.tsx` — so component and test files could drift out of Prettier compliance without `just verify` noticing. The pre-commit hook (`prettier --write --ignore-unknown` on staged files of type `text`) runs a stricter scope, so the moment any tsx file got touched in a PR the hook reformatted it, polluting unrelated diffs (most recently #92).

This widens the glob to `{ts,tsx,md,json}` and applies the sweep that result demands. All non-config changes are pure whitespace/line-wrap.

## Review focus

- **`package.json:16-17`** — the actual fix, two-character glob change.
- **Four reformatted files** — `App.stories.tsx`, `App.test.tsx`, `SubmitBar.tsx`, `Header.tsx`. Skim the diff and confirm no behavior changes (just line-wrapping at the project's print width).
- **Other extensions** — left out intentionally (`.jsx`, `.mjs`, `.yaml`, `.mdx` etc. don't exist in this repo today). If/when they appear, expand the glob then.

## Commits

- [\`6f0afe6\`](https://github.com/contextbridge/planbridge/commit/6f0afe6def9e974e045296204a0a9f137aef85bc) — chore: include .tsx in prettier format scripts and sweep existing drift