### PR TITLE
ci: skip zizmor audit when .github/ unchanged

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,20 +20,37 @@ jobs:
       actions: read # zizmor reads workflow run metadata for online audits
       security-events: write # upload SARIF to GitHub code scanning
     steps:
+      # Audit only when something zizmor cares about changed. Keeps the job a
+      # required check that always reports a status, while skipping the
+      # API-heavy audit (and SARIF upload) on unrelated PRs.
+      - name: Detect workflow changes
+        id: changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            github:
+              - '.github/**'
+              - 'zizmor.yml'
+
       - name: Checkout
+        if: steps.changes.outputs.github == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Install uv
+        if: steps.changes.outputs.github == 'true'
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Run zizmor
+        if: steps.changes.outputs.github == 'true'
         run: uvx zizmor --format=sarif .github/ > zizmor.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload zizmor SARIF to code scanning
+        if: steps.changes.outputs.github == 'true'
         uses: github/codeql-action/upload-sarif@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
         with:
           sarif_file: zizmor.sarif


### PR DESCRIPTION
## Summary

The previous merge to main (#98) surfaced GitHub API rate-limit exhaustion: zizmor's online audits make many cross-repo `compare` calls per pinned action, and when several workflows fire concurrently they collectively burn through the shared 5,000/hr installation quota — taking down zizmor itself ([failed run](https://github.com/contextbridge/planbridge/actions/runs/25812188244)) and unrelated workflows like `lint-pr-title` ([failed run](https://github.com/contextbridge/planbridge/actions/runs/25812386268)). This gates the audit on changes to `.github/**` or the root `zizmor.yml` config, so the heavy steps only run when something zizmor actually cares about changed.

## Review focus

- **Why an in-job filter rather than a trigger-level `paths:`.** `zizmor` is a required status check in the main branch ruleset. A trigger-level `paths:` filter would leave the check stuck in "Pending" on PRs that don't touch `.github/`, blocking merges. Putting the filter inside the job lets the job always start and report a status, while the audit + upload steps are gated with `if:`.
- **`dorny/paths-filter` without a prior checkout.** The action falls back to the GitHub API (one `compare` call per run) instead of a local git diff. That's still an API call, but a single one — far cheaper than the ~30+ calls per audit it replaces.
- **Inline filter, not a composite action.** Only one caller. The existing `detect-changes` action earned its keep across two workflows; this filter doesn't (yet). Easy to extract later if a second workflow needs the same gate.
- **Path list scope:** `.github/**` covers all workflows, composite actions, dependabot.yml, CODEOWNERS, etc. Plus the root `zizmor.yml` config. Anything under those paths re-triggers the audit; nothing else does.

## Commits

- [`64cd035`](https://github.com/contextbridge/planbridge/pull/102/commits/64cd035d4476741ca4b2a07724076a4763ed433a) — gate audit + SARIF upload on `.github/**` or `zizmor.yml` changes via in-job `dorny/paths-filter`.