### PR TITLE
ci: pin website CLI reference to stable tags

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -2,6 +2,12 @@ name: Deploy Website
 
 on:
   workflow_call:
+    inputs:
+      cli_ref:
+        description: Stable CLI tag to use when generating website CLI reference docs. Empty means use the checked-out CLI source.
+        required: false
+        type: string
+        default: ''
     secrets:
       website_deploy_role_arn:
         description: ARN of the OIDC role to assume for the S3 sync and CloudFront invalidation.
@@ -37,6 +43,40 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/bootstrap
+
+      - name: Pin CLI reference source
+        if: ${{ inputs.cli_ref != '' }}
+        shell: bash
+        env:
+          CLI_REF: ${{ inputs.cli_ref }}
+        run: |
+          set -euo pipefail
+          : "${CLI_REF:?Set CLI_REF}"
+
+          if ! git check-ref-format --allow-onelevel "${CLI_REF}"; then
+            echo "::error::Invalid CLI_REF '${CLI_REF}'"
+            exit 1
+          fi
+
+          case "${CLI_REF}" in
+            v*) ;;
+            *)
+              echo "::error::CLI_REF must be a v* tag, got '${CLI_REF}'"
+              exit 1
+              ;;
+          esac
+
+          case "${CLI_REF}" in
+            *-*)
+              echo "::error::CLI_REF must be a stable tag without '-', got '${CLI_REF}'"
+              exit 1
+              ;;
+          esac
+
+          git fetch --force --no-tags --depth=1 origin "refs/tags/${CLI_REF}:refs/tags/${CLI_REF}"
+          cli_ref_commit="$(git rev-parse --verify "refs/tags/${CLI_REF}^{commit}")"
+          git checkout "${cli_ref_commit}" -- packages/cli
+          echo "Pinned packages/cli to ${CLI_REF} (${cli_ref_commit})"
 
       - name: Build website
         run: bun run --cwd packages/website build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
       dependencies_changed: ${{ steps.changes.outputs.dependencies_changed }}
       install_script_changed: ${{ steps.changes.outputs.install_script_changed }}
       website_changed: ${{ steps.changes.outputs.website_changed }}
+      cli_ref: ${{ steps.cli-ref.outputs.cli_ref }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -33,6 +34,20 @@ jobs:
           mode: deploy
           workflow_name: Main Branch
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve latest stable CLI tag
+        id: cli-ref
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --force --tags origin
+          latest_tag="$(git tag --list 'v*' --sort=-version:refname | awk '$0 !~ /-/ { print; exit }')"
+          if [ -z "${latest_tag}" ]; then
+            echo "::error::No stable v* tag found for CLI reference generation"
+            exit 1
+          fi
+          echo "Latest stable CLI tag: ${latest_tag}"
+          echo "cli_ref=${latest_tag}" >> "${GITHUB_OUTPUT}"
 
   test:
     name: Tests
@@ -49,6 +64,8 @@ jobs:
     needs: [detect-changes, test]
     if: ${{ needs.detect-changes.outputs.website_changed == 'true' }}
     uses: ./.github/workflows/deploy-website.yml
+    with:
+      cli_ref: ${{ needs.detect-changes.outputs.cli_ref }}
     secrets:
       website_deploy_role_arn: ${{ secrets.WEBSITE_DEPLOY_ROLE_ARN }}
       website_bucket: ${{ secrets.WEBSITE_BUCKET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,8 @@ jobs:
     # Skip alpha releases so unreleased docs do not publish before stable CLI releases.
     if: ${{ !contains(github.ref_name, '-') }}
     uses: ./.github/workflows/deploy-website.yml
+    with:
+      cli_ref: ${{ github.ref_name }}
     secrets:
       website_deploy_role_arn: ${{ secrets.WEBSITE_DEPLOY_ROLE_ARN }}
       website_bucket: ${{ secrets.WEBSITE_BUCKET }}


### PR DESCRIPTION
## Summary

Pins the website CLI reference generation to released CLI source instead of whatever `packages/cli` happens to be on `main`. Main-branch website deploys now resolve the latest stable `v*` tag, while stable release deploys pass the release tag itself, so the generated docs stay aligned with published binaries. Closes #124.

## Review focus

Please sanity-check the workflow ref handling: caller-controlled refs are passed through `env`, validated as stable `v*` tags, fetched by exact tag refspec, and resolved with `^{commit}` before checking out `packages/cli`.

## Commits

- [`70f26b0`](https://github.com/contextbridge/planbridge/commit/70f26b07a743b218b300d3ac2167f73312ff3b47) — pin website CLI reference generation to stable tags
