### PR TITLE
ci: read website bucket and distribution id from secrets

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -6,6 +6,12 @@ on:
       website_deploy_role_arn:
         description: ARN of the OIDC role to assume for the S3 sync and CloudFront invalidation.
         required: true
+      website_bucket:
+        description: Name of the S3 bucket that hosts the website.
+        required: true
+      website_distribution_id:
+        description: CloudFront distribution ID fronting the website bucket.
+        required: true
 
 permissions: {}
 
@@ -45,10 +51,10 @@ jobs:
       - name: Sync website to S3
         shell: bash
         env:
-          WEBSITE_BUCKET: ${{ vars.WEBSITE_BUCKET }}
+          WEBSITE_BUCKET: ${{ secrets.website_bucket }}
         run: |
           set -euo pipefail
-          : "${WEBSITE_BUCKET:?Set WEBSITE_BUCKET repository variable}"
+          : "${WEBSITE_BUCKET:?Set WEBSITE_BUCKET repository secret}"
           aws s3 sync packages/website/dist/ "s3://${WEBSITE_BUCKET}/" \
             --delete \
             --exclude "_astro/*" \
@@ -62,10 +68,10 @@ jobs:
       - name: Invalidate website CloudFront cache
         shell: bash
         env:
-          WEBSITE_DISTRIBUTION_ID: ${{ vars.WEBSITE_DISTRIBUTION_ID }}
+          WEBSITE_DISTRIBUTION_ID: ${{ secrets.website_distribution_id }}
         run: |
           set -euo pipefail
-          : "${WEBSITE_DISTRIBUTION_ID:?Set WEBSITE_DISTRIBUTION_ID repository variable}"
+          : "${WEBSITE_DISTRIBUTION_ID:?Set WEBSITE_DISTRIBUTION_ID repository secret}"
           aws cloudfront create-invalidation \
             --distribution-id "${WEBSITE_DISTRIBUTION_ID}" \
             --paths "/*" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,8 @@ jobs:
     uses: ./.github/workflows/deploy-website.yml
     secrets:
       website_deploy_role_arn: ${{ secrets.WEBSITE_DEPLOY_ROLE_ARN }}
+      website_bucket: ${{ secrets.WEBSITE_BUCKET }}
+      website_distribution_id: ${{ secrets.WEBSITE_DISTRIBUTION_ID }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,8 @@ jobs:
     uses: ./.github/workflows/deploy-website.yml
     secrets:
       website_deploy_role_arn: ${{ secrets.WEBSITE_DEPLOY_ROLE_ARN }}
+      website_bucket: ${{ secrets.WEBSITE_BUCKET }}
+      website_distribution_id: ${{ secrets.WEBSITE_DISTRIBUTION_ID }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

Switches the reusable `deploy-website` workflow to read `WEBSITE_BUCKET` and `WEBSITE_DISTRIBUTION_ID` from `secrets.*` instead of `vars.*`. Run 25882776224 failed at the S3 sync step because both values were stored as repo secrets while the workflow expected repo variables — rather than move them to the Variables tab, this change makes the workflow contract match how we want to manage them (as secrets, for extra caution).

## Review focus

- The bucket name and distribution ID are not meaningfully sensitive (the bucket name leaks via DNS / origin config; the distribution ID shows up in CloudFront response headers). Treating them as secrets is a defense-in-depth choice, not a real confidentiality boundary — worth a sanity check that we still want this. The trade-off is that secrets are write-only in the GitHub UI, so future verification/rotation is slightly harder.
- Both callers (`main.yml` and `release.yml`) are updated in lockstep. If either is missed the reusable workflow will fail with a clear `Set …` error rather than silently deploying to the wrong place.

## Commits

- [`c4248bd`](https://github.com/contextbridge/planbridge/pull/126/commits/c4248bd72ddc222a91aa8926ae3a914d846d25f8) — ci: read website bucket and distribution id from secrets