### PR TITLE
refactor(cli): make handlers ResultAsync<void, AbortError> end-to-end

### DIFF
--- a/.contextbridge/rules/testing-patterns.md
+++ b/.contextbridge/rules/testing-patterns.md
@@ -45,3 +45,5 @@ globs: ["packages/**/*.test.ts", "packages/**/*.test.tsx", "packages/**/*TestIds
   import { annotationPopoverTestIds } from './AnnotationPopover.tsx';
   screen.getByTestId(annotationPopoverTestIds.textarea);
   ```
+
+- **Use shared Result assertion helpers for neverthrow handlers.** When testing code that returns `Result` or `ResultAsync`, import `expectOk`, `expectOkValue`, or `expectErr` from the package's test helpers instead of using `.rejects` or repeating local `isOk()` / `isErr()` helpers. This keeps neverthrow tests explicit and consistent.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -6,7 +6,13 @@ import { describe, expect, it } from 'bun:test';
 import { Command } from 'commander';
 import { CLAUDE_MARKETPLACE_NAME, CLAUDE_PLUGIN_ID } from '#src/installers/ClaudeInstaller.ts';
 import { environment } from '#src/testFactories.ts';
-import { createStubContext, primeClaudeShellouts, readErrorLogs, stubClaudeState } from '#src/testHelpers/index.ts';
+import {
+  createStubContext,
+  primeClaudeShellouts,
+  readErrorLogs,
+  readWarnLogs,
+  stubClaudeState,
+} from '#src/testHelpers/index.ts';
 import { resolveCbCommand, runCli } from './cli.ts';
 
 const CLAUDE_BINARY = getHarness('claude').binaryName;
@@ -75,7 +81,8 @@ describe('runCli', () => {
 
     expect(exitCode).toBe(1);
     expect(io.stdout.text()).toBe('');
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('unsupported hook_event_name: PreToolUse'))).toBe(true);
+    expect(readWarnLogs(logs).some((r) => r.msg.includes('unsupported hook_event_name: PreToolUse'))).toBe(true);
+    expect(readErrorLogs(logs)).toEqual([]);
   });
 
   it('surfaces unknown flags on hook claude as a CommanderError', async () => {

--- a/packages/cli/src/commands/abort.ts
+++ b/packages/cli/src/commands/abort.ts
@@ -1,18 +1,74 @@
+import { getErrorMessage } from '@contextbridge/shared/errors';
 import { CommanderError } from 'commander';
+import { ResultAsync } from 'neverthrow';
 import type { CliContext } from '#src/context.ts';
 
-/**
- * Log and throw a CommanderError for a user-recoverable ('input') or runtime
- * failure inside a subcommand handler.
- */
-export function abort(ctx: CliContext, command: string, kind: 'input' | 'runtime', message: string): never {
-  const { logger } = ctx;
-  // 'input' is user-recoverable — logged at warn so Sentry's pinoIntegration
-  // (error/fatal only) doesn't forward it. 'runtime' is a genuine failure.
-  if (kind === 'input') {
-    logger.warn(message);
-  } else {
-    logger.error(message);
+export type AbortKind = 'input' | 'runtime' | 'cancelled';
+export type AbortLevel = 'warn' | 'error';
+
+interface AbortErrorOptions {
+  readonly code?: string;
+  readonly exitCode?: number;
+}
+
+export class AbortError extends CommanderError {
+  readonly kind: AbortKind;
+  readonly level: AbortLevel;
+
+  constructor(command: string, kind: AbortKind, message: string, options: AbortErrorOptions = {}) {
+    const { code = `contextbridge.${command}.${kind}Error`, exitCode = kind === 'cancelled' ? 130 : 1 } = options;
+    super(exitCode, code, message);
+    this.kind = kind;
+    this.level = kind === 'runtime' ? 'error' : 'warn';
   }
-  throw new CommanderError(1, `contextbridge.${command}.${kind}Error`, message);
+
+  static input(command: string, message: string, options?: AbortErrorOptions): AbortError {
+    return new AbortError(command, 'input', message, options);
+  }
+
+  static runtime(command: string, message: string, options?: AbortErrorOptions): AbortError {
+    return new AbortError(command, 'runtime', message, options);
+  }
+
+  static cancelled(command: string, message: string, options?: AbortErrorOptions): AbortError {
+    return new AbortError(command, 'cancelled', message, options);
+  }
+}
+
+export function logAbortError(
+  ctx: CliContext,
+  err: AbortError,
+  message = err.message,
+  fields: Record<string, unknown> = {},
+): void {
+  const { logger } = ctx;
+  if (Object.keys(fields).length === 0) {
+    logger[err.level](message);
+    return;
+  }
+  logger[err.level]({ ...fields, err }, message);
+}
+
+export function throwLoggedAbort(ctx: CliContext, err: AbortError): never {
+  logAbortError(ctx, err);
+  throw err;
+}
+
+/**
+ * Commander action boundary: business logic returns ResultAsync, but commander
+ * still expects thrown CommanderError instances to drive exit codes.
+ */
+export function handleCommandResult<T>(ctx: CliContext, result: ResultAsync<T, AbortError>): Promise<T> {
+  return result.match(
+    (value) => value,
+    (err) => throwLoggedAbort(ctx, err),
+  );
+}
+
+export function toAbortError(command: string): (err: unknown) => AbortError {
+  return (err) => (err instanceof AbortError ? err : AbortError.runtime(command, getErrorMessage(err)));
+}
+
+export function abortable<T>(command: string, promise: Promise<T>): ResultAsync<T, AbortError> {
+  return ResultAsync.fromPromise(promise, toAbortError(command));
 }

--- a/packages/cli/src/commands/harnessOperation.ts
+++ b/packages/cli/src/commands/harnessOperation.ts
@@ -1,10 +1,11 @@
 import { getErrorMessage } from '@contextbridge/shared/errors';
-import { CommanderError } from 'commander';
+import type { ResultAsync as ResultAsyncType } from 'neverthrow';
 import type { CliContext } from '#src/context.ts';
 import { detectHarness } from '#src/installers/detect.ts';
 import type { HarnessInstaller, HarnessStatus, InstallActionOptions } from '#src/installers/HarnessInstaller.ts';
 import { ALL_INSTALLERS } from '#src/installers/installers.ts';
 import { PROMPTER_CANCELLED_CODE } from '#src/prompter.ts';
+import { AbortError, abortable, logAbortError } from './abort.ts';
 import { formatStatusLine } from './installStatus.ts';
 
 export type HarnessOperationMode = 'install' | 'uninstall';
@@ -18,7 +19,11 @@ interface ModeLabels {
   readonly failureMessagePrefix: string;
   readonly logMessage: string;
   readonly skippedNote: string;
-  readonly run: (installer: HarnessInstaller, ctx: CliContext, options: InstallActionOptions) => Promise<void>;
+  readonly run: (
+    installer: HarnessInstaller,
+    ctx: CliContext,
+    options: InstallActionOptions,
+  ) => ResultAsyncType<void, AbortError>;
 }
 
 const MODE_LABELS: Record<HarnessOperationMode, ModeLabels> = {
@@ -51,13 +56,21 @@ export interface HarnessOperationOptions {
   readonly force: boolean;
 }
 
-export async function runHarnessOperation(
+export function runHarnessOperation(
+  ctx: CliContext,
+  mode: HarnessOperationMode,
+  options: HarnessOperationOptions,
+): ResultAsyncType<void, AbortError> {
+  return abortable(mode, runHarnessOperationUnsafe(ctx, mode, options));
+}
+
+async function runHarnessOperationUnsafe(
   ctx: CliContext,
   mode: HarnessOperationMode,
   { yes, force }: HarnessOperationOptions,
 ): Promise<void> {
   const labels = MODE_LABELS[mode];
-  const { io, prompter, logger } = ctx;
+  const { io, prompter } = ctx;
 
   const detected: Array<{ installer: HarnessInstaller; status?: HarnessStatus }> = [];
   const failures: string[] = [];
@@ -71,18 +84,18 @@ export async function runHarnessOperation(
       continue;
     }
 
-    try {
-      const status = await installer.status(ctx);
+    const statusResult = await installer.status(ctx);
+    if (statusResult.isOk()) {
+      const status = statusResult.value;
       io.writeStderr(`${formatStatusLine(status)}\n`);
       if (status.detected) {
         detected.push({ installer, status });
       }
-    } catch (err) {
+    } else {
+      const err = statusResult.error;
       const { displayName, id } = installer.descriptor;
       io.writeStderr(`${formatStatusFailureLine(displayName, err)}\n`);
-      if (!(err instanceof CommanderError)) {
-        logger.error({ err, harness: id }, 'status failed');
-      }
+      logAbortError(ctx, err, 'status failed', { harness: id });
       failures.push(displayName);
       detected.push({ installer });
     }
@@ -90,10 +103,10 @@ export async function runHarnessOperation(
 
   if (detected.length === 0) {
     const supported = ALL_INSTALLERS.map((i) => i.descriptor.displayName).join(', ');
-    throw new CommanderError(
-      1,
-      labels.noHarnessesCode,
+    throw AbortError.input(
+      mode,
       `No supported AI coding harnesses detected. PlanBridge currently supports: ${supported}. ${labels.noHarnessesHint}`,
+      { code: labels.noHarnessesCode },
     );
   }
 
@@ -111,26 +124,29 @@ export async function runHarnessOperation(
     }
 
     if (!yes) {
-      const proceed = await prompter.confirm({
+      const proceedResult = await prompter.confirm({
         message: labels.confirmMessage(displayName),
         default: true,
       });
+      if (proceedResult.isErr()) {
+        throw proceedResult.error;
+      }
+      const proceed = proceedResult.value;
       if (!proceed) {
         io.writeStderr(`${displayName}: skipped\n`);
         continue;
       }
     }
 
-    try {
-      await labels.run(installer, ctx, { yes });
+    const runResult = await labels.run(installer, ctx, { yes });
+    if (runResult.isOk()) {
       completedCount += 1;
-    } catch (err) {
-      if (err instanceof CommanderError && err.code === PROMPTER_CANCELLED_CODE) {
+    } else {
+      const err = runResult.error;
+      if (err.code === PROMPTER_CANCELLED_CODE) {
         throw err;
       }
-      if (!(err instanceof CommanderError)) {
-        logger.error({ err, harness: installer.descriptor.id }, labels.logMessage);
-      }
+      logAbortError(ctx, err, labels.logMessage, { harness: installer.descriptor.id });
       failures.push(displayName);
     }
   }
@@ -140,7 +156,9 @@ export async function runHarnessOperation(
   io.writeStderr(`${labels.pastTense} ${completedCount} of ${detected.length} ${detectedNoun}${skippedSuffix}.\n`);
 
   if (failures.length > 0) {
-    throw new CommanderError(1, labels.failureCode, `${labels.failureMessagePrefix}: ${failures.join(', ')}`);
+    throw AbortError.runtime(mode, `${labels.failureMessagePrefix}: ${failures.join(', ')}`, {
+      code: labels.failureCode,
+    });
   }
 }
 

--- a/packages/cli/src/commands/hookClaude.test.ts
+++ b/packages/cli/src/commands/hookClaude.test.ts
@@ -1,11 +1,10 @@
 import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
 import { annotationSubmission } from '@contextbridge/shared/testFactories';
 import { describe, expect, it } from 'bun:test';
-import { CommanderError } from 'commander';
 import { type RunAnnotationArgs, runAnnotation } from '#src/annotation/runAnnotation.ts';
 import { claudeHookResponse } from '#src/formatters/plan/claudeHookResponse.ts';
 import { annotationArgs } from '#src/testFactories.ts';
-import { createAnnotationDependencies, createStubContext, readErrorLogs } from '#src/testHelpers/index.ts';
+import { createAnnotationDependencies, createStubContext, expectErr, readErrorLogs } from '#src/testHelpers/index.ts';
 import { type HookClaudeDependencies, runHookClaude } from './hookClaude.ts';
 
 describe('hookClaude handler', () => {
@@ -92,7 +91,7 @@ describe('hookClaude handler', () => {
     expect(typeof submitted?.properties?.['duration_ms']).toBe('number');
   });
 
-  it('aborts when hook_event_name is unsupported', () => {
+  it('aborts when hook_event_name is unsupported', async () => {
     const { context, io, logs } = createStubContext();
     const deps = createHookDependencies();
     io.stdin.write(
@@ -107,13 +106,14 @@ describe('hookClaude handler', () => {
     );
     io.stdin.end();
 
-    expect(runHookClaude(context, deps)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runHookClaude(context, deps));
+    expect(err.message).toContain('unsupported hook_event_name: PreToolUse');
     expect(io.stdout.text()).toBe('');
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('unsupported hook_event_name: PreToolUse'))).toBe(true);
+    expect(readErrorLogs(logs)).toEqual([]);
     expect(deps.calls).toEqual([]);
   });
 
-  it('aborts when PermissionRequest arrives for a tool other than ExitPlanMode', () => {
+  it('aborts when PermissionRequest arrives for a tool other than ExitPlanMode', async () => {
     const { context, io, logs } = createStubContext();
     const deps = createHookDependencies();
     io.stdin.write(
@@ -128,25 +128,27 @@ describe('hookClaude handler', () => {
     );
     io.stdin.end();
 
-    expect(runHookClaude(context, deps)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runHookClaude(context, deps));
+    expect(err.message).toContain('unsupported tool for PermissionRequest: Bash');
     expect(io.stdout.text()).toBe('');
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('unsupported tool for PermissionRequest: Bash'))).toBe(true);
+    expect(readErrorLogs(logs)).toEqual([]);
     expect(deps.calls).toEqual([]);
   });
 
-  it('aborts on invalid JSON', () => {
+  it('aborts on invalid JSON', async () => {
     const { context, io, logs } = createStubContext();
     const deps = createHookDependencies();
     io.stdin.write('{not-json');
     io.stdin.end();
 
-    expect(runHookClaude(context, deps)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runHookClaude(context, deps));
+    expect(err.message).toContain('failed to parse hook event JSON');
     expect(io.stdout.text()).toBe('');
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('failed to parse hook event JSON'))).toBe(true);
+    expect(readErrorLogs(logs)).toEqual([]);
     expect(deps.calls).toEqual([]);
   });
 
-  it('aborts when tool_input.plan is missing', () => {
+  it('aborts when tool_input.plan is missing', async () => {
     const { context, io, logs } = createStubContext();
     const deps = createHookDependencies();
     io.stdin.write(
@@ -161,21 +163,23 @@ describe('hookClaude handler', () => {
     );
     io.stdin.end();
 
-    expect(runHookClaude(context, deps)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runHookClaude(context, deps));
+    expect(err.message).toContain('invalid hook event payload');
     expect(io.stdout.text()).toBe('');
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('invalid hook event payload'))).toBe(true);
+    expect(readErrorLogs(logs)).toEqual([]);
     expect(deps.calls).toEqual([]);
   });
 
-  it('aborts when required top-level fields are missing', () => {
+  it('aborts when required top-level fields are missing', async () => {
     const { context, io, logs } = createStubContext();
     const deps = createHookDependencies();
     io.stdin.write(JSON.stringify({ hook_event_name: 'PermissionRequest' }));
     io.stdin.end();
 
-    expect(runHookClaude(context, deps)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runHookClaude(context, deps));
+    expect(err.message).toContain('invalid hook event payload');
     expect(io.stdout.text()).toBe('');
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('invalid hook event payload'))).toBe(true);
+    expect(readErrorLogs(logs)).toEqual([]);
   });
 });
 

--- a/packages/cli/src/commands/hookClaude.ts
+++ b/packages/cli/src/commands/hookClaude.ts
@@ -1,22 +1,26 @@
 import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
 import { getErrorMessage } from '@contextbridge/shared/errors';
-import { type Command, CommanderError } from 'commander';
+import { safeJsonParse } from '@contextbridge/shared/json';
+import type { Command } from 'commander';
+import { ResultAsync, err, errAsync, ok } from 'neverthrow';
 import { type RunAnnotationArgs, runAnnotation } from '#src/annotation/runAnnotation.ts';
 import type { CliContext } from '#src/context.ts';
 import { type ClaudeHookResponse, claudeHookResponse } from '#src/formatters/plan/claudeHookResponse.ts';
+import { AbortError, handleCommandResult } from './abort.ts';
 import { type ClaudeHookPayload, ClaudeHookPayloadSchema } from './claudeHookSchema.ts';
 
 export interface HookClaudeDependencies {
   runReview?: (ctx: CliContext, args: RunAnnotationArgs) => Promise<AnnotationSubmission>;
 }
 
-export async function runHookClaude(ctx: CliContext, deps: HookClaudeDependencies = {}): Promise<void> {
+export function runHookClaude(ctx: CliContext, deps: HookClaudeDependencies = {}): ResultAsync<void, AbortError> {
   const { io } = ctx;
 
-  const payload = await readAndValidatePayload(ctx);
-  const response = await dispatchHookEvent(ctx, payload, deps);
-
-  io.writeStdout(`${JSON.stringify(response)}\n`);
+  return readAndValidatePayload(ctx)
+    .andThen((payload) => dispatchHookEvent(ctx, payload, deps))
+    .map((response) => {
+      io.writeStdout(`${JSON.stringify(response)}\n`);
+    });
 }
 
 export function registerHookClaude(ctx: CliContext, hookCommand: Command): void {
@@ -26,85 +30,73 @@ export function registerHookClaude(ctx: CliContext, hookCommand: Command): void 
       'Adapter for Claude Code PermissionRequest:ExitPlanMode hook — reads event JSON on stdin, emits a hookSpecificOutput envelope on stdout',
     )
     .action(async () => {
-      await runHookClaude(ctx);
+      await handleCommandResult(ctx, runHookClaude(ctx));
     });
 }
 
-async function readAndValidatePayload(ctx: CliContext): Promise<ClaudeHookPayload> {
+function readAndValidatePayload(ctx: CliContext): ResultAsync<ClaudeHookPayload, AbortError> {
   const { io } = ctx;
-  const raw = await io.readStdin();
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (err) {
-    abort(ctx, 'input', `failed to parse hook event JSON: ${getErrorMessage(err)}`);
-  }
-
-  const result = ClaudeHookPayloadSchema.safeParse(parsed);
-  if (!result.success) {
-    const summary = result.error.issues
-      .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
-      .join('; ');
-    abort(ctx, 'input', `invalid hook event payload: ${summary}`);
-  }
-
-  return result.data;
+  return ResultAsync.fromPromise(io.readStdin(), (e) => AbortError.runtime('hookClaude', getErrorMessage(e)))
+    .andThen((raw) =>
+      safeJsonParse(raw).mapErr((e) =>
+        AbortError.input('hookClaude', `failed to parse hook event JSON: ${getErrorMessage(e)}`),
+      ),
+    )
+    .andThen((parsed) => {
+      const result = ClaudeHookPayloadSchema.safeParse(parsed);
+      if (result.success) return ok(result.data);
+      const summary = result.error.issues
+        .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+        .join('; ');
+      return err(AbortError.input('hookClaude', `invalid hook event payload: ${summary}`));
+    });
 }
 
-async function dispatchHookEvent(
+function dispatchHookEvent(
   ctx: CliContext,
   payload: ClaudeHookPayload,
   deps: HookClaudeDependencies,
-): Promise<ClaudeHookResponse> {
+): ResultAsync<ClaudeHookResponse, AbortError> {
   switch (payload.hook_event_name) {
     case 'PermissionRequest':
       return handlePermissionRequest(ctx, payload, deps);
     default:
-      abort(ctx, 'input', `unsupported hook_event_name: ${payload.hook_event_name}`);
+      return errAsync(AbortError.input('hookClaude', `unsupported hook_event_name: ${payload.hook_event_name}`));
   }
 }
 
-async function handlePermissionRequest(
+function handlePermissionRequest(
   ctx: CliContext,
   payload: ClaudeHookPayload,
   deps: HookClaudeDependencies,
-): Promise<ClaudeHookResponse> {
+): ResultAsync<ClaudeHookResponse, AbortError> {
   switch (payload.tool_name) {
     case 'ExitPlanMode':
       return handleExitPlanMode(ctx, payload, deps);
     default:
-      abort(ctx, 'input', `unsupported tool for PermissionRequest: ${payload.tool_name ?? '<missing>'}`);
+      return errAsync(
+        AbortError.input('hookClaude', `unsupported tool for PermissionRequest: ${payload.tool_name ?? '<missing>'}`),
+      );
   }
 }
 
-async function handleExitPlanMode(
+function handleExitPlanMode(
   ctx: CliContext,
   payload: ClaudeHookPayload,
   deps: HookClaudeDependencies,
-): Promise<ClaudeHookResponse> {
+): ResultAsync<ClaudeHookResponse, AbortError> {
   const { logger } = ctx;
   const { runReview = runAnnotation } = deps;
 
   if (!payload.tool_input?.plan) {
-    abort(ctx, 'input', 'missing tool_input.plan for ExitPlanMode');
+    return errAsync(AbortError.input('hookClaude', 'missing tool_input.plan for ExitPlanMode'));
   }
 
   const planContent = payload.tool_input.plan;
   logger.info({ tool: payload.tool_name, bytes: Buffer.byteLength(planContent, 'utf8') }, 'claude hook received');
 
-  let submission: AnnotationSubmission;
-  try {
-    submission = await runReview(ctx, { content: planContent, contentKind: 'plan', entrypoint: 'hook_claude' });
-  } catch (err) {
-    abort(ctx, 'runtime', getErrorMessage(err));
-  }
-
-  return claudeHookResponse(submission, planContent);
-}
-
-function abort(ctx: CliContext, kind: 'input' | 'runtime', message: string): never {
-  const { logger } = ctx;
-  logger.error(message);
-  throw new CommanderError(1, `contextbridge.hookClaude.${kind}Error`, message);
+  return ResultAsync.fromPromise(
+    runReview(ctx, { content: planContent, contentKind: 'plan', entrypoint: 'hook_claude' }),
+    (e) => AbortError.runtime('hookClaude', getErrorMessage(e)),
+  ).map((submission: AnnotationSubmission) => claudeHookResponse(submission, planContent));
 }

--- a/packages/cli/src/commands/hookCodex.test.ts
+++ b/packages/cli/src/commands/hookCodex.test.ts
@@ -1,7 +1,6 @@
 import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
 import { annotationSubmission } from '@contextbridge/shared/testFactories';
 import { describe, expect, it } from 'bun:test';
-import { CommanderError } from 'commander';
 import { type RunAnnotationArgs, runAnnotation } from '#src/annotation/runAnnotation.ts';
 import type { CodexStopResponse } from '#src/formatters/plan/codexStopResponse.ts';
 import {
@@ -10,7 +9,7 @@ import {
   codexTranscriptHookPromptLine,
   codexTranscriptPlanLine,
 } from '#src/testFactories.ts';
-import { createAnnotationDependencies, createStubContext, readErrorLogs } from '#src/testHelpers/index.ts';
+import { createAnnotationDependencies, createStubContext, expectErr, readErrorLogs } from '#src/testHelpers/index.ts';
 import type { CodexStopHookPayload } from './codexHookSchema.ts';
 import { type HookCodexDependencies, extractLatestPlanFromTranscript, runHookCodex } from './hookCodex.ts';
 
@@ -242,18 +241,19 @@ describe('hookCodex handler', () => {
     expect(deps.transcriptReadCount).toBe(1);
   });
 
-  it('aborts on invalid JSON', () => {
+  it('aborts on invalid JSON', async () => {
     const { context, io, logs } = createStubContext();
     const deps = createHookDependencies();
     io.stdin.write('{not-json');
     io.stdin.end();
 
-    expect(runHookCodex(context, deps)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runHookCodex(context, deps));
+    expect(err.message).toContain('failed to parse hook event JSON');
     expect(io.stdout.text()).toBe('');
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('failed to parse hook event JSON'))).toBe(true);
+    expect(readErrorLogs(logs)).toEqual([]);
   });
 
-  it('aborts when the event payload is not a Codex Stop hook', () => {
+  it('aborts when the event payload is not a Codex Stop hook', async () => {
     const { context, io, logs } = createStubContext();
     const deps = createHookDependencies();
     io.stdin.write(
@@ -266,9 +266,10 @@ describe('hookCodex handler', () => {
     );
     io.stdin.end();
 
-    expect(runHookCodex(context, deps)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runHookCodex(context, deps));
+    expect(err.message).toContain('invalid hook event payload');
     expect(io.stdout.text()).toBe('');
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('invalid hook event payload'))).toBe(true);
+    expect(readErrorLogs(logs)).toEqual([]);
     expect(deps.calls).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/hookCodex.ts
+++ b/packages/cli/src/commands/hookCodex.ts
@@ -1,11 +1,12 @@
 import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
 import { getErrorMessage, toError } from '@contextbridge/shared/errors';
 import { safeJsonParse } from '@contextbridge/shared/json';
-import { type Command, CommanderError } from 'commander';
-import { ResultAsync, err, ok } from 'neverthrow';
+import type { Command } from 'commander';
+import { ResultAsync, err, ok, okAsync } from 'neverthrow';
 import { type RunAnnotationArgs, runAnnotation } from '#src/annotation/runAnnotation.ts';
 import type { CliContext } from '#src/context.ts';
 import { type CodexStopResponse, codexStopResponse } from '#src/formatters/plan/codexStopResponse.ts';
+import { AbortError, handleCommandResult } from './abort.ts';
 import {
   type CodexStopHookPayload,
   CodexStopHookPayloadSchema,
@@ -25,13 +26,14 @@ const TRANSCRIPT_TAIL_READ_BYTES = 1024 * 1024;
 // invalid per the spec. When we have no continuation to deliver, write `{}` — a valid JSON object
 // with none of the recognized action keys (`decision`, `continue`, `reason`), which leaves Codex's
 // default Stop behavior intact. See https://developers.openai.com/codex/hooks#stop.
-export async function runHookCodex(ctx: CliContext, deps: HookCodexDependencies = {}): Promise<void> {
+export function runHookCodex(ctx: CliContext, deps: HookCodexDependencies = {}): ResultAsync<void, AbortError> {
   const { io } = ctx;
 
-  const payload = await readAndValidatePayload(ctx);
-  const response = await handleStop(ctx, payload, deps);
-
-  io.writeStdout(`${JSON.stringify(response ?? {})}\n`);
+  return readAndValidatePayload(ctx)
+    .andThen((payload) => handleStop(ctx, payload, deps))
+    .map((response) => {
+      io.writeStdout(`${JSON.stringify(response ?? {})}\n`);
+    });
 }
 
 export function registerHookCodex(ctx: CliContext, hookCommand: Command): void {
@@ -41,7 +43,7 @@ export function registerHookCodex(ctx: CliContext, hookCommand: Command): void {
       'Adapter for Codex CLI Stop hook — reads event JSON on stdin, reviews the latest proposed plan, and emits a Stop continuation on stdout',
     )
     .action(async () => {
-      await runHookCodex(ctx);
+      await handleCommandResult(ctx, runHookCodex(ctx));
     });
 }
 
@@ -63,31 +65,28 @@ export function extractLatestPlanFromTranscript(transcript: string, turnId: stri
   return null;
 }
 
-async function readAndValidatePayload(ctx: CliContext): Promise<CodexStopHookPayload> {
+function readAndValidatePayload(ctx: CliContext): ResultAsync<CodexStopHookPayload, AbortError> {
   const { io } = ctx;
-  const raw = await io.readStdin();
-
-  return safeJsonParse(raw)
-    .mapErr((e) => `failed to parse hook event JSON: ${getErrorMessage(e)}`)
-    .andThen((value) => {
-      const parsed = CodexStopHookPayloadSchema.safeParse(value);
-      if (parsed.success) return ok(parsed.data);
-      const summary = parsed.error.issues
-        .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
-        .join('; ');
-      return err(`invalid hook event payload: ${summary}`);
-    })
-    .match(
-      (data) => data,
-      (message) => abort(ctx, 'input', message),
-    );
+  return ResultAsync.fromPromise(io.readStdin(), (e) => AbortError.runtime('hookCodex', getErrorMessage(e))).andThen(
+    (raw) =>
+      safeJsonParse(raw)
+        .mapErr((e) => AbortError.input('hookCodex', `failed to parse hook event JSON: ${getErrorMessage(e)}`))
+        .andThen((value) => {
+          const parsed = CodexStopHookPayloadSchema.safeParse(value);
+          if (parsed.success) return ok(parsed.data);
+          const summary = parsed.error.issues
+            .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+            .join('; ');
+          return err(AbortError.input('hookCodex', `invalid hook event payload: ${summary}`));
+        }),
+  );
 }
 
-async function handleStop(
+function handleStop(
   ctx: CliContext,
   payload: CodexStopHookPayload,
   deps: HookCodexDependencies,
-): Promise<CodexStopResponse | null> {
+): ResultAsync<CodexStopResponse | null, AbortError> {
   const { logger } = ctx;
   const { runReview = runAnnotation } = deps;
 
@@ -95,29 +94,26 @@ async function handleStop(
     logger.debug({ hook: payload.hook_event_name }, 'codex hook inspecting active Stop continuation');
   }
 
-  const planContent = await resolvePlanContent(ctx, payload, deps);
+  return resolvePlanContent(ctx, payload, deps).andThen((planContent) => {
+    if (!planContent) {
+      logger.debug({ hook: payload.hook_event_name }, 'codex hook found no proposed plan');
+      return okAsync(null);
+    }
 
-  if (!planContent) {
-    logger.debug({ hook: payload.hook_event_name }, 'codex hook found no proposed plan');
-    return null;
-  }
+    logger.info({ bytes: Buffer.byteLength(planContent, 'utf8') }, 'codex hook received');
 
-  logger.info({ bytes: Buffer.byteLength(planContent, 'utf8') }, 'codex hook received');
-
-  return ResultAsync.fromPromise(
-    runReview(ctx, { content: planContent, contentKind: 'plan', entrypoint: 'hook_codex' }),
-    toError,
-  ).match(
-    (submission: AnnotationSubmission) => codexStopResponse(submission, planContent),
-    (e) => abort(ctx, 'runtime', getErrorMessage(e)),
-  );
+    return ResultAsync.fromPromise(
+      runReview(ctx, { content: planContent, contentKind: 'plan', entrypoint: 'hook_codex' }),
+      (e) => AbortError.runtime('hookCodex', getErrorMessage(e)),
+    ).map((submission: AnnotationSubmission) => codexStopResponse(submission, planContent));
+  });
 }
 
-async function resolvePlanContent(
+function resolvePlanContent(
   ctx: CliContext,
   payload: CodexStopHookPayload,
   deps: HookCodexDependencies,
-): Promise<string | null> {
+): ResultAsync<string | null, AbortError> {
   const { logger } = ctx;
   const { readTranscript = readTranscriptFile } = deps;
   const {
@@ -129,20 +125,17 @@ async function resolvePlanContent(
 
   if (!stopHookActive) {
     const assistantMessagePlan = extractPlanFromAssistantMessage(lastAssistantMessage);
-    if (assistantMessagePlan) return assistantMessagePlan;
+    if (assistantMessagePlan) return okAsync(assistantMessagePlan);
   }
 
-  if (!transcriptPath) return null;
+  if (!transcriptPath) return okAsync(null);
 
   return ResultAsync.fromPromise(readTranscript(transcriptPath), toError)
     .map((transcript) => extractLatestPlanFromTranscript(transcript, turnId))
-    .match(
-      (plan) => plan,
-      (e) => {
-        logger.error({ err: e, transcript_path: transcriptPath }, 'failed to read codex transcript');
-        return null;
-      },
-    );
+    .orElse((e) => {
+      logger.error({ err: e, transcript_path: transcriptPath }, 'failed to read codex transcript');
+      return okAsync(null);
+    });
 }
 
 function readTranscriptFile(path: string): Promise<string> {
@@ -171,10 +164,4 @@ function isPlanReviewHookPrompt(value: unknown): boolean {
   return parsed.data.payload.content.some(
     (item) => item.text.includes('<hook_prompt') && item.text.includes('# Plan review:'),
   );
-}
-
-function abort(ctx: CliContext, kind: 'input' | 'runtime', message: string): never {
-  const { logger } = ctx;
-  logger.error(message);
-  throw new CommanderError(1, `contextbridge.hookCodex.${kind}Error`, message);
 }

--- a/packages/cli/src/commands/install.test.ts
+++ b/packages/cli/src/commands/install.test.ts
@@ -3,14 +3,20 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getHarness } from '@contextbridge/harness';
 import { describe, expect, it } from 'bun:test';
-import { CommanderError } from 'commander';
 import {
   CLAUDE_MARKETPLACE_NAME,
   CLAUDE_MARKETPLACE_SOURCE,
   CLAUDE_PLUGIN_ID,
 } from '#src/installers/ClaudeInstaller.ts';
 import { environment } from '#src/testFactories.ts';
-import { createStubContext, primeClaudeShellouts, stubClaudeState } from '#src/testHelpers/index.ts';
+import {
+  createStubContext,
+  expectErr,
+  expectOk,
+  primeClaudeShellouts,
+  stubClaudeState,
+} from '#src/testHelpers/index.ts';
+import { AbortError } from './abort.ts';
 import { runInstall } from './install.ts';
 
 const CLAUDE_BINARY = getHarness('claude').binaryName;
@@ -20,7 +26,7 @@ describe('runInstall', () => {
   it('with --yes installs Claude when not yet wired up and reports the summary', async () => {
     const { context, io, commandRunner, prompter } = setupTest();
 
-    await runInstall(context, { yes: true });
+    await expectOk(runInstall(context, { yes: true }));
 
     const marketplaceAdd = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']);
     const pluginInstall = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install']);
@@ -47,7 +53,7 @@ describe('runInstall', () => {
       marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] }],
     });
 
-    await runInstall(context, { yes: true });
+    await expectOk(runInstall(context, { yes: true }));
 
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])).toEqual([]);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toEqual([]);
@@ -65,7 +71,7 @@ describe('runInstall', () => {
       marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] }],
     });
 
-    await runInstall(context, { yes: true, force: true });
+    await expectOk(runInstall(context, { yes: true, force: true }));
 
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])).toHaveLength(1);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'update'])).toHaveLength(1);
@@ -81,7 +87,7 @@ describe('runInstall', () => {
       marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }] }],
     });
 
-    await runInstall(context, { yes: true });
+    await expectOk(runInstall(context, { yes: true }));
 
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])).toEqual([]);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toEqual([]);
@@ -96,7 +102,7 @@ describe('runInstall', () => {
     const { context, io, commandRunner } = setupTest();
     stubClaudeState(commandRunner, { marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME }] });
 
-    await runInstall(context, { yes: true });
+    await expectOk(runInstall(context, { yes: true }));
 
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])).toHaveLength(1);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toHaveLength(1);
@@ -117,9 +123,7 @@ describe('runInstall', () => {
       mkdirSync(configDir, { recursive: true });
       writeFileSync(join(configDir, 'hooks.json'), '{ bad json');
 
-      const err = await captureError(runInstall(context, { yes: true }));
-      expect(err).toBeInstanceOf(CommanderError);
-      if (!(err instanceof CommanderError)) throw err;
+      const err = await expectErr(runInstall(context, { yes: true }));
       expect(err.message).toBe('Install failed for: Codex CLI');
 
       const marketplaceAdd = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']);
@@ -147,7 +151,7 @@ describe('runInstall', () => {
     const { context, io, commandRunner, prompter } = setupTest();
     prompter.setConfirm(false);
 
-    await runInstall(context);
+    await expectOk(runInstall(context));
 
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])).toEqual([]);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toEqual([]);
@@ -161,7 +165,7 @@ describe('runInstall', () => {
     prompter.setConfirm(true);
     prompter.setSelect('project');
 
-    await runInstall(context);
+    await expectOk(runInstall(context));
 
     const marketplaceAdd = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']);
     const pluginInstall = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install']);
@@ -174,11 +178,12 @@ describe('runInstall', () => {
     expect(prompter.selectCalls[0]?.message).toBe('Install scope:');
   });
 
-  it('throws when no supported harnesses are detected', () => {
+  it('throws when no supported harnesses are detected', async () => {
     const { context, commandRunner, io } = setupTest();
     commandRunner.setWhich(CLAUDE_BINARY, null);
 
-    expect(runInstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runInstall(context, { yes: true }));
+    expect(err).toBeInstanceOf(AbortError);
     expect(commandRunner.calls).toEqual([]);
     expect(io.stderr.text()).toContain('Claude Code: not detected');
   });
@@ -188,13 +193,4 @@ function setupTest(overrides?: Parameters<typeof createStubContext>[0]) {
   const stub = createStubContext(overrides);
   primeClaudeShellouts(stub.commandRunner);
   return stub;
-}
-
-async function captureError(promise: Promise<unknown>): Promise<unknown> {
-  try {
-    await promise;
-    return null;
-  } catch (err) {
-    return err;
-  }
 }

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -1,6 +1,9 @@
 import type { Command } from 'commander';
+import type { ResultAsync } from 'neverthrow';
 import type { CliContext } from '#src/context.ts';
 import { ALL_INSTALLERS } from '#src/installers/installers.ts';
+import type { AbortError } from './abort.ts';
+import { handleCommandResult } from './abort.ts';
 import { runHarnessOperation } from './harnessOperation.ts';
 import { registerInstallStatus } from './installStatus.ts';
 
@@ -9,9 +12,9 @@ export interface InstallOptions {
   force?: boolean;
 }
 
-export async function runInstall(ctx: CliContext, options: InstallOptions = {}): Promise<void> {
+export function runInstall(ctx: CliContext, options: InstallOptions = {}): ResultAsync<void, AbortError> {
   const { yes = false, force = false } = options;
-  await runHarnessOperation(ctx, 'install', { yes, force });
+  return runHarnessOperation(ctx, 'install', { yes, force });
 }
 
 export function registerInstall(ctx: CliContext, program: Command): void {
@@ -23,7 +26,7 @@ export function registerInstall(ctx: CliContext, program: Command): void {
     .option('-y, --yes', 'skip confirmation prompts', false)
     .option('--force', 'reinstall even when PlanBridge is already wired up', false)
     .action(async (opts: InstallOptions) => {
-      await runInstall(ctx, opts);
+      await handleCommandResult(ctx, runInstall(ctx, opts));
     });
 
   for (const installer of ALL_INSTALLERS) {

--- a/packages/cli/src/commands/installStatus.test.ts
+++ b/packages/cli/src/commands/installStatus.test.ts
@@ -1,7 +1,13 @@
 import { getHarness } from '@contextbridge/harness';
 import { describe, expect, it } from 'bun:test';
 import { CLAUDE_MARKETPLACE_NAME, CLAUDE_PLUGIN_ID } from '#src/installers/ClaudeInstaller.ts';
-import { createStubContext, marketplaceListResult, parseStdoutJson, pluginListResult } from '#src/testHelpers/index.ts';
+import {
+  createStubContext,
+  expectOk,
+  marketplaceListResult,
+  parseStdoutJson,
+  pluginListResult,
+} from '#src/testHelpers/index.ts';
 import { runInstallStatus } from './installStatus.ts';
 
 const CLAUDE_BINARY = getHarness('claude').binaryName;
@@ -17,7 +23,7 @@ describe('runInstallStatus', () => {
       .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
       .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]));
 
-    await runInstallStatus(context);
+    await expectOk(runInstallStatus(context));
 
     const stderr = io.stderr.text();
     expect(stderr).toContain('Claude Code: PlanBridge installed');
@@ -32,7 +38,7 @@ describe('runInstallStatus', () => {
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
 
-    await runInstallStatus(context);
+    await expectOk(runInstallStatus(context));
 
     expect(io.stderr.text()).toContain('Claude Code: PlanBridge not installed');
   });
@@ -45,7 +51,7 @@ describe('runInstallStatus', () => {
       .resolves(marketplaceListResult([{ name: CLAUDE_MARKETPLACE_NAME }]));
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
 
-    await runInstallStatus(context);
+    await expectOk(runInstallStatus(context));
 
     const stderr = io.stderr.text();
     expect(stderr).toContain('Claude Code: PlanBridge not installed (marketplace contextbridge)');
@@ -60,7 +66,7 @@ describe('runInstallStatus', () => {
       .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
       .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]));
 
-    await runInstallStatus(context);
+    await expectOk(runInstallStatus(context));
 
     expect(io.stderr.text()).toContain('plugin planbridge@contextbridge @ project');
   });
@@ -69,7 +75,7 @@ describe('runInstallStatus', () => {
     const { context, io, commandRunner } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, null);
 
-    await runInstallStatus(context);
+    await expectOk(runInstallStatus(context));
 
     expect(io.stderr.text()).toContain('Claude Code: not detected');
     expect(commandRunner.calls).toEqual([]);
@@ -85,7 +91,7 @@ describe('runInstallStatus', () => {
       .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
       .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]));
 
-    await runInstallStatus(context, { json: true });
+    await expectOk(runInstallStatus(context, { json: true }));
 
     expect(io.stderr.text()).toBe('');
     const payload = parseStdoutJson(io) as unknown[];

--- a/packages/cli/src/commands/installStatus.ts
+++ b/packages/cli/src/commands/installStatus.ts
@@ -1,21 +1,23 @@
 import type { Command } from 'commander';
+import type { ResultAsync } from 'neverthrow';
 import type { CliContext } from '#src/context.ts';
 import type { HarnessStatus } from '#src/installers/HarnessInstaller.ts';
 import { ALL_INSTALLERS } from '#src/installers/installers.ts';
+import { AbortError, abortable, handleCommandResult } from './abort.ts';
 
 export interface InstallStatusOptions {
   json?: boolean;
 }
 
-export async function runInstallStatus(ctx: CliContext, options: InstallStatusOptions = {}): Promise<void> {
+export function runInstallStatus(ctx: CliContext, options: InstallStatusOptions = {}): ResultAsync<void, AbortError> {
+  return abortable('installStatus', runInstallStatusUnsafe(ctx, options));
+}
+
+async function runInstallStatusUnsafe(ctx: CliContext, options: InstallStatusOptions): Promise<void> {
   const { json = false } = options;
   const { io } = ctx;
 
-  const statuses: HarnessStatus[] = [];
-  for (const installer of ALL_INSTALLERS) {
-    statuses.push(await installer.status(ctx));
-  }
-
+  const statuses = await readStatuses(ctx);
   if (json) {
     io.writeStdout(`${JSON.stringify(statuses, null, 2)}\n`);
     return;
@@ -42,8 +44,18 @@ export function registerInstallStatus(ctx: CliContext, installCommand: Command):
     )
     .option('--json', 'emit machine-readable JSON to stdout', false)
     .action(async (opts: InstallStatusOptions) => {
-      await runInstallStatus(ctx, opts);
+      await handleCommandResult(ctx, runInstallStatus(ctx, opts));
     });
+}
+
+async function readStatuses(ctx: CliContext): Promise<HarnessStatus[]> {
+  const statuses: HarnessStatus[] = [];
+  for (const installer of ALL_INSTALLERS) {
+    const result = await installer.status(ctx);
+    if (result.isErr()) throw result.error;
+    statuses.push(result.value);
+  }
+  return statuses;
 }
 
 function formatManaged(status: HarnessStatus): string {

--- a/packages/cli/src/commands/open.test.ts
+++ b/packages/cli/src/commands/open.test.ts
@@ -5,12 +5,12 @@ import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchem
 import { annotationSubmission } from '@contextbridge/shared/testFactories';
 import { createDeferred } from '@contextbridge/shared/testHelpers';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { CommanderError } from 'commander';
 import { formatAgentResponse } from '#src/formatters/annotation/markdown.ts';
 import { DOCUMENT_TEMPLATES } from '#src/formatters/document/templates.ts';
 import {
   createAnnotationDependencies,
   createStubContext,
+  expectErr,
   readErrorLogs,
   readWarnLogs,
 } from '#src/testHelpers/index.ts';
@@ -76,34 +76,37 @@ describe('open handler', () => {
     expect(payload).toMatchObject({ metadata: { sourcePath: resolve(file) } });
   });
 
-  it('errors cleanly when neither a path nor piped stdin is supplied', () => {
+  it('errors cleanly when neither a path nor piped stdin is supplied', async () => {
     const { context, io, logs } = createStubContext();
     io.stdin.isTTY = true;
 
-    expect(runOpen(context, {})).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runOpen(context, {}));
+    expect(err.message).toContain('provide content via stdin');
     expect(io.stdout.text()).toBe('');
-    expect(readWarnLogs(logs).some((r) => r.msg.includes('provide content via stdin'))).toBe(true);
+    expect(readWarnLogs(logs)).toEqual([]);
   });
 
-  it('errors cleanly when the file does not exist', () => {
+  it('errors cleanly when the file does not exist', async () => {
     const { context, io, logs } = createStubContext();
     io.stdin.isTTY = true;
 
-    expect(runOpen(context, { path: join(tmp, 'missing.md') })).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runOpen(context, { path: join(tmp, 'missing.md') }));
+    expect(err.message).toContain('failed to read content from file');
     expect(io.stdout.text()).toBe('');
-    expect(readWarnLogs(logs).some((r) => r.msg.includes('failed to read content from file'))).toBe(true);
+    expect(readWarnLogs(logs)).toEqual([]);
   });
 
-  it('errors when content is empty', () => {
+  it('errors when content is empty', async () => {
     const file = join(tmp, 'empty.md');
     writeFileSync(file, '   \n\n');
 
     const { context, io, logs } = createStubContext();
     io.stdin.isTTY = true;
 
-    expect(runOpen(context, { path: file })).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runOpen(context, { path: file }));
+    expect(err.message).toContain('content is empty');
     expect(io.stdout.text()).toBe('');
-    expect(readWarnLogs(logs).some((r) => r.msg.includes('content is empty'))).toBe(true);
+    expect(readWarnLogs(logs)).toEqual([]);
   });
 
   it('closes the server and exits cleanly (without error-level logs) when SIGINT is received', async () => {
@@ -116,7 +119,8 @@ describe('open handler', () => {
     await deps.sigintHandlerRegistered;
     deps.triggerSigint();
 
-    expect(openPromise).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(openPromise);
+    expect(err.kind).toBe('cancelled');
     expect(io.stdout.text()).toBe('');
     expect(deps.closed).toBe(true);
     // Interrupt path logs at info level so pinoIntegration doesn't forward it to Sentry.

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -1,6 +1,7 @@
 import { resolve as resolvePath } from 'node:path';
 import { getErrorMessage } from '@contextbridge/shared/errors';
-import { type Command, CommanderError } from 'commander';
+import type { Command } from 'commander';
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
 import {
   type AnnotationDependencies,
   AnnotationInterruptedError,
@@ -9,55 +10,47 @@ import {
 import type { CliContext } from '#src/context.ts';
 import { formatAgentResponse } from '#src/formatters/annotation/markdown.ts';
 import { DOCUMENT_TEMPLATES } from '#src/formatters/document/templates.ts';
-import { abort } from './abort.ts';
+import { AbortError, handleCommandResult } from './abort.ts';
 
 export interface OpenArgs {
   path?: string;
 }
 
-export async function runOpen(ctx: CliContext, args: OpenArgs, deps?: AnnotationDependencies): Promise<void> {
+export function runOpen(ctx: CliContext, args: OpenArgs, deps?: AnnotationDependencies): ResultAsync<void, AbortError> {
   const { io, logger } = ctx;
   const { path: argPath } = args;
 
   if (!argPath && io.stdinIsTTY === true) {
-    abort(
-      ctx,
-      'open',
-      'input',
-      'provide content via stdin (e.g. `cat doc.md | contextbridge open`) or a file path via [path]',
+    return errAsync(
+      AbortError.input(
+        'open',
+        'provide content via stdin (e.g. `cat doc.md | contextbridge open`) or a file path via [path]',
+      ),
     );
   }
 
   const source: 'file' | 'stdin' = argPath ? 'file' : 'stdin';
-  let content: string;
-  try {
-    content = argPath ? await Bun.file(argPath).text() : await io.readStdin();
-  } catch (err) {
-    abort(ctx, 'open', 'input', `failed to read content from ${source}: ${getErrorMessage(err)}`);
-  }
-
-  if (content.trim().length === 0) {
-    abort(ctx, 'open', 'input', 'content is empty');
-  }
-
   const sourcePath = argPath ? resolvePath(argPath) : undefined;
 
-  logger.info({ source, bytes: Buffer.byteLength(content, 'utf8') }, 'open received');
-
-  try {
-    const submission = await runAnnotation(
-      ctx,
-      { content, contentKind: 'document', entrypoint: 'open_command', sourcePath },
-      deps,
-    );
-    io.writeStdout(formatAgentResponse(DOCUMENT_TEMPLATES, submission, content, { sourcePath }));
-  } catch (err) {
-    if (err instanceof AnnotationInterruptedError) {
-      logger.info('open session interrupted');
-      throw new CommanderError(130, 'contextbridge.open.sigint', 'open session interrupted');
-    }
-    abort(ctx, 'open', 'runtime', getErrorMessage(err));
-  }
+  return ResultAsync.fromPromise(argPath ? Bun.file(argPath).text() : io.readStdin(), (err) =>
+    AbortError.input('open', `failed to read content from ${source}: ${getErrorMessage(err)}`),
+  )
+    .andThen((content) => {
+      if (content.trim().length === 0) return errAsync(AbortError.input('open', 'content is empty'));
+      return okAsync(content);
+    })
+    .andThen((content) => {
+      logger.info({ source, bytes: Buffer.byteLength(content, 'utf8') }, 'open received');
+      return ResultAsync.fromPromise(
+        runAnnotation(ctx, { content, contentKind: 'document', entrypoint: 'open_command', sourcePath }, deps),
+        (err) =>
+          err instanceof AnnotationInterruptedError
+            ? AbortError.cancelled('open', 'open session interrupted', { code: 'contextbridge.open.sigint' })
+            : AbortError.runtime('open', getErrorMessage(err)),
+      ).map((submission) => {
+        io.writeStdout(formatAgentResponse(DOCUMENT_TEMPLATES, submission, content, { sourcePath }));
+      });
+    });
 }
 
 export function registerOpen(ctx: CliContext, program: Command): void {
@@ -68,6 +61,6 @@ export function registerOpen(ctx: CliContext, program: Command): void {
     )
     .argument('[path]', 'path to a file containing the content to annotate (alternative to stdin)')
     .action(async (path: string | undefined) => {
-      await runOpen(ctx, { path });
+      await handleCommandResult(ctx, runOpen(ctx, { path }));
     });
 }

--- a/packages/cli/src/commands/plan.test.ts
+++ b/packages/cli/src/commands/plan.test.ts
@@ -5,13 +5,13 @@ import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchem
 import { annotationSubmission } from '@contextbridge/shared/testFactories';
 import { createDeferred } from '@contextbridge/shared/testHelpers';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { CommanderError } from 'commander';
 import { formatAgentResponse } from '#src/formatters/annotation/markdown.ts';
 import { PLAN_TEMPLATES } from '#src/formatters/plan/templates.ts';
 import { environment } from '#src/testFactories.ts';
 import {
   createAnnotationDependencies,
   createStubContext,
+  expectErr,
   readErrorLogs,
   readLogs,
   readWarnLogs,
@@ -72,44 +72,48 @@ describe('plan handler', () => {
     expect(deps.payloads[0]?.content).toBe('from positional path');
   });
 
-  it('errors cleanly when the file does not exist', () => {
+  it('errors cleanly when the file does not exist', async () => {
     const { context, io, logs } = createStubContext();
     io.stdin.isTTY = true;
 
-    expect(runPlan(context, { path: join(tmp, 'missing.md') })).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runPlan(context, { path: join(tmp, 'missing.md') }));
+    expect(err.message).toContain('failed to read plan from file');
     expect(io.stdout.text()).toBe('');
-    expect(readWarnLogs(logs).some((r) => r.msg.includes('failed to read plan from file'))).toBe(true);
+    expect(readWarnLogs(logs)).toEqual([]);
   });
 
-  it('errors when neither a path nor piped stdin is supplied', () => {
+  it('errors when neither a path nor piped stdin is supplied', async () => {
     const { context, io, logs } = createStubContext();
     io.stdin.isTTY = true;
 
-    expect(runPlan(context, {})).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runPlan(context, {}));
+    expect(err.message).toContain('provide plan content via stdin');
     expect(io.stdout.text()).toBe('');
-    expect(readWarnLogs(logs).some((r) => r.msg.includes('provide plan content via stdin'))).toBe(true);
+    expect(readWarnLogs(logs)).toEqual([]);
   });
 
-  it('errors when the plan content is empty / whitespace-only', () => {
+  it('errors when the plan content is empty / whitespace-only', async () => {
     const { context, io, logs } = createStubContext();
     io.stdin.write('   \n\t  \n');
     io.stdin.end();
 
-    expect(runPlan(context, {})).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runPlan(context, {}));
+    expect(err.message).toContain('plan content is empty');
     expect(io.stdout.text()).toBe('');
-    expect(readWarnLogs(logs).some((r) => r.msg.includes('plan content is empty'))).toBe(true);
+    expect(readWarnLogs(logs)).toEqual([]);
   });
 
-  it('closes the server and surfaces a runtime error when the browser open fails', () => {
+  it('closes the server and surfaces a runtime error when the browser open fails', async () => {
     const { context, io, logs } = createStubContext({ openUrl: () => Promise.reject(new Error('open failed')) });
     const deps = createAnnotationDependencies();
     io.stdin.write('# Plan\n');
     io.stdin.end();
 
-    expect(runPlan(context, {}, deps)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runPlan(context, {}, deps));
+    expect(err.message).toContain('open failed');
     expect(io.stdout.text()).toBe('');
     expect(deps.closed).toBe(true);
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('open failed'))).toBe(true);
+    expect(readErrorLogs(logs)).toEqual([]);
   });
 
   it('closes the server and exits cleanly (without error-level logs) when SIGINT is received', async () => {
@@ -122,11 +126,11 @@ describe('plan handler', () => {
     await deps.sigintHandlerRegistered;
     deps.triggerSigint();
 
-    expect(reviewPromise).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(reviewPromise);
+    expect(err.kind).toBe('cancelled');
     expect(io.stdout.text()).toBe('');
     expect(deps.closed).toBe(true);
-    // Interrupt path logs at info level so pinoIntegration doesn't forward it to Sentry.
-    expect(readLogs(logs).some((r) => r.msg === 'plan review interrupted')).toBe(true);
+    expect(readLogs(logs).filter((record) => record.level >= 40)).toEqual([]);
     expect(readErrorLogs(logs)).toEqual([]);
   });
 
@@ -181,7 +185,8 @@ describe('plan handler', () => {
     await deps.sigintHandlerRegistered;
     deps.triggerSigint();
 
-    expect(reviewPromise).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(reviewPromise);
+    expect(err.kind).toBe('cancelled');
     expect(telemetry.exceptions).toEqual([]);
     expect(analytics.captures.some((c) => c.event === 'plan_review_submitted')).toBe(false);
   });

--- a/packages/cli/src/commands/plan.ts
+++ b/packages/cli/src/commands/plan.ts
@@ -1,5 +1,6 @@
 import { getErrorMessage } from '@contextbridge/shared/errors';
-import { type Command, CommanderError, InvalidArgumentError } from 'commander';
+import { type Command, InvalidArgumentError } from 'commander';
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
 import {
   type AnnotationDependencies,
   AnnotationInterruptedError,
@@ -9,54 +10,46 @@ import type { CliContext } from '#src/context.ts';
 import { parsePort } from '#src/environment.ts';
 import { formatAgentResponse } from '#src/formatters/annotation/markdown.ts';
 import { PLAN_TEMPLATES } from '#src/formatters/plan/templates.ts';
-import { abort } from './abort.ts';
+import { AbortError, handleCommandResult } from './abort.ts';
 
 export interface PlanArgs {
   path?: string;
   port?: number;
 }
 
-export async function runPlan(ctx: CliContext, args: PlanArgs, deps?: AnnotationDependencies): Promise<void> {
+export function runPlan(ctx: CliContext, args: PlanArgs, deps?: AnnotationDependencies): ResultAsync<void, AbortError> {
   const { io, logger } = ctx;
   const { path, port } = args;
 
   if (!path && io.stdinIsTTY === true) {
-    abort(
-      ctx,
-      'plan',
-      'input',
-      'provide plan content via stdin (e.g. `cat plan.md | contextbridge plan`) or a file path via [path]',
+    return errAsync(
+      AbortError.input(
+        'plan',
+        'provide plan content via stdin (e.g. `cat plan.md | contextbridge plan`) or a file path via [path]',
+      ),
     );
   }
 
   const source: 'file' | 'stdin' = path ? 'file' : 'stdin';
-  let content: string;
-  try {
-    content = path ? await Bun.file(path).text() : await io.readStdin();
-  } catch (err) {
-    abort(ctx, 'plan', 'input', `failed to read plan from ${source}: ${getErrorMessage(err)}`);
-  }
-
-  if (content.trim().length === 0) {
-    abort(ctx, 'plan', 'input', 'plan content is empty');
-  }
-
-  logger.info({ source, bytes: Buffer.byteLength(content, 'utf8') }, 'plan received');
-
-  try {
-    const submission = await runAnnotation(
-      ctx,
-      { content, contentKind: 'plan', entrypoint: 'plan_command', port },
-      deps,
-    );
-    io.writeStdout(formatAgentResponse(PLAN_TEMPLATES, submission, content));
-  } catch (err) {
-    if (err instanceof AnnotationInterruptedError) {
-      logger.info('plan review interrupted');
-      throw new CommanderError(130, 'contextbridge.plan.sigint', 'plan review interrupted');
-    }
-    abort(ctx, 'plan', 'runtime', getErrorMessage(err));
-  }
+  return ResultAsync.fromPromise(path ? Bun.file(path).text() : io.readStdin(), (err) =>
+    AbortError.input('plan', `failed to read plan from ${source}: ${getErrorMessage(err)}`),
+  )
+    .andThen((content) => {
+      if (content.trim().length === 0) return errAsync(AbortError.input('plan', 'plan content is empty'));
+      return okAsync(content);
+    })
+    .andThen((content) => {
+      logger.info({ source, bytes: Buffer.byteLength(content, 'utf8') }, 'plan received');
+      return ResultAsync.fromPromise(
+        runAnnotation(ctx, { content, contentKind: 'plan', entrypoint: 'plan_command', port }, deps),
+        (err) =>
+          err instanceof AnnotationInterruptedError
+            ? AbortError.cancelled('plan', 'plan review interrupted', { code: 'contextbridge.plan.sigint' })
+            : AbortError.runtime('plan', getErrorMessage(err)),
+      ).map((submission) => {
+        io.writeStdout(formatAgentResponse(PLAN_TEMPLATES, submission, content));
+      });
+    });
 }
 
 export function registerPlan(ctx: CliContext, program: Command): void {
@@ -68,7 +61,7 @@ export function registerPlan(ctx: CliContext, program: Command): void {
     .argument('[path]', 'path to a file containing the plan (alternative to stdin)')
     .option('--port <number>', 'serve the plan review browser UI on a specific port', parsePortOption)
     .action(async (path: string | undefined, opts: { port?: number }) => {
-      await runPlan(ctx, { path, port: opts.port });
+      await handleCommandResult(ctx, runPlan(ctx, { path, port: opts.port }));
     });
 }
 

--- a/packages/cli/src/commands/uninstall.test.ts
+++ b/packages/cli/src/commands/uninstall.test.ts
@@ -1,8 +1,14 @@
 import { getHarness } from '@contextbridge/harness';
 import { describe, expect, it } from 'bun:test';
-import { CommanderError } from 'commander';
 import { CLAUDE_MARKETPLACE_NAME, CLAUDE_PLUGIN_ID } from '#src/installers/ClaudeInstaller.ts';
-import { createStubContext, marketplaceListResult, pluginListResult } from '#src/testHelpers/index.ts';
+import {
+  createStubContext,
+  expectErr,
+  expectOk,
+  marketplaceListResult,
+  pluginListResult,
+} from '#src/testHelpers/index.ts';
+import { AbortError } from './abort.ts';
 import { runUninstall } from './uninstall.ts';
 
 const CLAUDE_BINARY = getHarness('claude').binaryName;
@@ -20,7 +26,7 @@ describe('runUninstall', () => {
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves();
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
 
-    await runUninstall(context, { yes: true });
+    await expectOk(runUninstall(context, { yes: true }));
 
     const uninstallCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall']);
     const marketplaceRemoveCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']);
@@ -38,7 +44,7 @@ describe('runUninstall', () => {
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
 
-    await runUninstall(context, { yes: true });
+    await expectOk(runUninstall(context, { yes: true }));
 
     expect(commandRunner.calls).toHaveLength(2);
     expect(prompter.calls).toEqual([]);
@@ -56,7 +62,7 @@ describe('runUninstall', () => {
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']).resolves();
 
-    await runUninstall(context, { yes: true });
+    await expectOk(runUninstall(context, { yes: true }));
 
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
     const marketplaceRemoveCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove']);
@@ -74,7 +80,7 @@ describe('runUninstall', () => {
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
 
-    await runUninstall(context, { yes: true, force: true });
+    await expectOk(runUninstall(context, { yes: true, force: true }));
 
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toEqual([]);
@@ -94,18 +100,19 @@ describe('runUninstall', () => {
       .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]));
     prompter.setConfirm(false);
 
-    await runUninstall(context);
+    await expectOk(runUninstall(context));
 
     expect(prompter.calls).toEqual([{ message: 'Remove PlanBridge from Claude Code?', default: true }]);
     expect(io.stderr.text()).toContain('Claude Code: skipped');
     expect(io.stderr.text()).toContain('Uninstalled 0 of 1 detected harness');
   });
 
-  it('throws when no supported harnesses are detected', () => {
+  it('throws when no supported harnesses are detected', async () => {
     const { context, commandRunner, io } = createStubContext();
     commandRunner.setWhich(CLAUDE_BINARY, null);
 
-    expect(runUninstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runUninstall(context, { yes: true }));
+    expect(err).toBeInstanceOf(AbortError);
     expect(commandRunner.calls).toEqual([]);
     expect(io.stderr.text()).toContain('Claude Code: not detected');
   });

--- a/packages/cli/src/commands/uninstall.ts
+++ b/packages/cli/src/commands/uninstall.ts
@@ -1,6 +1,9 @@
 import type { Command } from 'commander';
+import type { ResultAsync } from 'neverthrow';
 import type { CliContext } from '#src/context.ts';
 import { ALL_INSTALLERS } from '#src/installers/installers.ts';
+import type { AbortError } from './abort.ts';
+import { handleCommandResult } from './abort.ts';
 import { runHarnessOperation } from './harnessOperation.ts';
 
 export interface UninstallOptions {
@@ -8,9 +11,9 @@ export interface UninstallOptions {
   force?: boolean;
 }
 
-export async function runUninstall(ctx: CliContext, options: UninstallOptions = {}): Promise<void> {
+export function runUninstall(ctx: CliContext, options: UninstallOptions = {}): ResultAsync<void, AbortError> {
   const { yes = false, force = false } = options;
-  await runHarnessOperation(ctx, 'uninstall', { yes, force });
+  return runHarnessOperation(ctx, 'uninstall', { yes, force });
 }
 
 export function registerUninstall(ctx: CliContext, program: Command): void {
@@ -22,7 +25,7 @@ export function registerUninstall(ctx: CliContext, program: Command): void {
     .option('-y, --yes', 'skip confirmation prompts', false)
     .option('--force', 'run uninstall even when PlanBridge is not wired up', false)
     .action(async (opts: UninstallOptions) => {
-      await runUninstall(ctx, opts);
+      await handleCommandResult(ctx, runUninstall(ctx, opts));
     });
 
   for (const installer of ALL_INSTALLERS) {

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -3,15 +3,17 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getHarness } from '@contextbridge/harness';
 import { describe, expect, it } from 'bun:test';
-import { CommanderError } from 'commander';
 import { CLAUDE_LEGACY_PLUGIN_ID, CLAUDE_MARKETPLACE_NAME, CLAUDE_PLUGIN_ID } from '#src/installers/ClaudeInstaller.ts';
 import {
   createStubContext,
+  expectErr,
+  expectOk,
   marketplaceListResult,
   pluginListResult,
   readErrorLogs,
   readWarnLogs,
 } from '#src/testHelpers/index.ts';
+import { AbortError } from './abort.ts';
 import { runUpdate } from './update.ts';
 
 const CLAUDE_BINARY = getHarness('claude').binaryName;
@@ -23,11 +25,11 @@ const FAKE_CONTEXTBRIDGE_PATH = '/usr/local/bin/contextbridge';
 describe('runUpdate', () => {
   it('prints "up to date" and exits 0 when there is no notice', async () => {
     const { context, io } = createStubContext();
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
     expect(io.stderr.text()).toContain('contextbridge is up to date');
   });
 
-  it('refuses on dev-build with no logger.error', () => {
+  it('refuses on dev-build with no logger.error', async () => {
     const { context, io, logs, updater } = createStubContext();
     // Dev-build detection happens inside UpdaterImpl; the FakeUpdater lets
     // us simulate it by returning a notice + refusal.
@@ -38,12 +40,13 @@ describe('runUpdate', () => {
       message: 'contextbridge is running as a dev build. Rebuild from source to update.',
     });
 
-    expect(runUpdate(context)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runUpdate(context));
+    expect(err).toBeInstanceOf(AbortError);
     expect(io.stderr.text()).toContain('dev build');
     expect(readErrorLogs(logs)).toEqual([]);
   });
 
-  it('refuses on opt-out with no logger.error', () => {
+  it('refuses on opt-out with no logger.error', async () => {
     const { context, io, logs, updater } = createStubContext();
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({
@@ -52,12 +55,13 @@ describe('runUpdate', () => {
       message: 'update check is disabled via CONTEXTBRIDGE_UPDATE_CHECK_DISABLED.',
     });
 
-    expect(runUpdate(context)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runUpdate(context));
+    expect(err).toBeInstanceOf(AbortError);
     expect(io.stderr.text()).toContain('disabled');
     expect(readErrorLogs(logs)).toEqual([]);
   });
 
-  it('emits logger.warn with diagnostics AND prints fallback commands on recovery-needed', () => {
+  it('emits logger.warn with diagnostics AND prints fallback commands on recovery-needed', async () => {
     const { context, io, logs, updater } = createStubContext();
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({
@@ -77,7 +81,8 @@ describe('runUpdate', () => {
       },
     });
 
-    expect(runUpdate(context)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runUpdate(context));
+    expect(err).toBeInstanceOf(AbortError);
 
     // Both fallback commands printed to stdout so users can pipe/script them.
     expect(io.stdout.text()).toContain('brew upgrade --cask contextbridge/tap/cli');
@@ -96,7 +101,7 @@ describe('runUpdate', () => {
     expect(readErrorLogs(logs)).toEqual([]);
   });
 
-  it('prints alpha-channel fallback commands on recovery-needed for alpha builds', () => {
+  it('prints alpha-channel fallback commands on recovery-needed for alpha builds', async () => {
     const { context, io, updater } = createStubContext();
     updater.setCheckResult({
       currentVersion: '0.2.0-alpha.1',
@@ -120,7 +125,8 @@ describe('runUpdate', () => {
       },
     });
 
-    expect(runUpdate(context)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runUpdate(context));
+    expect(err).toBeInstanceOf(AbortError);
 
     // Alpha variants must appear so users copy the right install command.
     expect(io.stdout.text()).toContain('brew upgrade --cask contextbridge/tap/cli@alpha');
@@ -132,7 +138,7 @@ describe('runUpdate', () => {
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({ status: 'skipped-already-latest', currentVersion: '0.2.0' });
 
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
 
     expect(io.stderr.text()).toContain('up to date (v0.2.0)');
   });
@@ -146,7 +152,7 @@ describe('runUpdate', () => {
       exitCode: 0,
     });
 
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
     expect(io.stderr.text()).toContain('update complete');
   });
 
@@ -159,12 +165,12 @@ describe('runUpdate', () => {
       exitCode: 0,
     });
 
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
 
     expect(io.stderr.text()).toContain('https://github.com/contextbridge/planbridge/releases/tag/v0.2.0');
   });
 
-  it('logger.error + throws CommanderError when the installer exits non-zero', () => {
+  it('logger.error + returns a typed error when the installer exits non-zero', async () => {
     const { context, io, logs, updater } = createStubContext();
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({
@@ -173,12 +179,13 @@ describe('runUpdate', () => {
       cause: new Error('installer exited 17'),
     });
 
-    expect(runUpdate(context)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runUpdate(context));
+    expect(err).toBeInstanceOf(AbortError);
     expect(io.stderr.text()).toContain('installer exited 17');
     expect(readErrorLogs(logs).some((r) => r.msg.includes('installer exited 17'))).toBe(true);
   });
 
-  it('logger.error + throws on error status', () => {
+  it('logger.error + returns a typed error on error status', async () => {
     const { context, logs, updater } = createStubContext();
     updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
     updater.setPerformResult({
@@ -187,7 +194,8 @@ describe('runUpdate', () => {
       cause: new Error('ECONNRESET'),
     });
 
-    expect(runUpdate(context)).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(runUpdate(context));
+    expect(err).toBeInstanceOf(AbortError);
     const errorLogs = readErrorLogs(logs);
     expect(errorLogs.length).toBe(1);
     expect(errorLogs[0]?.msg).toContain('ECONNRESET');
@@ -202,7 +210,7 @@ describe('runUpdate', () => {
       exitCode: 0,
     });
 
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
     expect(updater.checkForUpdateCalls).toEqual([{ forceRefresh: true }]);
     expect(updater.performUpdateCallCount).toBe(1);
   });
@@ -225,7 +233,7 @@ describe('runUpdate', () => {
       .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]));
     commandRunner.on(FAKE_CONTEXTBRIDGE_PATH, ['install', 'claude']).resolves();
 
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
 
     const spawnCall = commandRunner.calls.find((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
     expect(spawnCall).toBeDefined();
@@ -250,7 +258,7 @@ describe('runUpdate', () => {
       .resolves(pluginListResult([{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }]));
     commandRunner.on(FAKE_CONTEXTBRIDGE_PATH, ['install', 'claude']).resolves();
 
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
 
     const spawnCall = commandRunner.calls.find((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
     expect(spawnCall).toBeDefined();
@@ -275,7 +283,7 @@ describe('runUpdate', () => {
       .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'project' }]));
     commandRunner.on(FAKE_CONTEXTBRIDGE_PATH, ['install', 'claude']).resolves();
 
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
 
     const spawnCall = commandRunner.calls.find((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
     expect(spawnCall).toBeDefined();
@@ -300,7 +308,7 @@ describe('runUpdate', () => {
       .resolves(pluginListResult([{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'project' }]));
     commandRunner.on(FAKE_CONTEXTBRIDGE_PATH, ['install', 'claude']).resolves();
 
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
 
     const spawnCall = commandRunner.calls.find((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
     expect(spawnCall).toBeDefined();
@@ -330,7 +338,7 @@ describe('runUpdate', () => {
       );
       commandRunner.on(FAKE_CONTEXTBRIDGE_PATH, ['install', 'codex']).resolves();
 
-      await runUpdate(context);
+      await expectOk(runUpdate(context));
 
       const spawnCall = commandRunner.calls.find((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
       expect(spawnCall).toBeDefined();
@@ -353,7 +361,7 @@ describe('runUpdate', () => {
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves(marketplaceListResult([]));
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
 
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
 
     const spawnCalls = commandRunner.calls.filter((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
     expect(spawnCalls).toEqual([]);
@@ -374,8 +382,29 @@ describe('runUpdate', () => {
       .resolves(marketplaceListResult([{ name: CLAUDE_MARKETPLACE_NAME }]));
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'list', '--json']).resolves(pluginListResult([]));
 
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
 
+    const spawnCalls = commandRunner.calls.filter((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
+    expect(spawnCalls).toEqual([]);
+  });
+
+  it('logs a warning and skips refresh when Codex is too old after update', async () => {
+    const { context, io, logs, commandRunner, updater } = createStubContext();
+    commandRunner.setWhich(CODEX_BINARY, '/usr/local/bin/codex');
+    commandRunner.setWhich('contextbridge', FAKE_CONTEXTBRIDGE_PATH);
+    commandRunner.on(CODEX_BINARY, ['--version']).resolves({ stdout: 'codex-cli 0.128.0\n' });
+    updater.setCheckResult({ currentVersion: '0.1.0', latestVersion: '0.2.0', channel: 'stable' });
+    updater.setPerformResult({
+      status: 'executed',
+      command: ['brew', 'upgrade', '--cask', 'contextbridge/tap/cli'],
+      exitCode: 0,
+    });
+
+    await expectOk(runUpdate(context));
+
+    expect(io.stderr.text()).toContain('update complete');
+    expect(readWarnLogs(logs).some((r) => r.msg.includes('post-update harness refresh failed'))).toBe(true);
+    expect(readErrorLogs(logs)).toEqual([]);
     const spawnCalls = commandRunner.calls.filter((c) => c.cmd === FAKE_CONTEXTBRIDGE_PATH);
     expect(spawnCalls).toEqual([]);
   });
@@ -400,7 +429,7 @@ describe('runUpdate', () => {
       .on(FAKE_CONTEXTBRIDGE_PATH, ['install', 'claude'])
       .resolves({ exitCode: 1, stderr: 'install failed' });
 
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
 
     expect(io.stderr.text()).toContain('update complete');
     expect(readErrorLogs(logs).some((r) => r.msg.includes('post-update harness refresh failed'))).toBe(true);
@@ -423,7 +452,7 @@ describe('runUpdate', () => {
       .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
       .resolves(pluginListResult([{ id: CLAUDE_PLUGIN_ID, scope: 'user' }]));
 
-    await runUpdate(context);
+    await expectOk(runUpdate(context));
 
     expect(io.stderr.text()).toContain('update complete');
     expect(readErrorLogs(logs).some((r) => r.msg.includes('contextbridge not found on PATH'))).toBe(true);

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,10 +1,16 @@
 import { GITHUB_REPO_URL } from '@contextbridge/shared/links';
-import { type Command, CommanderError } from 'commander';
+import type { Command } from 'commander';
+import type { ResultAsync } from 'neverthrow';
 import type { CliContext } from '#src/context.ts';
 import type { HarnessInstaller, ManagedEntry } from '#src/installers/HarnessInstaller.ts';
 import { ALL_INSTALLERS } from '#src/installers/installers.ts';
+import { AbortError, abortable, handleCommandResult, logAbortError } from './abort.ts';
 
-export async function runUpdate(ctx: CliContext): Promise<void> {
+export function runUpdate(ctx: CliContext): ResultAsync<void, AbortError> {
+  return abortable('update', runUpdateUnsafe(ctx));
+}
+
+async function runUpdateUnsafe(ctx: CliContext): Promise<void> {
   const { io, logger, updater } = ctx;
 
   const notice = await updater.checkForUpdate({ forceRefresh: true });
@@ -20,7 +26,7 @@ export async function runUpdate(ctx: CliContext): Promise<void> {
   switch (result.status) {
     case 'refused':
       io.writeStderr(`${result.message}\n`);
-      throw new CommanderError(1, `contextbridge.update.${result.reason}`, result.message);
+      throw AbortError.input('update', result.message, { code: `contextbridge.update.${result.reason}` });
 
     case 'recovery-needed':
       logger.warn(result.diagnostics, 'update: could not detect install method');
@@ -28,7 +34,7 @@ export async function runUpdate(ctx: CliContext): Promise<void> {
       for (const command of result.fallbackCommands) {
         io.writeStdout(`${command}\n`);
       }
-      throw new CommanderError(1, `contextbridge.update.${result.reason}`, result.message);
+      throw AbortError.input('update', result.message, { code: `contextbridge.update.${result.reason}` });
 
     case 'skipped-already-latest':
       io.writeStderr(`contextbridge is up to date (v${result.currentVersion}).\n`);
@@ -42,7 +48,7 @@ export async function runUpdate(ctx: CliContext): Promise<void> {
     case 'error':
       logger.error({ cause: result.cause }, result.message);
       io.writeStderr(`${result.message}\n`);
-      throw new CommanderError(1, 'contextbridge.update.unexpected', result.message);
+      throw AbortError.runtime('update', result.message, { code: 'contextbridge.update.unexpected' });
 
     default:
       return assertNever(result);
@@ -56,7 +62,7 @@ export function registerUpdate(ctx: CliContext, program: Command): void {
       'Check for a newer release and re-run the install method that put this binary on your system (Homebrew or the install script).',
     )
     .action(async () => {
-      await runUpdate(ctx);
+      await handleCommandResult(ctx, runUpdate(ctx));
     });
 }
 
@@ -80,13 +86,12 @@ async function refreshInstalledHarnesses(ctx: CliContext): Promise<void> {
 }
 
 async function getInstallerRefreshScopes(ctx: CliContext, installer: HarnessInstaller): Promise<string[]> {
-  try {
-    const status = await installer.status(ctx);
-    return getRefreshScopes(status.managed);
-  } catch (err) {
-    ctx.logger.error({ err, harness: installer.descriptor.id }, 'post-update harness refresh failed');
+  const result = await installer.status(ctx);
+  if (result.isErr()) {
+    logAbortError(ctx, result.error, 'post-update harness refresh failed', { harness: installer.descriptor.id });
     return [];
   }
+  return getRefreshScopes(result.value.managed);
 }
 
 async function refreshInstallerScope(

--- a/packages/cli/src/installers/ClaudeInstaller.test.ts
+++ b/packages/cli/src/installers/ClaudeInstaller.test.ts
@@ -1,10 +1,12 @@
 import { getHarness } from '@contextbridge/harness';
 import { describe, expect, it } from 'bun:test';
-import { CommanderError } from 'commander';
+import { AbortError } from '#src/commands/abort.ts';
 import {
   createStubContext,
+  expectErr,
+  expectOk,
+  expectOkValue,
   primeClaudeShellouts,
-  readErrorLogs,
   readLogs,
   stubClaudeState,
 } from '#src/testHelpers/index.ts';
@@ -22,7 +24,7 @@ describe('ClaudeInstaller.install', () => {
   it('runs marketplace-add then plugin-install at user scope and emits onboarding prose', async () => {
     const { installer, context, io, commandRunner } = setupTest();
 
-    await installer.install(context, { yes: true });
+    await expectOk(installer.install(context, { yes: true }));
 
     expect(commandRunner.calls).toEqual([
       { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
@@ -49,7 +51,7 @@ describe('ClaudeInstaller.install', () => {
       stdout: "Adding marketplace…✔ Marketplace 'contextbridge' already on disk — declared in user settings",
     });
 
-    await installer.install(context, { yes: true });
+    await expectOk(installer.install(context, { yes: true }));
 
     const updateCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'update']);
     expect(updateCalls).toHaveLength(1);
@@ -63,7 +65,7 @@ describe('ClaudeInstaller.install', () => {
     const { installer, context, io, commandRunner } = setupTest();
     stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }] });
 
-    await installer.install(context, { yes: true });
+    await expectOk(installer.install(context, { yes: true }));
 
     expect(commandRunner.calls).toEqual([
       { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
@@ -88,60 +90,64 @@ describe('ClaudeInstaller.install', () => {
     const { installer, context, io, commandRunner } = setupTest();
     stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'project' }] });
 
-    await installer.install(context, { yes: true });
+    await expectOk(installer.install(context, { yes: true }));
 
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toHaveLength(1);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
     expect(io.stderr.text()).not.toContain('renamed from cli@contextbridge');
   });
 
-  it('aborts when claude is not on PATH and never invokes a shellout', () => {
+  it('aborts when claude is not on PATH and never invokes a shellout', async () => {
     const { installer, context, commandRunner } = setupTest();
     commandRunner.setWhich(CLAUDE_BINARY, null);
 
-    expect(installer.install(context, { yes: true })).rejects.toThrow('Install Claude Code');
+    const err = await expectErr(installer.install(context, { yes: true }));
+    expect(err.message).toContain('Install Claude Code');
     expect(commandRunner.calls).toEqual([]);
   });
 
-  it('aborts when marketplace-add fails and bubbles stderr', () => {
-    const { installer, context, commandRunner, logs } = setupTest();
+  it('aborts when marketplace-add fails and bubbles stderr', async () => {
+    const { installer, context, commandRunner } = setupTest();
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])
       .resolves({ exitCode: 1, stderr: 'network unreachable' });
 
-    expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(installer.install(context, { yes: true }));
+    expect(err).toBeInstanceOf(AbortError);
+    expect(err.message).toContain('network unreachable');
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toEqual([]);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'update'])).toEqual([]);
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('network unreachable'))).toBe(true);
   });
 
-  it('aborts when plugin-install fails after a successful marketplace-add', () => {
-    const { installer, context, commandRunner, logs } = setupTest();
+  it('aborts when plugin-install fails after a successful marketplace-add', async () => {
+    const { installer, context, commandRunner } = setupTest();
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'install'])
       .resolves({ exitCode: 1, stderr: 'plugin not found in marketplace' });
 
-    expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(installer.install(context, { yes: true }));
+    expect(err).toBeInstanceOf(AbortError);
+    expect(err.message).toContain('plugin not found in marketplace');
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toHaveLength(1);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('plugin not found in marketplace'))).toBe(true);
   });
 
-  it('does not remove a legacy install when the new plugin install fails', () => {
-    const { installer, context, commandRunner, logs } = setupTest();
+  it('does not remove a legacy install when the new plugin install fails', async () => {
+    const { installer, context, commandRunner } = setupTest();
     stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }] });
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'install'])
       .resolves({ exitCode: 1, stderr: 'plugin not found in marketplace' });
 
-    expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(installer.install(context, { yes: true }));
+    expect(err).toBeInstanceOf(AbortError);
+    expect(err.message).toContain('plugin not found in marketplace');
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'install'])).toHaveLength(1);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('plugin not found in marketplace'))).toBe(true);
   });
 
-  it('does not remove a legacy install when the new plugin update fails', () => {
-    const { installer, context, commandRunner, logs } = setupTest();
+  it('does not remove a legacy install when the new plugin update fails', async () => {
+    const { installer, context, commandRunner } = setupTest();
     stubClaudeState(commandRunner, {
       unmanagedPlugins: [
         { id: CLAUDE_PLUGIN_ID, scope: 'user' },
@@ -150,18 +156,20 @@ describe('ClaudeInstaller.install', () => {
     });
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'update']).resolves({ exitCode: 1, stderr: 'update failed' });
 
-    expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(installer.install(context, { yes: true }));
+    expect(err).toBeInstanceOf(AbortError);
+    expect(err.message).toContain('update failed');
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'update'])).toHaveLength(1);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('update failed'))).toBe(true);
   });
 
-  it('logs a synthetic detail when stderr is empty on a non-zero exit', () => {
-    const { installer, context, commandRunner, logs } = setupTest();
+  it('returns a synthetic detail when stderr is empty on a non-zero exit', async () => {
+    const { installer, context, commandRunner } = setupTest();
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'add']).resolves({ exitCode: 3 });
 
-    expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
-    expect(readLogs(logs).some((r) => r.msg.includes('exited 3'))).toBe(true);
+    const err = await expectErr(installer.install(context, { yes: true }));
+    expect(err).toBeInstanceOf(AbortError);
+    expect(err.message).toContain('exited 3');
   });
 });
 
@@ -172,7 +180,7 @@ describe('ClaudeInstaller.uninstall', () => {
       marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] }],
     });
 
-    await installer.uninstall(context, { yes: true });
+    await expectOk(installer.uninstall(context, { yes: true }));
 
     expect(commandRunner.calls).toEqual([
       { cmd: CLAUDE_BINARY, args: ['plugin', 'list', '--json'], opts: {} },
@@ -190,7 +198,7 @@ describe('ClaudeInstaller.uninstall', () => {
       marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }] }],
     });
 
-    await installer.uninstall(context, { yes: true });
+    await expectOk(installer.uninstall(context, { yes: true }));
 
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toHaveLength(1);
@@ -202,7 +210,7 @@ describe('ClaudeInstaller.uninstall', () => {
     const { installer, context, io, commandRunner, logs } = setupTest();
     stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] });
 
-    await installer.uninstall(context, { yes: true });
+    await expectOk(installer.uninstall(context, { yes: true }));
 
     const uninstallCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall']);
     expect(uninstallCalls).toHaveLength(1);
@@ -218,7 +226,7 @@ describe('ClaudeInstaller.uninstall', () => {
       marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }] }],
     });
 
-    await installer.uninstall(context, { yes: true });
+    await expectOk(installer.uninstall(context, { yes: true }));
 
     const uninstallCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall']);
     expect(uninstallCalls).toHaveLength(1);
@@ -242,7 +250,7 @@ describe('ClaudeInstaller.uninstall', () => {
       ],
     });
 
-    await installer.uninstall(context, { yes: true });
+    await expectOk(installer.uninstall(context, { yes: true }));
 
     const uninstallCalls = commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall']);
     expect(uninstallCalls).toHaveLength(2);
@@ -254,45 +262,48 @@ describe('ClaudeInstaller.uninstall', () => {
   it('is fully idempotent when both the plugin and marketplace are already absent', async () => {
     const { installer, context, io, commandRunner } = setupTest();
 
-    await installer.uninstall(context, { yes: true });
+    await expectOk(installer.uninstall(context, { yes: true }));
 
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toEqual([]);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toEqual([]);
     expect(io.stderr.text()).toContain('PlanBridge plugin removed');
   });
 
-  it('aborts when claude is not on PATH and never invokes a shellout', () => {
+  it('aborts when claude is not on PATH and never invokes a shellout', async () => {
     const { installer, context, commandRunner } = setupTest();
     commandRunner.setWhich(CLAUDE_BINARY, null);
 
-    expect(installer.uninstall(context, { yes: true })).rejects.toThrow('Install Claude Code');
+    const err = await expectErr(installer.uninstall(context, { yes: true }));
+    expect(err.message).toContain('Install Claude Code');
     expect(commandRunner.calls).toEqual([]);
   });
 
-  it('bubbles a CommanderError and runs no further shellouts when `plugin list --json` fails', () => {
-    const { installer, context, commandRunner, logs } = setupTest();
+  it('bubbles a typed error and runs no further shellouts when `plugin list --json` fails', async () => {
+    const { installer, context, commandRunner } = setupTest();
     commandRunner
       .on(CLAUDE_BINARY, ['plugin', 'list', '--json'])
       .resolves({ exitCode: 1, stderr: 'permission denied' });
 
-    expect(installer.uninstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(installer.uninstall(context, { yes: true }));
+    expect(err).toBeInstanceOf(AbortError);
+    expect(err.message).toContain('permission denied');
     expect(commandRunner.calls).toHaveLength(1);
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('permission denied'))).toBe(true);
   });
 
-  it('bubbles a real plugin-uninstall failure and does not call marketplace-list', () => {
-    const { installer, context, commandRunner, logs } = setupTest();
+  it('bubbles a real plugin-uninstall failure and does not call marketplace-list', async () => {
+    const { installer, context, commandRunner } = setupTest();
     stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] });
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'uninstall']).resolves({ exitCode: 1, stderr: 'disk full' });
 
-    expect(installer.uninstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(installer.uninstall(context, { yes: true }));
+    expect(err).toBeInstanceOf(AbortError);
+    expect(err.message).toContain('disk full');
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'uninstall'])).toHaveLength(1);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json'])).toEqual([]);
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('disk full'))).toBe(true);
   });
 
-  it('bubbles a real marketplace-remove failure after a clean plugin uninstall', () => {
-    const { installer, context, commandRunner, logs } = setupTest();
+  it('bubbles a real marketplace-remove failure after a clean plugin uninstall', async () => {
+    const { installer, context, commandRunner } = setupTest();
     stubClaudeState(commandRunner, {
       marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] }],
     });
@@ -300,9 +311,10 @@ describe('ClaudeInstaller.uninstall', () => {
       .on(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])
       .resolves({ exitCode: 1, stderr: 'some other marketplace error' });
 
-    expect(installer.uninstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
+    const err = await expectErr(installer.uninstall(context, { yes: true }));
+    expect(err).toBeInstanceOf(AbortError);
+    expect(err.message).toContain('some other marketplace error');
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'remove'])).toHaveLength(1);
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('some other marketplace error'))).toBe(true);
   });
 });
 
@@ -311,7 +323,7 @@ describe('ClaudeInstaller scope prompt', () => {
     const { installer, context, commandRunner, prompter } = setupTest();
     prompter.setSelect('project');
 
-    await installer.install(context, { yes: false });
+    await expectOk(installer.install(context, { yes: false }));
 
     expect(prompter.selectCalls).toHaveLength(1);
     expect(prompter.selectCalls[0]?.message).toBe('Install scope:');
@@ -322,7 +334,7 @@ describe('ClaudeInstaller scope prompt', () => {
   it('skips the scope prompt when yes=true and uses the user-scope default', async () => {
     const { installer, context, commandRunner, prompter } = setupTest();
 
-    await installer.install(context, { yes: true });
+    await expectOk(installer.install(context, { yes: true }));
 
     expect(prompter.selectCalls).toEqual([]);
     expect(commandRunner.callsTo(CLAUDE_BINARY, ['plugin', 'marketplace', 'add'])[0]?.args).toContain('user');
@@ -335,7 +347,7 @@ describe('ClaudeInstaller scope prompt', () => {
     });
     prompter.setSelect('project');
 
-    await installer.uninstall(context, { yes: false });
+    await expectOk(installer.uninstall(context, { yes: false }));
 
     expect(prompter.selectCalls).toHaveLength(1);
     expect(prompter.selectCalls[0]?.message).toBe('Uninstall scope:');
@@ -354,7 +366,7 @@ describe('ClaudeInstaller.status', () => {
     const { installer, context, commandRunner } = setupTest();
     commandRunner.setWhich(CLAUDE_BINARY, null);
 
-    const status = await installer.status(context);
+    const status = await expectOkValue(installer.status(context));
 
     expect(status.detected).toBe(false);
     expect(status.installed).toBe(false);
@@ -368,7 +380,7 @@ describe('ClaudeInstaller.status', () => {
       marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'user' }] }],
     });
 
-    const status = await installer.status(context);
+    const status = await expectOkValue(installer.status(context));
 
     expect(status.detected).toBe(true);
     expect(status.installed).toBe(true);
@@ -382,7 +394,7 @@ describe('ClaudeInstaller.status', () => {
     const { installer, context, commandRunner } = setupTest();
     stubClaudeState(commandRunner, { unmanagedPlugins: [{ id: CLAUDE_PLUGIN_ID, scope: 'project' }] });
 
-    const status = await installer.status(context);
+    const status = await expectOkValue(installer.status(context));
 
     expect(status.detected).toBe(true);
     expect(status.installed).toBe(true);
@@ -395,7 +407,7 @@ describe('ClaudeInstaller.status', () => {
       marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME, plugins: [{ id: CLAUDE_LEGACY_PLUGIN_ID, scope: 'user' }] }],
     });
 
-    const status = await installer.status(context);
+    const status = await expectOkValue(installer.status(context));
 
     expect(status.detected).toBe(true);
     expect(status.installed).toBe(false);
@@ -419,7 +431,7 @@ describe('ClaudeInstaller.status', () => {
       ],
     });
 
-    const status = await installer.status(context);
+    const status = await expectOkValue(installer.status(context));
 
     expect(status.detected).toBe(true);
     expect(status.installed).toBe(true);
@@ -434,7 +446,7 @@ describe('ClaudeInstaller.status', () => {
     const { installer, context, commandRunner } = setupTest();
     stubClaudeState(commandRunner, { marketplaces: [{ name: CLAUDE_MARKETPLACE_NAME }] });
 
-    const status = await installer.status(context);
+    const status = await expectOkValue(installer.status(context));
 
     expect(status.detected).toBe(true);
     expect(status.installed).toBe(false);
@@ -444,19 +456,20 @@ describe('ClaudeInstaller.status', () => {
   it('reports detected: true with no managed entries when claude is on PATH but PlanBridge is not installed', async () => {
     const { installer, context } = setupTest();
 
-    const status = await installer.status(context);
+    const status = await expectOkValue(installer.status(context));
 
     expect(status.detected).toBe(true);
     expect(status.installed).toBe(false);
     expect(status.managed).toEqual([]);
   });
 
-  it('bubbles a CommanderError when marketplace status cannot be listed', () => {
-    const { installer, context, commandRunner, logs } = setupTest();
+  it('bubbles a typed error when marketplace status cannot be listed', async () => {
+    const { installer, context, commandRunner } = setupTest();
     commandRunner.on(CLAUDE_BINARY, ['plugin', 'marketplace', 'list', '--json']).resolves({ exitCode: 2 });
 
-    expect(installer.status(context)).rejects.toBeInstanceOf(CommanderError);
-    expect(readErrorLogs(logs).some((r) => r.msg.includes('exited 2'))).toBe(true);
+    const err = await expectErr(installer.status(context));
+    expect(err).toBeInstanceOf(AbortError);
+    expect(err.message).toContain('exited 2');
   });
 });
 

--- a/packages/cli/src/installers/ClaudeInstaller.ts
+++ b/packages/cli/src/installers/ClaudeInstaller.ts
@@ -1,6 +1,7 @@
 import { type InstallableHarness, getInstallableHarness } from '@contextbridge/harness';
-import { CommanderError } from 'commander';
+import type { ResultAsync } from 'neverthrow';
 import { z } from 'zod';
+import { AbortError, abortable } from '#src/commands/abort.ts';
 import type { CliContext } from '#src/context.ts';
 import { detectHarness } from './detect.ts';
 import { type HarnessStatus, type ManagedEntry } from './HarnessInstaller.ts';
@@ -32,7 +33,11 @@ export class ClaudeInstaller extends ScopedHarnessInstaller {
   protected readonly uninstallDescription =
     'Uninstall the PlanBridge plugin from Claude Code via the `claude plugin` CLI.';
 
-  async status(ctx: CliContext): Promise<HarnessStatus> {
+  status(ctx: CliContext): ResultAsync<HarnessStatus, AbortError> {
+    return abortable('claudeInstaller', this.statusUnsafe(ctx));
+  }
+
+  private async statusUnsafe(ctx: CliContext): Promise<HarnessStatus> {
     const { binaryName } = this.descriptor;
     const detection = detectHarness(ctx, this.descriptor);
     if (!detection.binaryOnPath) {
@@ -54,7 +59,11 @@ export class ClaudeInstaller extends ScopedHarnessInstaller {
     return { descriptor: this.descriptor, detected: true, installed: newScopes.length > 0, managed };
   }
 
-  protected async runInstall(ctx: CliContext, scope: InstallScope): Promise<void> {
+  protected runInstall(ctx: CliContext, scope: InstallScope): ResultAsync<void, AbortError> {
+    return abortable('claudeInstaller', this.runInstallUnsafe(ctx, scope));
+  }
+
+  private async runInstallUnsafe(ctx: CliContext, scope: InstallScope): Promise<void> {
     const { io } = ctx;
     const { binaryName } = this.descriptor;
 
@@ -92,7 +101,11 @@ export class ClaudeInstaller extends ScopedHarnessInstaller {
     io.writeStderr(`Restart Claude Code for the plugin to load.\n`);
   }
 
-  protected async runUninstall(ctx: CliContext, scope: InstallScope): Promise<void> {
+  protected runUninstall(ctx: CliContext, scope: InstallScope): ResultAsync<void, AbortError> {
+    return abortable('claudeInstaller', this.runUninstallUnsafe(ctx, scope));
+  }
+
+  private async runUninstallUnsafe(ctx: CliContext, scope: InstallScope): Promise<void> {
     const { io, logger } = ctx;
     const { binaryName } = this.descriptor;
 
@@ -143,14 +156,14 @@ async function isMarketplaceConfigured(ctx: CliContext, binaryName: string): Pro
 async function listPlugins(ctx: CliContext, binaryName: string): Promise<InstalledPlugin[]> {
   const { commandRunner } = ctx;
   const result = await commandRunner.run(binaryName, ['plugin', 'list', '--json']);
-  requireCleanExit(ctx, binaryName, result, 'plugin list');
+  requireCleanExit(binaryName, result, 'plugin list');
   return InstalledPluginsSchema.parse(JSON.parse(result.stdout));
 }
 
 async function listMarketplaces(ctx: CliContext, binaryName: string): Promise<ConfiguredMarketplace[]> {
   const { commandRunner } = ctx;
   const result = await commandRunner.run(binaryName, ['plugin', 'marketplace', 'list', '--json']);
-  requireCleanExit(ctx, binaryName, result, 'plugin marketplace list');
+  requireCleanExit(binaryName, result, 'plugin marketplace list');
   return ConfiguredMarketplacesSchema.parse(JSON.parse(result.stdout));
 }
 
@@ -170,20 +183,18 @@ async function runPluginCommand(
 
   if (result.exitCode !== 0) {
     const detail = result.stderr.trim() || `${binaryName} plugin ${label} exited ${result.exitCode}`;
-    logger.error(detail);
-    throw new CommanderError(result.exitCode, 'contextbridge.claudeInstaller.shellFailure', detail);
+    throw AbortError.runtime('claudeInstaller', detail, {
+      code: 'contextbridge.claudeInstaller.shellFailure',
+      exitCode: result.exitCode,
+    });
   }
 }
 
-function requireCleanExit(
-  ctx: CliContext,
-  binaryName: string,
-  result: { exitCode: number; stderr: string },
-  label: string,
-): void {
+function requireCleanExit(binaryName: string, result: { exitCode: number; stderr: string }, label: string): void {
   if (result.exitCode === 0) return;
-  const { logger } = ctx;
   const detail = result.stderr.trim() || `${binaryName} ${label} exited ${result.exitCode}`;
-  logger.error(detail);
-  throw new CommanderError(result.exitCode, 'contextbridge.claudeInstaller.listFailure', detail);
+  throw AbortError.runtime('claudeInstaller', detail, {
+    code: 'contextbridge.claudeInstaller.listFailure',
+    exitCode: result.exitCode,
+  });
 }

--- a/packages/cli/src/installers/CodexInstaller.test.ts
+++ b/packages/cli/src/installers/CodexInstaller.test.ts
@@ -5,9 +5,9 @@ import { join } from 'node:path';
 import { getHarness } from '@contextbridge/harness';
 import { bundledSkills } from '@contextbridge/skills/codex';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { CommanderError } from 'commander';
+import { AbortError } from '#src/commands/abort.ts';
 import { environment } from '#src/testFactories.ts';
-import { createStubContext, readErrorLogs } from '#src/testHelpers/index.ts';
+import { createStubContext, expectErr, expectOk, expectOkValue } from '#src/testHelpers/index.ts';
 import { CodexInstaller } from './CodexInstaller.ts';
 
 const CODEX_BINARY = getHarness('codex').binaryName;
@@ -28,7 +28,7 @@ describe('CodexInstaller', () => {
     it('installs user-scope hook configuration and enables the feature flag', async () => {
       const { installer, context, io } = createCodexInstallerContext(tmp);
 
-      await installer.install(context, { yes: true });
+      await expectOk(installer.install(context, { yes: true }));
 
       const hooks = readHooksJson(join(tmp, '.codex', 'hooks.json'));
       expect(hooks.hooks.Stop[0]?.hooks[0]).toMatchObject({
@@ -49,7 +49,7 @@ describe('CodexInstaller', () => {
       const project = join(tmp, 'project');
       const { installer, context } = createCodexInstallerContext(tmp, { projectRoot: project });
 
-      await installer.install(context, { yes: true, scope: 'project' });
+      await expectOk(installer.install(context, { yes: true, scope: 'project' }));
 
       const hooks = readHooksJson(join(project, '.codex', 'hooks.json'));
       expect(hooks.hooks.Stop[0]?.hooks[0]).toMatchObject({ command: 'contextbridge hook codex' });
@@ -67,19 +67,20 @@ describe('CodexInstaller', () => {
       });
       const { installer, context } = createCodexInstallerContext(tmp);
 
-      await installer.install(context, { yes: true });
-      await installer.install(context, { yes: true });
+      await expectOk(installer.install(context, { yes: true }));
+      await expectOk(installer.install(context, { yes: true }));
 
       const hooks = readHooksJson(join(configDir, 'hooks.json'));
       const commands = hooks.hooks.Stop.flatMap((group) => group.hooks.map((hook) => hook.command));
       expect(commands).toEqual(['echo other', 'contextbridge hook codex']);
     });
 
-    it('aborts before writing config when codex is not on PATH', () => {
+    it('aborts before writing config when codex is not on PATH', async () => {
       const { installer, context, commandRunner } = createCodexInstallerContext(tmp);
       commandRunner.setWhich(CODEX_BINARY, null);
 
-      expect(installer.install(context, { yes: true })).rejects.toThrow('Install Codex CLI first');
+      const err = await expectErr(installer.install(context, { yes: true }));
+      expect(err.message).toContain('Install Codex CLI first');
       expect(existsSync(join(tmp, '.codex'))).toBe(false);
     });
 
@@ -90,7 +91,7 @@ describe('CodexInstaller', () => {
       writeFileSync(configPath, '[features\nbroken');
       const { installer, context } = createCodexInstallerContext(tmp);
 
-      await installer.install(context, { yes: true });
+      await expectOk(installer.install(context, { yes: true }));
 
       expect(readHooksJson(join(configDir, 'hooks.json')).hooks.Stop[0]?.hooks[0]).toMatchObject({
         command: 'contextbridge hook codex',
@@ -98,7 +99,7 @@ describe('CodexInstaller', () => {
       expect(readFileSync(configPath, 'utf8')).toBe('[features\nbroken');
     });
 
-    it('does not run feature commands when hooks.json has an invalid hooks root', () => {
+    it('does not run feature commands when hooks.json has an invalid hooks root', async () => {
       const configDir = join(tmp, '.codex');
       const configPath = join(configDir, 'config.toml');
       const hooksPath = join(configDir, 'hooks.json');
@@ -107,52 +108,45 @@ describe('CodexInstaller', () => {
       writeHooksJson(hooksPath, { hooks: [] });
       const { installer, context } = createCodexInstallerContext(tmp);
 
-      expect(installer.install(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
+      const err = await expectErr(installer.install(context, { yes: true }));
+      expect(err).toBeInstanceOf(AbortError);
       expect(readFileSync(configPath, 'utf8')).toBe('[features]\nunified_exec = true\n');
       expect(readFileSync(hooksPath, 'utf8')).toBe('{"hooks":[]}');
       expect(commandRunnerCalls(context, ['features', 'enable', 'hooks'])).toHaveLength(0);
     });
 
-    it('fails before writing files when Codex is too old', () => {
+    it('fails before writing files when Codex is too old', async () => {
       const { installer, context } = createCodexInstallerContext(tmp, {}, { versionStdout: 'codex-cli 0.128.0\n' });
 
-      const installPromise = installer.install(context, { yes: true });
-      expect(installPromise).rejects.toBeInstanceOf(CommanderError);
-      expect(installPromise).rejects.toThrow('requires Codex CLI 0.129.0 or newer');
+      const err = await expectErr(installer.install(context, { yes: true }));
+      expect(err.message).toContain('requires Codex CLI 0.129.0 or newer');
       expect(existsSync(join(tmp, '.codex'))).toBe(false);
       expect(commandRunnerCalls(context, ['features', 'enable', 'hooks'])).toHaveLength(0);
     });
 
-    it('fails before writing files when Codex version output is unparseable', () => {
-      const { installer, context, logs } = createCodexInstallerContext(tmp, {}, { versionStdout: 'weird\n' });
+    it('fails before writing files when Codex version output is unparseable', async () => {
+      const { installer, context } = createCodexInstallerContext(tmp, {}, { versionStdout: 'weird\n' });
 
-      const installPromise = installer.install(context, { yes: true });
-      expect(installPromise).rejects.toBeInstanceOf(CommanderError);
-      expect(installPromise).rejects.toThrow('Could not determine Codex CLI version');
+      const err = await expectErr(installer.install(context, { yes: true }));
+      expect(err.message).toContain('Could not determine Codex CLI version');
       expect(existsSync(join(tmp, '.codex'))).toBe(false);
-      expect(
-        readErrorLogs(logs).some(
-          (record) => record.msg === 'could not determine Codex CLI version' && record['stdout'] === 'weird\n',
-        ),
-      ).toBe(true);
     });
 
-    it('fails when Codex feature commands fail', () => {
+    it('fails when Codex feature commands fail', async () => {
       const { installer, context } = createCodexInstallerContext(
         tmp,
         {},
         { enableHooksResult: { exitCode: 2, stderr: 'nope' } },
       );
 
-      const installPromise = installer.install(context, { yes: true });
-      expect(installPromise).rejects.toBeInstanceOf(CommanderError);
-      expect(installPromise).rejects.toThrow(/^nope$/);
+      const err = await expectErr(installer.install(context, { yes: true }));
+      expect(err.message).toBe('nope');
     });
 
     it('writes the skill to ~/.agents/skills/planbridge-open/SKILL.md on user-scope install', async () => {
       const { installer, context } = createCodexInstallerContext(tmp);
 
-      await installer.install(context, { yes: true });
+      await expectOk(installer.install(context, { yes: true }));
 
       const skillPath = join(tmp, '.agents', 'skills', 'planbridge-open', 'SKILL.md');
       expect(existsSync(skillPath)).toBe(true);
@@ -163,7 +157,7 @@ describe('CodexInstaller', () => {
       const project = join(tmp, 'project');
       const { installer, context } = createCodexInstallerContext(tmp, { projectRoot: project });
 
-      await installer.install(context, { yes: true, scope: 'project' });
+      await expectOk(installer.install(context, { yes: true, scope: 'project' }));
 
       const skillPath = join(tmp, '.agents', 'skills', 'planbridge-open', 'SKILL.md');
       expect(existsSync(skillPath)).toBe(true);
@@ -173,8 +167,8 @@ describe('CodexInstaller', () => {
     it('skill install is idempotent', async () => {
       const { installer, context } = createCodexInstallerContext(tmp);
 
-      await installer.install(context, { yes: true });
-      await installer.install(context, { yes: true });
+      await expectOk(installer.install(context, { yes: true }));
+      await expectOk(installer.install(context, { yes: true }));
 
       const skillPath = join(tmp, '.agents', 'skills', 'planbridge-open', 'SKILL.md');
       expect(readFileSync(skillPath, 'utf8')).toBe(bundledOpenSkill);
@@ -200,7 +194,7 @@ describe('CodexInstaller', () => {
       });
       const { installer, context, io } = createCodexInstallerContext(tmp);
 
-      await installer.uninstall(context, { yes: true });
+      await expectOk(installer.uninstall(context, { yes: true }));
 
       const hooks = readHooksJson(join(configDir, 'hooks.json'));
       expect(hooks.hooks.Stop).toHaveLength(1);
@@ -208,14 +202,15 @@ describe('CodexInstaller', () => {
       expect(io.stderr.text()).toContain('PlanBridge hook removed from Codex CLI (scope: user)');
     });
 
-    it('rejects an invalid hooks root without rewriting hooks.json', () => {
+    it('rejects an invalid hooks root without rewriting hooks.json', async () => {
       const configDir = join(tmp, '.codex');
       const hooksPath = join(configDir, 'hooks.json');
       mkdirSync(configDir, { recursive: true });
       writeHooksJson(hooksPath, { hooks: [] });
       const { installer, context } = createCodexInstallerContext(tmp);
 
-      expect(installer.uninstall(context, { yes: true })).rejects.toBeInstanceOf(CommanderError);
+      const err = await expectErr(installer.uninstall(context, { yes: true }));
+      expect(err).toBeInstanceOf(AbortError);
       expect(readFileSync(hooksPath, 'utf8')).toBe('{"hooks":[]}');
     });
 
@@ -224,9 +219,9 @@ describe('CodexInstaller', () => {
       await mkdir(join(skillsDir, 'some-other-tool'), { recursive: true });
       await writeFile(join(skillsDir, 'some-other-tool', 'SKILL.md'), 'other tool skill');
       const { installer, context } = createCodexInstallerContext(tmp);
-      await installer.install(context, { yes: true });
+      await expectOk(installer.install(context, { yes: true }));
 
-      await installer.uninstall(context, { yes: true });
+      await expectOk(installer.uninstall(context, { yes: true }));
 
       expect(existsSync(join(skillsDir, 'planbridge-open'))).toBe(false);
       expect(readFileSync(join(skillsDir, 'some-other-tool', 'SKILL.md'), 'utf8')).toBe('other tool skill');
@@ -235,9 +230,9 @@ describe('CodexInstaller', () => {
     it('project-scope uninstall does not remove the skill', async () => {
       const project = join(tmp, 'project');
       const { installer, context } = createCodexInstallerContext(tmp, { projectRoot: project });
-      await installer.install(context, { yes: true, scope: 'project' });
+      await expectOk(installer.install(context, { yes: true, scope: 'project' }));
 
-      await installer.uninstall(context, { yes: true, scope: 'project' });
+      await expectOk(installer.uninstall(context, { yes: true, scope: 'project' }));
 
       const skillPath = join(tmp, '.agents', 'skills', 'planbridge-open', 'SKILL.md');
       expect(existsSync(skillPath)).toBe(true);
@@ -246,7 +241,7 @@ describe('CodexInstaller', () => {
     it('user-scope uninstall is idempotent when skill is already gone', async () => {
       const { installer, context } = createCodexInstallerContext(tmp);
 
-      await installer.uninstall(context, { yes: true });
+      await expectOk(installer.uninstall(context, { yes: true }));
     });
   });
 
@@ -255,7 +250,7 @@ describe('CodexInstaller', () => {
       const { installer, context, commandRunner } = createCodexInstallerContext(tmp);
       commandRunner.setWhich(CODEX_BINARY, null);
 
-      const status = await installer.status(context);
+      const status = await expectOkValue(installer.status(context));
 
       expect(status).toMatchObject({
         descriptor: { id: 'codex' },
@@ -267,9 +262,9 @@ describe('CodexInstaller', () => {
 
     it('reports an installed hook and skill when both are present', async () => {
       const { installer, context } = createCodexInstallerContext(tmp);
-      await installer.install(context, { yes: true });
+      await expectOk(installer.install(context, { yes: true }));
 
-      const status = await installer.status(context);
+      const status = await expectOkValue(installer.status(context));
       expect(status).toMatchObject({
         descriptor: { id: 'codex' },
         detected: true,
@@ -287,7 +282,7 @@ describe('CodexInstaller', () => {
       writePlanBridgeHooksJson(join(configDir, 'hooks.json'));
       const { installer, context } = createCodexInstallerContext(tmp);
 
-      const status = await installer.status(context);
+      const status = await expectOkValue(installer.status(context));
 
       expect(status.detected).toBe(true);
       expect(status.installed).toBe(true);
@@ -299,42 +294,45 @@ describe('CodexInstaller', () => {
       mkdirSync(configDir, { recursive: true });
       const { installer, context } = createCodexInstallerContext(tmp);
 
-      const status = await installer.status(context);
+      const status = await expectOkValue(installer.status(context));
 
       expect(status.detected).toBe(true);
       expect(status.installed).toBe(false);
       expect(status.managed).toEqual([]);
     });
 
-    it('bubbles invalid hooks.json as a CommanderError', () => {
+    it('bubbles invalid hooks.json as a typed error', async () => {
       const configDir = join(tmp, '.codex');
       mkdirSync(configDir, { recursive: true });
       writeFileSync(join(configDir, 'hooks.json'), '{ bad json');
       const { installer, context } = createCodexInstallerContext(tmp);
 
-      expect(installer.status(context)).rejects.toBeInstanceOf(CommanderError);
+      const err = await expectErr(installer.status(context));
+      expect(err).toBeInstanceOf(AbortError);
     });
 
-    it('bubbles invalid hooks.json shape as a CommanderError', () => {
+    it('bubbles invalid hooks.json shape as a typed error', async () => {
       const configDir = join(tmp, '.codex');
       mkdirSync(configDir, { recursive: true });
       writeHooksJson(join(configDir, 'hooks.json'), { hooks: [] });
       const { installer, context } = createCodexInstallerContext(tmp);
 
-      expect(installer.status(context)).rejects.toBeInstanceOf(CommanderError);
+      const err = await expectErr(installer.status(context));
+      expect(err).toBeInstanceOf(AbortError);
     });
 
-    it('reports status unavailable when Codex is too old', () => {
+    it('reports status unavailable when Codex is too old', async () => {
       const { installer, context } = createCodexInstallerContext(tmp, {}, { versionStdout: 'codex-cli 0.128.0\n' });
 
-      expect(installer.status(context)).rejects.toBeInstanceOf(CommanderError);
+      const err = await expectErr(installer.status(context));
+      expect(err).toBeInstanceOf(AbortError);
     });
 
     it('reports the skill as a ManagedEntry when installed', async () => {
       const { installer, context } = createCodexInstallerContext(tmp);
-      await installer.install(context, { yes: true });
+      await expectOk(installer.install(context, { yes: true }));
 
-      const status = await installer.status(context);
+      const status = await expectOkValue(installer.status(context));
 
       expect(status.managed).toContainEqual({ kind: 'skill', identifier: 'planbridge-open', scope: 'user' });
       expect(status.installed).toBe(true);
@@ -343,7 +341,7 @@ describe('CodexInstaller', () => {
     it('does not report the skill when not installed', async () => {
       const { installer, context } = createCodexInstallerContext(tmp);
 
-      const status = await installer.status(context);
+      const status = await expectOkValue(installer.status(context));
 
       expect(status.managed.some((m) => m.kind === 'skill')).toBe(false);
     });

--- a/packages/cli/src/installers/CodexInstaller.ts
+++ b/packages/cli/src/installers/CodexInstaller.ts
@@ -5,8 +5,9 @@ import { getErrorMessage, hasErrorCode } from '@contextbridge/shared/errors';
 import { safeJsonParse } from '@contextbridge/shared/json';
 import { isRecord } from '@contextbridge/shared/typeGuards';
 import { type BundledSkill, bundledSkills } from '@contextbridge/skills/codex';
-import { CommanderError } from 'commander';
+import type { ResultAsync } from 'neverthrow';
 import semver from 'semver';
+import { AbortError, abortable } from '#src/commands/abort.ts';
 import type { CliContext } from '#src/context.ts';
 import { detectHarness } from './detect.ts';
 import { type HarnessStatus, type ManagedEntry } from './HarnessInstaller.ts';
@@ -35,7 +36,11 @@ export class CodexInstaller extends ScopedHarnessInstaller {
   protected readonly installDescription = 'Install the PlanBridge Stop hook into Codex CLI.';
   protected readonly uninstallDescription = 'Uninstall the PlanBridge Stop hook from Codex CLI.';
 
-  async status(ctx: CliContext): Promise<HarnessStatus> {
+  status(ctx: CliContext): ResultAsync<HarnessStatus, AbortError> {
+    return abortable('codexInstaller', this.statusUnsafe(ctx));
+  }
+
+  private async statusUnsafe(ctx: CliContext): Promise<HarnessStatus> {
     const detection = detectHarness(ctx, this.descriptor);
     if (!detection.binaryOnPath) {
       return { descriptor: this.descriptor, detected: false, installed: false, managed: [] };
@@ -63,7 +68,11 @@ export class CodexInstaller extends ScopedHarnessInstaller {
     return { descriptor: this.descriptor, detected: true, installed, managed };
   }
 
-  protected async runInstall(ctx: CliContext, scope: InstallScope): Promise<void> {
+  protected runInstall(ctx: CliContext, scope: InstallScope): ResultAsync<void, AbortError> {
+    return abortable('codexInstaller', this.runInstallUnsafe(ctx, scope));
+  }
+
+  private async runInstallUnsafe(ctx: CliContext, scope: InstallScope): Promise<void> {
     const { io } = ctx;
     await requireSupportedCodexVersion(ctx, this.descriptor.binaryName);
 
@@ -91,7 +100,11 @@ export class CodexInstaller extends ScopedHarnessInstaller {
     }
   }
 
-  protected async runUninstall(ctx: CliContext, scope: InstallScope): Promise<void> {
+  protected runUninstall(ctx: CliContext, scope: InstallScope): ResultAsync<void, AbortError> {
+    return abortable('codexInstaller', this.runUninstallUnsafe(ctx, scope));
+  }
+
+  private async runUninstallUnsafe(ctx: CliContext, scope: InstallScope): Promise<void> {
     const { io } = ctx;
     const configDir = getOptionalCodexConfigDir(ctx, scope);
 
@@ -121,11 +134,9 @@ async function getCodexHookStatusAtScope(ctx: CliContext, scope: InstallScope): 
 function getCodexConfigDir(ctx: CliContext, scope: InstallScope): string {
   const configDir = getOptionalCodexConfigDir(ctx, scope);
   if (!configDir) {
-    throw new CommanderError(
-      1,
-      'contextbridge.codexInstaller.missingHome',
-      'HOME is required for user-scope Codex install',
-    );
+    throw AbortError.input('codexInstaller', 'HOME is required for user-scope Codex install', {
+      code: 'contextbridge.codexInstaller.missingHome',
+    });
   }
   return configDir;
 }
@@ -189,20 +200,16 @@ function parseHooksJson(source: string): Record<string, unknown> {
   const parsed = safeJsonParse(source).match(
     (value) => value,
     (err) => {
-      throw new CommanderError(
-        1,
-        'contextbridge.codexInstaller.invalidHooksJson',
-        `invalid Codex hooks.json: ${getErrorMessage(err)}`,
-      );
+      throw AbortError.input('codexInstaller', `invalid Codex hooks.json: ${getErrorMessage(err)}`, {
+        code: 'contextbridge.codexInstaller.invalidHooksJson',
+      });
     },
   );
 
   if (!isRecord(parsed)) {
-    throw new CommanderError(
-      1,
-      'contextbridge.codexInstaller.invalidHooksJson',
-      'Codex hooks.json must contain an object',
-    );
+    throw AbortError.input('codexInstaller', 'Codex hooks.json must contain an object', {
+      code: 'contextbridge.codexInstaller.invalidHooksJson',
+    });
   }
 
   return parsed;
@@ -233,11 +240,9 @@ function ensureHooksRoot(file: Record<string, unknown>): Record<string, unknown>
     return hooks;
   }
 
-  throw new CommanderError(
-    1,
-    'contextbridge.codexInstaller.invalidHooksJson',
-    'Codex hooks.json `hooks` field must contain an object',
-  );
+  throw AbortError.input('codexInstaller', 'Codex hooks.json `hooks` field must contain an object', {
+    code: 'contextbridge.codexInstaller.invalidHooksJson',
+  });
 }
 
 function getStopGroups(hooks: Record<string, unknown>): unknown[] {
@@ -294,11 +299,9 @@ function getOptionalHooksRoot(file: Record<string, unknown>): Record<string, unk
     return hooks;
   }
 
-  throw new CommanderError(
-    1,
-    'contextbridge.codexInstaller.invalidHooksJson',
-    'Codex hooks.json `hooks` field must contain an object',
-  );
+  throw AbortError.input('codexInstaller', 'Codex hooks.json `hooks` field must contain an object', {
+    code: 'contextbridge.codexInstaller.invalidHooksJson',
+  });
 }
 
 function isPlanBridgeHook(value: unknown): boolean {
@@ -306,23 +309,21 @@ function isPlanBridgeHook(value: unknown): boolean {
 }
 
 async function requireSupportedCodexVersion(ctx: CliContext, binaryName: string): Promise<void> {
-  const { logger } = ctx;
   const result = await runCodexCommand(ctx, binaryName, ['--version'], 'version check');
   const parsed = parseCodexVersion(result.stdout);
   if (!parsed) {
-    logger.error({ stdout: result.stdout }, 'could not determine Codex CLI version');
-    throw new CommanderError(
-      1,
-      'contextbridge.codexInstaller.unsupportedVersion',
+    throw AbortError.input(
+      'codexInstaller',
       `Could not determine Codex CLI version from \`${binaryName} --version\`. Update Codex CLI to ${MINIMUM_CODEX_VERSION} or newer, then re-run install.`,
+      { code: 'contextbridge.codexInstaller.unsupportedVersion' },
     );
   }
 
   if (!semver.gte(parsed, MINIMUM_CODEX_VERSION)) {
-    throw new CommanderError(
-      1,
-      'contextbridge.codexInstaller.unsupportedVersion',
+    throw AbortError.input(
+      'codexInstaller',
       `Codex CLI ${parsed} is installed, but PlanBridge requires Codex CLI ${MINIMUM_CODEX_VERSION} or newer. Update Codex CLI, then re-run install.`,
+      { code: 'contextbridge.codexInstaller.unsupportedVersion' },
     );
   }
 }
@@ -347,8 +348,10 @@ async function runCodexCommand(
 
   if (result.exitCode !== 0) {
     const detail = result.stderr.trim() || `${binaryName} ${label} exited ${result.exitCode}`;
-    logger.error(detail);
-    throw new CommanderError(result.exitCode, 'contextbridge.codexInstaller.shellFailure', detail);
+    throw AbortError.runtime('codexInstaller', detail, {
+      code: 'contextbridge.codexInstaller.shellFailure',
+      exitCode: result.exitCode,
+    });
   }
 
   return result;

--- a/packages/cli/src/installers/HarnessInstaller.ts
+++ b/packages/cli/src/installers/HarnessInstaller.ts
@@ -1,5 +1,7 @@
 import type { InstallableHarness } from '@contextbridge/harness';
-import { type Command, CommanderError } from 'commander';
+import type { Command } from 'commander';
+import { type Result, type ResultAsync, err, ok } from 'neverthrow';
+import { AbortError } from '#src/commands/abort.ts';
 import type { CliContext } from '#src/context.ts';
 
 export interface HarnessStatus {
@@ -22,20 +24,20 @@ export interface InstallActionOptions {
 
 export abstract class HarnessInstaller {
   abstract readonly descriptor: InstallableHarness;
-  abstract status(ctx: CliContext): Promise<HarnessStatus>;
-  abstract install(ctx: CliContext, options: InstallActionOptions): Promise<void>;
-  abstract uninstall(ctx: CliContext, options: InstallActionOptions): Promise<void>;
+  abstract status(ctx: CliContext): ResultAsync<HarnessStatus, AbortError>;
+  abstract install(ctx: CliContext, options: InstallActionOptions): ResultAsync<void, AbortError>;
+  abstract uninstall(ctx: CliContext, options: InstallActionOptions): ResultAsync<void, AbortError>;
   abstract registerInstall(ctx: CliContext, parent: Command): void;
   abstract registerUninstall(ctx: CliContext, parent: Command): void;
 
-  protected requireBinary(ctx: CliContext, code: string): void {
+  protected requireBinary(ctx: CliContext, code: string): Result<void, AbortError> {
     const { commandRunner } = ctx;
     const { binaryName } = this.descriptor;
 
-    if (commandRunner.which(binaryName)) return;
+    if (commandRunner.which(binaryName)) return ok(undefined);
 
     const message = this.binaryNotFoundMessage();
-    throw new CommanderError(1, code, message);
+    return err(AbortError.input(this.descriptor.id, message, { code }));
   }
 
   private binaryNotFoundMessage(): string {

--- a/packages/cli/src/installers/ScopedHarnessInstaller.ts
+++ b/packages/cli/src/installers/ScopedHarnessInstaller.ts
@@ -1,4 +1,7 @@
 import { type Command, Option } from 'commander';
+import { ResultAsync, okAsync } from 'neverthrow';
+import type { AbortError } from '#src/commands/abort.ts';
+import { handleCommandResult } from '#src/commands/abort.ts';
 import type { CliContext } from '#src/context.ts';
 import { HarnessInstaller, type InstallActionOptions } from './HarnessInstaller.ts';
 
@@ -17,16 +20,16 @@ export abstract class ScopedHarnessInstaller extends HarnessInstaller {
   protected abstract readonly installDescription: string;
   protected abstract readonly uninstallDescription: string;
 
-  async install(ctx: CliContext, options: ScopedInstallActionOptions): Promise<void> {
-    const scope = await this.resolveScope(ctx, options, 'install');
-    this.requireBinary(ctx, this.binaryMissingCode);
-    await this.runInstall(ctx, scope);
+  install(ctx: CliContext, options: ScopedInstallActionOptions): ResultAsync<void, AbortError> {
+    return this.resolveScope(ctx, options, 'install')
+      .andThen((scope) => this.requireBinary(ctx, this.binaryMissingCode).map(() => scope))
+      .andThen((scope) => this.runInstall(ctx, scope));
   }
 
-  async uninstall(ctx: CliContext, options: ScopedInstallActionOptions): Promise<void> {
-    const scope = await this.resolveScope(ctx, options, 'uninstall');
-    this.requireBinary(ctx, this.binaryMissingCode);
-    await this.runUninstall(ctx, scope);
+  uninstall(ctx: CliContext, options: ScopedInstallActionOptions): ResultAsync<void, AbortError> {
+    return this.resolveScope(ctx, options, 'uninstall')
+      .andThen((scope) => this.requireBinary(ctx, this.binaryMissingCode).map(() => scope))
+      .andThen((scope) => this.runUninstall(ctx, scope));
   }
 
   registerInstall(ctx: CliContext, parent: Command): void {
@@ -35,7 +38,7 @@ export abstract class ScopedHarnessInstaller extends HarnessInstaller {
       .description(this.installDescription)
       .addOption(this.createScopeOption('install'))
       .action(async (opts: { scope: InstallScope }) => {
-        await this.install(ctx, { yes: true, scope: opts.scope });
+        await handleCommandResult(ctx, this.install(ctx, { yes: true, scope: opts.scope }));
       });
   }
 
@@ -45,24 +48,24 @@ export abstract class ScopedHarnessInstaller extends HarnessInstaller {
       .description(this.uninstallDescription)
       .addOption(this.createScopeOption('uninstall'))
       .action(async (opts: { scope: InstallScope }) => {
-        await this.uninstall(ctx, { yes: true, scope: opts.scope });
+        await handleCommandResult(ctx, this.uninstall(ctx, { yes: true, scope: opts.scope }));
       });
   }
 
-  protected abstract runInstall(ctx: CliContext, scope: InstallScope): Promise<void>;
-  protected abstract runUninstall(ctx: CliContext, scope: InstallScope): Promise<void>;
+  protected abstract runInstall(ctx: CliContext, scope: InstallScope): ResultAsync<void, AbortError>;
+  protected abstract runUninstall(ctx: CliContext, scope: InstallScope): ResultAsync<void, AbortError>;
 
-  private async resolveScope(
+  private resolveScope(
     ctx: CliContext,
     { yes, scope }: ScopedInstallActionOptions,
     verb: 'install' | 'uninstall',
-  ): Promise<InstallScope> {
-    if (scope) return scope;
-    if (yes) return 'user';
+  ): ResultAsync<InstallScope, AbortError> {
+    if (scope) return okAsync(scope);
+    if (yes) return okAsync('user' as const);
     return this.promptForScope(ctx, verb);
   }
 
-  private promptForScope(ctx: CliContext, verb: 'install' | 'uninstall'): Promise<InstallScope> {
+  private promptForScope(ctx: CliContext, verb: 'install' | 'uninstall'): ResultAsync<InstallScope, AbortError> {
     const { prompter } = ctx;
     const action = verb === 'install' ? 'install into' : 'remove from';
     return prompter.select<InstallScope>({

--- a/packages/cli/src/prompter.test.ts
+++ b/packages/cli/src/prompter.test.ts
@@ -1,21 +1,17 @@
 import { describe, expect, it } from 'bun:test';
-import { CommanderError } from 'commander';
+import { AbortError } from './commands/abort.ts';
 import { PROMPTER_NON_TTY_CODE, createClackPrompter } from './prompter.ts';
-import { FakeIo } from './testHelpers/index.ts';
+import { FakeIo, expectErr } from './testHelpers/index.ts';
 
 describe('createClackPrompter', () => {
-  it('throws a CommanderError directing the user to --yes when stdin is not a TTY', async () => {
+  it('returns a typed error directing the user to --yes when stdin is not a TTY', async () => {
     const io = new FakeIo();
     const prompter = createClackPrompter(io);
 
-    try {
-      await prompter.confirm({ message: 'proceed?' });
-      throw new Error('expected confirm() to reject');
-    } catch (err) {
-      expect(err).toBeInstanceOf(CommanderError);
-      const cmdErr = err as CommanderError;
-      expect(cmdErr.code).toBe(PROMPTER_NON_TTY_CODE);
-      expect(cmdErr.message).toContain('--yes');
-    }
+    const err = await expectErr(prompter.confirm({ message: 'proceed?' }));
+
+    expect(err).toBeInstanceOf(AbortError);
+    expect(err.code).toBe(PROMPTER_NON_TTY_CODE);
+    expect(err.message).toContain('--yes');
   });
 });

--- a/packages/cli/src/prompter.ts
+++ b/packages/cli/src/prompter.ts
@@ -4,7 +4,9 @@ import {
   isCancel as clackIsCancel,
   select as clackSelect,
 } from '@clack/prompts';
-import { CommanderError } from 'commander';
+import { getErrorMessage } from '@contextbridge/shared/errors';
+import { type Result, ResultAsync, err, errAsync, ok, okAsync } from 'neverthrow';
+import { AbortError } from '#src/commands/abort.ts';
 import type { Io } from '#src/IoImpl.ts';
 
 export const PROMPTER_CANCELLED_CODE = 'contextbridge.prompter.cancelled';
@@ -30,53 +32,68 @@ export interface SelectOptions<T extends SelectValue> {
 }
 
 export interface Prompter {
-  confirm(options: ConfirmOptions): Promise<boolean>;
-  select<T extends SelectValue>(options: SelectOptions<T>): Promise<T>;
+  confirm(options: ConfirmOptions): ResultAsync<boolean, AbortError>;
+  select<T extends SelectValue>(options: SelectOptions<T>): ResultAsync<T, AbortError>;
 }
 
 export function createClackPrompter(io: Io): Prompter {
   return {
-    async confirm({ message, default: defaultValue = true }) {
-      assertTty(io);
-      const result = await clackConfirm({
-        message,
-        initialValue: defaultValue,
-        input: io.stdin,
-        output: io.stderr,
+    confirm({ message, default: defaultValue = true }) {
+      const tty = assertTty(io);
+      if (tty.isErr()) return errAsync(tty.error);
+      return ResultAsync.fromPromise(
+        clackConfirm({
+          message,
+          initialValue: defaultValue,
+          input: io.stdin,
+          output: io.stderr,
+        }),
+        (e) => AbortError.runtime('prompter', getErrorMessage(e)),
+      ).andThen((result) => {
+        if (clackIsCancel(result)) {
+          return errAsync(AbortError.cancelled('prompter', 'Cancelled.', { code: PROMPTER_CANCELLED_CODE }));
+        }
+        return okAsync(result);
       });
-      if (clackIsCancel(result)) {
-        throw new CommanderError(130, PROMPTER_CANCELLED_CODE, 'Cancelled.');
-      }
-      return result;
     },
-    async select<T extends SelectValue>({ message, choices, default: defaultValue }: SelectOptions<T>): Promise<T> {
-      assertTty(io);
+    select<T extends SelectValue>({
+      message,
+      choices,
+      default: defaultValue,
+    }: SelectOptions<T>): ResultAsync<T, AbortError> {
+      const tty = assertTty(io);
+      if (tty.isErr()) return errAsync(tty.error);
       const options: ClackOption<T>[] = choices.map((c) =>
         c.hint === undefined
           ? ({ value: c.value, label: c.label } as ClackOption<T>)
           : ({ value: c.value, label: c.label, hint: c.hint } as ClackOption<T>),
       );
-      const result = await clackSelect<T>({
-        message,
-        options,
-        initialValue: defaultValue,
-        input: io.stdin,
-        output: io.stderr,
+      return ResultAsync.fromPromise(
+        clackSelect<T>({
+          message,
+          options,
+          initialValue: defaultValue,
+          input: io.stdin,
+          output: io.stderr,
+        }),
+        (e) => AbortError.runtime('prompter', getErrorMessage(e)),
+      ).andThen((result) => {
+        if (clackIsCancel(result)) {
+          return errAsync(AbortError.cancelled('prompter', 'Cancelled.', { code: PROMPTER_CANCELLED_CODE }));
+        }
+        return okAsync(result);
       });
-      if (clackIsCancel(result)) {
-        throw new CommanderError(130, PROMPTER_CANCELLED_CODE, 'Cancelled.');
-      }
-      return result;
     },
   };
 }
 
-function assertTty(io: Io): void {
+function assertTty(io: Io): Result<void, AbortError> {
   if (io.stdinIsTTY !== true) {
-    throw new CommanderError(
-      1,
-      PROMPTER_NON_TTY_CODE,
-      'Cannot prompt in a non-interactive session. Pass `--yes` to skip confirmations.',
+    return err(
+      AbortError.input('prompter', 'Cannot prompt in a non-interactive session. Pass `--yes` to skip confirmations.', {
+        code: PROMPTER_NON_TTY_CODE,
+      }),
     );
   }
+  return ok(undefined);
 }

--- a/packages/cli/src/testHelpers/FakePrompter.ts
+++ b/packages/cli/src/testHelpers/FakePrompter.ts
@@ -1,3 +1,5 @@
+import { type ResultAsync, errAsync, okAsync } from 'neverthrow';
+import { AbortError } from '#src/commands/abort.ts';
 import type { ConfirmOptions, Prompter, SelectOptions, SelectValue } from '#src/prompter.ts';
 
 export class FakePrompter implements Prompter {
@@ -14,21 +16,25 @@ export class FakePrompter implements Prompter {
     this.selectAnswers.push(...answers);
   }
 
-  confirm(options: ConfirmOptions): Promise<boolean> {
+  confirm(options: ConfirmOptions): ResultAsync<boolean, AbortError> {
     this.calls.push(options);
     const next = this.confirmAnswers.shift();
     if (next === undefined) {
-      return Promise.reject(new Error(`FakePrompter: no scripted confirm answer for "${options.message}"`));
+      return errAsync(
+        AbortError.runtime('prompter', `FakePrompter: no scripted confirm answer for "${options.message}"`),
+      );
     }
-    return Promise.resolve(next);
+    return okAsync(next);
   }
 
-  select<T extends SelectValue>(options: SelectOptions<T>): Promise<T> {
+  select<T extends SelectValue>(options: SelectOptions<T>): ResultAsync<T, AbortError> {
     this.selectCalls.push(options);
     const next = this.selectAnswers.shift();
     if (next === undefined) {
-      return Promise.reject(new Error(`FakePrompter: no scripted select answer for "${options.message}"`));
+      return errAsync(
+        AbortError.runtime('prompter', `FakePrompter: no scripted select answer for "${options.message}"`),
+      );
     }
-    return Promise.resolve(next as T);
+    return okAsync(next as T);
   }
 }

--- a/packages/cli/src/testHelpers/index.ts
+++ b/packages/cli/src/testHelpers/index.ts
@@ -16,3 +16,4 @@ export { type TestContext, createStubContext } from './createStubContext.ts';
 export { parseStdoutJson } from './parseStdoutJson.ts';
 export { createAnnotationDependencies, type TrackedAnnotationDependencies } from './annotationFakes.ts';
 export { type LogRecord, readErrorLogs, readLogs, readWarnLogs } from './readLogs.ts';
+export { expectErr, expectOk, expectOkValue } from './resultAssertions.ts';

--- a/packages/cli/src/testHelpers/resultAssertions.ts
+++ b/packages/cli/src/testHelpers/resultAssertions.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+import type { ResultAsync } from 'neverthrow';
+
+export async function expectOk<T, E>(resultAsync: ResultAsync<T, E>): Promise<T> {
+  const result = await resultAsync;
+  assert(result.isOk(), `expected Ok, got Err: ${String(result.isErr() ? result.error : '<unknown>')}`);
+  return result.value;
+}
+
+export async function expectOkValue<T, E>(resultAsync: ResultAsync<T, E>): Promise<T> {
+  return expectOk(resultAsync);
+}
+
+export async function expectErr<T, E>(resultAsync: ResultAsync<T, E>): Promise<E> {
+  const result = await resultAsync;
+  assert(result.isErr(), `expected Err, got Ok: ${String(result.isOk() ? result.value : '<unknown>')}`);
+  return result.error;
+}


### PR DESCRIPTION
## Summary

Closes #86. Converts every CLI subcommand handler, installer, and the prompter to return `ResultAsync<T, AbortError>` end-to-end instead of the previous `try`/`catch` + fused `abort()` style. Introduces a typed `AbortError` (subclass of `CommanderError`) and centralizes the log + throw at the commander boundary via `handleCommandResult` / `throwLoggedAbort`, so the cli package now matches the team neverthrow conventions already applied to IO wrappers.

## Review focus

- **`commands/abort.ts`** — the new `AbortError` class, the `handleCommandResult` boundary helper, and the `toAbortError` / `abortable` adapters. Everything else hangs off this shape.
- **`cancelled` kind absorbs ad-hoc `CommanderError(130, ...)` throws** previously scattered across `plan.ts`, `open.ts`, and `prompter.ts`. Worth confirming the new error code strings still match what consumers (and the Sentry pinoIntegration filter) expect.
- **`harnessOperation.ts` + the installers** — multi-installer flow now collects per-installer Results into a single combined failure. Sanity-check the aggregation behavior.
- **Test migration** — `testHelpers/resultAssertions.ts` adds `expectOk` / `expectErr` helpers; the previous `rejects.toBeInstanceOf(CommanderError)` assertions are gone. New rule in `.contextbridge/rules/testing-patterns.md` documents the assertion style.

## Commits

- [`f52fd7f`](https://github.com/contextbridge/planbridge/commit/f52fd7ff63f100f0c6480fffaa0e6456730a33b8) — refactor(cli): make handlers ResultAsync<void, AbortError> end-to-end