### PR TITLE
fix: stop disabling deprecated codex_hooks feature flag

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -119,7 +119,6 @@ describe('runCli', () => {
     commandRunner.setWhich(CODEX_BINARY, '/usr/local/bin/codex');
     commandRunner.on(CODEX_BINARY, ['--version']).resolves({ stdout: 'codex-cli 0.129.0\n' });
     commandRunner.on(CODEX_BINARY, ['features', 'enable', 'hooks']).resolves();
-    commandRunner.on(CODEX_BINARY, ['features', 'disable', 'codex_hooks']).resolves();
 
     try {
       const exitCode = await runCli(context, ['install', 'codex']);
@@ -129,7 +128,6 @@ describe('runCli', () => {
         hooks: { Stop: [{ hooks: [{ command: 'contextbridge hook codex' }] }] },
       });
       expect(commandRunner.callsTo(CODEX_BINARY, ['features', 'enable', 'hooks'])).toHaveLength(1);
-      expect(commandRunner.callsTo(CODEX_BINARY, ['features', 'disable', 'codex_hooks'])).toHaveLength(1);
       expect(io.stderr.text()).toContain('scope: user');
     } finally {
       rmSync(tmp, { recursive: true, force: true });
@@ -145,7 +143,6 @@ describe('runCli', () => {
     commandRunner.setWhich(CODEX_BINARY, '/usr/local/bin/codex');
     commandRunner.on(CODEX_BINARY, ['--version']).resolves({ stdout: 'codex-cli 0.129.0\n' });
     commandRunner.on(CODEX_BINARY, ['features', 'enable', 'hooks']).resolves();
-    commandRunner.on(CODEX_BINARY, ['features', 'disable', 'codex_hooks']).resolves();
 
     try {
       const exitCode = await runCli(context, ['install', 'codex']);

--- a/packages/cli/src/harnesses/CodexInstaller.test.ts
+++ b/packages/cli/src/harnesses/CodexInstaller.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { CommanderError } from 'commander';
 import { bundledSkills } from '#src/bundledSkills.ts';
 import { environment } from '#src/testFactories.ts';
-import { createStubContext, readErrorLogs, readWarnLogs } from '#src/testHelpers/index.ts';
+import { createStubContext, readErrorLogs } from '#src/testHelpers/index.ts';
 import { CodexInstaller } from './CodexInstaller.ts';
 import { getDescriptor } from './registry.ts';
 
@@ -38,7 +38,6 @@ describe('CodexInstaller', () => {
         statusMessage: 'Opening PlanBridge',
       });
       expect(commandRunnerCalls(context, ['features', 'enable', 'hooks'])).toHaveLength(1);
-      expect(commandRunnerCalls(context, ['features', 'disable', 'codex_hooks'])).toHaveLength(1);
       expect(io.stderr.text()).toContain('PlanBridge hook installed for Codex CLI (scope: user)');
       expect(io.stderr.text()).toContain('Action required');
       expect(io.stderr.text()).toContain('PlanBridge will not run in Codex until this hook is trusted');
@@ -56,7 +55,6 @@ describe('CodexInstaller', () => {
       expect(hooks.hooks.Stop[0]?.hooks[0]).toMatchObject({ command: 'contextbridge hook codex' });
       expect(existsSync(join(project, '.codex', 'config.toml'))).toBe(false);
       expect(commandRunnerCalls(context, ['features', 'enable', 'hooks'])).toHaveLength(1);
-      expect(commandRunnerCalls(context, ['features', 'disable', 'codex_hooks'])).toHaveLength(1);
     });
 
     it('is idempotent and preserves other Stop hooks', async () => {
@@ -149,28 +147,6 @@ describe('CodexInstaller', () => {
       const installPromise = installer.install(context, { yes: true });
       expect(installPromise).rejects.toBeInstanceOf(CommanderError);
       expect(installPromise).rejects.toThrow(/^nope$/);
-    });
-
-    it('continues when disabling the legacy Codex hook feature fails', async () => {
-      const { installer, context, logs } = createCodexInstallerContext(
-        tmp,
-        {},
-        { disableLegacyHooksResult: { exitCode: 1, stdout: 'not enabled\n', stderr: 'unknown feature\n' } },
-      );
-
-      await installer.install(context, { yes: true });
-
-      expect(readHooksJson(join(tmp, '.codex', 'hooks.json')).hooks.Stop[0]?.hooks[0]).toMatchObject({
-        command: 'contextbridge hook codex',
-      });
-      expect(
-        readWarnLogs(logs).some(
-          (record) =>
-            record.msg === 'codex features disable codex_hooks failed; continuing' &&
-            record['stdout'] === 'not enabled\n' &&
-            record['stderr'] === 'unknown feature\n',
-        ),
-      ).toBe(true);
     });
 
     it('writes the skill to ~/.agents/skills/planbridge-open/SKILL.md on user-scope install', async () => {
@@ -393,20 +369,14 @@ function createCodexInstallerContext(
   options: {
     readonly versionStdout?: string;
     readonly enableHooksResult?: { readonly exitCode?: number; readonly stdout?: string; readonly stderr?: string };
-    readonly disableLegacyHooksResult?: {
-      readonly exitCode?: number;
-      readonly stdout?: string;
-      readonly stderr?: string;
-    };
   } = {},
 ) {
-  const { versionStdout = 'codex-cli 0.129.0\n', enableHooksResult, disableLegacyHooksResult } = options;
+  const { versionStdout = 'codex-cli 0.129.0\n', enableHooksResult } = options;
   const { env = environment.build({ HOME: tmp }), ...restOverrides } = overrides;
   const testContext = createStubContext({ env, ...restOverrides });
   testContext.commandRunner.setWhich(CODEX_BINARY, '/usr/local/bin/codex');
   testContext.commandRunner.on(CODEX_BINARY, ['--version']).resolves({ stdout: versionStdout });
   testContext.commandRunner.on(CODEX_BINARY, ['features', 'enable', 'hooks']).resolves(enableHooksResult);
-  testContext.commandRunner.on(CODEX_BINARY, ['features', 'disable', 'codex_hooks']).resolves(disableLegacyHooksResult);
   return { installer: new CodexInstaller(), ...testContext };
 }
 

--- a/packages/cli/src/harnesses/CodexInstaller.ts
+++ b/packages/cli/src/harnesses/CodexInstaller.ts
@@ -76,7 +76,7 @@ export class CodexInstaller extends ScopedHarnessInstaller {
     const hooksSource = await readOptionalText(hooksPath);
     const nextHooks = upsertPlanBridgeHookJson(hooksSource);
     await writeFile(hooksPath, nextHooks);
-    await enableCodexHookFeatureFlags(ctx, this.descriptor.binaryName);
+    await enableCodexHooksFeature(ctx, this.descriptor.binaryName);
     for (const skill of bundledSkills) {
       await writeSkill(ctx, skill);
     }
@@ -329,9 +329,8 @@ async function requireSupportedCodexVersion(ctx: CliContext, binaryName: string)
   }
 }
 
-async function enableCodexHookFeatureFlags(ctx: CliContext, binaryName: string): Promise<void> {
+async function enableCodexHooksFeature(ctx: CliContext, binaryName: string): Promise<void> {
   await runCodexCommand(ctx, binaryName, ['features', 'enable', 'hooks'], 'features enable hooks');
-  await tryRunCodexCommand(ctx, binaryName, ['features', 'disable', 'codex_hooks'], 'features disable codex_hooks');
 }
 
 async function runCodexCommand(
@@ -355,32 +354,6 @@ async function runCodexCommand(
   }
 
   return result;
-}
-
-async function tryRunCodexCommand(
-  ctx: CliContext,
-  binaryName: string,
-  args: readonly string[],
-  label: string,
-): Promise<void> {
-  const { commandRunner, logger } = ctx;
-  try {
-    const result = await commandRunner.run(binaryName, args);
-    if (result.exitCode === 0) {
-      logger.debug(
-        { args, exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr },
-        `${binaryName} ${label}`,
-      );
-      return;
-    }
-
-    logger.warn(
-      { args, exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr },
-      `${binaryName} ${label} failed; continuing`,
-    );
-  } catch (err) {
-    logger.warn({ err, args }, `${binaryName} ${label} failed; continuing`);
-  }
 }
 
 function parseCodexVersion(source: string): string | null {


### PR DESCRIPTION
## Summary

`enableCodexHookFeatureFlags` was running `codex features disable codex_hooks` as a tidy-up step after enabling the new `hooks` flag, but that command writes `codex_hooks = false` into the user's `[features]` table rather than removing the key. Codex's deprecation warning fires whenever the key is present at all, so users kept seeing it on every Codex startup after `contextbridge install`.

Drop the call entirely. Fresh installs on Codex `0.129.0+` no longer touch the deprecated key, so it stays absent and the warning never fires. Legacy installs that already wrote `codex_hooks` to the user's config will need to hand-remove the key from `~/.codex/config.toml`; that path is documented separately in the Codex usage docs (private repo PR).

Closes #100.

## Review focus

- The alternative — direct TOML edits via `toml-patch` — was considered and rejected. `toml-patch` is unmaintained (last release 2019), and surgically rewriting the user's `config.toml` for cosmetic cleanup introduces failure modes (malformed TOML, lost comments) that aren't worth the trade. Codex's deprecation warning has a bounded lifespan and is self-documenting, so leaving the migration to users is reasonable.
- `tryRunCodexCommand` was deleted as part of this change — it was only used for the now-gone disable call.
- `cli.test.ts` still has a test (`'routes install codex without parsing Codex config.toml'`) that seeds a malformed `config.toml` and asserts install succeeds. That test now serves double duty as a regression guard against the rejected alternative.

## Commits

- [`8a60e28`](https://github.com/contextbridge/planbridge/commit/8a60e28) — fix: stop disabling deprecated codex_hooks feature flag