### PR TITLE
fix: expose PlanBridge open skill in Codex

### DIFF
--- a/packages/cli/src/bundledSkills.test.ts
+++ b/packages/cli/src/bundledSkills.test.ts
@@ -11,9 +11,10 @@ describe('bundled skills', () => {
   });
 
   for (const { name, body } of bundledSkills) {
-    it(`embedded ${name} skill matches the Claude plugin SKILL.md`, () => {
+    it(`embedded ${name} skill matches the Claude plugin SKILL.md except for the Codex command name`, () => {
       const claudeSource = readFileSync(join(repoRoot, 'harnessIntegrations/claude/skills', name, 'SKILL.md'), 'utf8');
-      expect(body).toBe(claudeSource);
+      expect(body).toBe(claudeSource.replace(`name: ${name}`, `name: planbridge-${name}`));
+      expect(body).toContain(`name: planbridge-${name}`);
     });
   }
 });

--- a/packages/cli/src/bundledSkills.ts
+++ b/packages/cli/src/bundledSkills.ts
@@ -1,9 +1,8 @@
 // Skill assets embedded into the CLI binary at build time. The Codex installer
 // writes each entry to disk under `~/.agents/skills/planbridge-<name>/SKILL.md`;
-// the Claude side ships the same files as plugin assets at
+// the Claude side ships plugin assets at
 // `harnessIntegrations/claude/skills/<name>/SKILL.md`. A sync test
-// (`bundledSkills.test.ts`) asserts each embedded copy stays in lockstep with
-// its on-disk Claude source.
+// (`bundledSkills.test.ts`) asserts Codex bodies only rewrite the skill name.
 //
 // To add a new skill: drop `harnessIntegrations/claude/skills/<name>/SKILL.md`
 // in place, then add a single line to the `bundledSkills` array below — the
@@ -11,10 +10,18 @@
 import openSkill from '../../../harnessIntegrations/claude/skills/open/SKILL.md' with { type: 'text' };
 
 export interface BundledSkill {
-  /** Directory name under `harnessIntegrations/claude/skills/`. Becomes `planbridge-<name>` on Codex install. */
+  /** Harness skill directory name. Becomes `planbridge-<name>` on Codex install. */
   readonly name: string;
   /** SKILL.md content embedded at build time. */
   readonly body: string;
 }
 
-export const bundledSkills: readonly BundledSkill[] = [{ name: 'open', body: openSkill }];
+export const bundledSkills: readonly BundledSkill[] = [{ name: 'open', body: toCodexSkill('open', openSkill) }];
+
+/**
+ * Claude displays plugin skills with the plugin namespace (`/planbridge:open`),
+ * but Codex displays the skill's frontmatter name directly (`$planbridge-open`).
+ */
+function toCodexSkill(name: string, body: string): string {
+  return body.replace(`name: ${name}`, `name: planbridge-${name}`);
+}

--- a/packages/cli/src/harnesses/CodexInstaller.test.ts
+++ b/packages/cli/src/harnesses/CodexInstaller.test.ts
@@ -156,7 +156,9 @@ describe('CodexInstaller', () => {
 
       const skillPath = join(tmp, '.agents', 'skills', 'planbridge-open', 'SKILL.md');
       expect(existsSync(skillPath)).toBe(true);
-      expect(readFileSync(skillPath, 'utf8')).toBe(bundledOpenSkill);
+      const installedSkill = readFileSync(skillPath, 'utf8');
+      expect(installedSkill).toBe(bundledOpenSkill);
+      expect(installedSkill).toContain('name: planbridge-open');
     });
 
     it('writes the skill at user level even on project-scope install', async () => {


### PR DESCRIPTION
## Summary

Fixes the Codex-installed PlanBridge open skill so Codex exposes it as `$planbridge-open` instead of `$open`. The installer continues to use the Claude skill asset as the source of truth and rewrites only the frontmatter name for Codex.

## Review focus

The key behavior is in the Codex skill bundling path: Claude namespaces plugin skills as `/planbridge:open`, while Codex displays the skill frontmatter name directly. The test coverage should make sure we do not reintroduce a duplicated Codex skill file or lose the `planbridge-` prefix.

## Commits

- [`61a0743`](https://github.com/contextbridge/planbridge/commit/61a07432e93890089cfcbb5e3e6ecad547e1292d) — derive the Codex skill name from the Claude skill source.
