### PR TITLE
docs: make other agents instructions copyable

### DIFF
--- a/packages/website/src/content/docs/usage/other-agents.mdx
+++ b/packages/website/src/content/docs/usage/other-agents.mdx
@@ -13,7 +13,12 @@ The setup is one instruction in your agent's system prompt or rules file: pipe t
 
 Add something like this to your prompt, system instructions, or rules file (`.cursorrules`, `AGENTS.md`, project README, wherever your agent picks up persistent guidance):
 
-> Before you start coding, write your plan to stdin of `contextbridge plan` and read the markdown returned on stdout. If the response starts with `# Plan review: changes requested`, revise the plan to address every comment, then run `contextbridge plan` again with the revised plan. Continue until you get `# Plan review: approved`, or stop if the command exits with code 130 (the user cancelled).
+```markdown
+Whenever you produce a plan, pipe it to `contextbridge plan` on stdin and read
+the markdown returned on stdout. The response will tell you whether your plan
+was approved or needs revision and what to change. Follow the instructions in
+the response. If the command exits with a non-zero status, stop.
+```
 
 The agent runs something like:
 


### PR DESCRIPTION
## Summary

Updates the Other agents setup guidance so the instruction snippet is a copyable markdown code block instead of a blockquote. The snippet now tells agents to pipe plans through `contextbridge plan` and follow the returned markdown without hardcoding response headers or specific exit-code loops. Closes #132.

<img width="884" height="366" alt="Screenshot 2026-05-15 at 08 31 05" src="https://github.com/user-attachments/assets/5f5f23fb-70d2-4579-a68a-f30081de11e1" />

## Review focus

Nothing unusual.

## Commits

- [`112d032`](https://github.com/contextbridge/planbridge/commit/112d032682f4dd1c96bcefa729aa0e137413ce88) — make the Other agents instruction snippet copyable and less prescriptive.
