### PR TITLE
fix(ci): pin codeql-action upload-sarif to commit SHA, not tag object

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload zizmor SARIF to code scanning
         if: steps.changes.outputs.github == 'true'
-        uses: github/codeql-action/upload-sarif@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           sarif_file: zizmor.sarif
           category: zizmor


### PR DESCRIPTION
## Summary

Change the `github/codeql-action/upload-sarif` pin in `zizmor.yml` from the annotated tag-object SHA (`3ce22a6e…`) to the commit SHA it dereferences to (`68bde559…`). Both are valid for `v4.35.4` from the runner's perspective, but the tag-object SHA trips zizmor's `impostor-commit` audit into walking every ref in `github/codeql-action` (~893 refs) via `compare_commits`, each call returning 404 and getting retried 3× — ~3,500 wasted REST calls per zizmor run, enough to drain the 1,000/hr `GITHUB_TOKEN` budget multiple times over in a single CI run. That's what was actually breaking the workflow on busy PR days, not the volume of legitimate API traffic, so the previous "route through an app token" attempt is no longer needed.

Upstream issue: [zizmorcore/zizmor#1997](https://github.com/zizmorcore/zizmor/issues/1997).

## Review focus

- The SHA swap is the only change. `gh api repos/github/codeql-action/git/ref/tags/v4.35.4` returns an annotated tag (`.object.type == "tag"`) whose `.object.sha` is `3ce22a6e…`; `gh api repos/.../git/tags/3ce22a6e…` dereferences to commit `68bde559…`. The new pin is that commit.
- I audited the other action pins under `.github/` — none of them are annotated-tag-object SHAs, so this is the only one.

## Commits

- [`d536dfa`](https://github.com/contextbridge/planbridge/commit/d536dfa0a418ffae1127a8dc3247ee996b7b4ea5) — fix(ci): pin codeql-action upload-sarif to commit SHA, not tag object