### PR TITLE
feat!: rename Claude Code `/open` skill to `/planbridge-open` for consistency

### DIFF
--- a/.claude/rules/planbridge-skills.md
+++ b/.claude/rules/planbridge-skills.md
@@ -9,19 +9,19 @@ paths:
 
 # Adding a PlanBridge skill
 
-A skill is `packages/skills/sources/<name>/SKILL.md` following the [agentskills.io specification](https://agentskills.io/specification). `bun run skills:generate` renders it to one SKILL.md per skill-renderable harness in `@contextbridge/harness` (today: `harnessIntegrations/claude/skills/<name>/SKILL.md` and `harnessIntegrations/codex/skills/planbridge-<name>/SKILL.md`) — all committed, drift-checked by `bun run skills:check`.
+A skill is `packages/skills/sources/<name>/SKILL.md` following the [agentskills.io specification](https://agentskills.io/specification). `bun run skills:generate` renders it to one SKILL.md per skill-renderable harness in `@contextbridge/harness` (today: `harnessIntegrations/claude/skills/<name>/SKILL.md` and `harnessIntegrations/codex/skills/<name>/SKILL.md`) — all committed, drift-checked by `bun run skills:check`.
 
 Edit `packages/skills/sources/<name>/SKILL.md`. Files under `harnessIntegrations/<id>/skills/` are generated.
 
 ## Steps
 
-1. Write `packages/skills/sources/<name>/SKILL.md`. Frontmatter: required `name` (kebab-case logical name — `open`, not `planbridge-open`) and `description`. The body is a Handlebars template evaluated with `{ harness }` as context; wrap any harness-specific content (e.g. Codex sandbox guidance) in `{{#if (eq harness.id "…")}}…{{/if}}` and pull in reusable partials from `sources/_partials/<harnessId>/<topic>.md` via `{{> …}}` inside the conditional.
+1. Write `packages/skills/sources/<name>/SKILL.md`. Frontmatter: required `name` (canonical/public kebab-case skill name, for example `planbridge-open`) and `description`. The body is a Handlebars template evaluated with `{ harness }` as context; wrap any harness-specific content (e.g. Codex sandbox guidance) in `{{#if (eq harness.id "…")}}…{{/if}}` and pull in reusable partials from `sources/_partials/<harnessId>/<topic>.md` via `{{> …}}` inside the conditional.
 2. Add an import + entry in `packages/skills/src/codex.ts`:
 
    ```typescript
-   import newSkill from '../../../harnessIntegrations/codex/skills/planbridge-<name>/SKILL.md' with { type: 'text' };
+   import newSkill from '../../../harnessIntegrations/codex/skills/<name>/SKILL.md' with { type: 'text' };
    // ...
-   { installId: 'planbridge-<name>', body: newSkill },
+   { installId: parseSkill(newSkill).frontmatter.name, body: newSkill },
    ```
 
 3. `bun run skills:generate`.
@@ -32,14 +32,14 @@ If the skill needs a new CLI subcommand, add it under `packages/cli/src/commands
 
 ## Invocation surfaces
 
-- Claude: `/planbridge:<name>` — namespace comes from the plugin manifest.
-- Codex: `$planbridge-<name>` — installed to `~/.agents/skills/planbridge-<name>/SKILL.md`.
+- Claude: `/planbridge-open` or `/planbridge:planbridge-open` for the manual open skill, depending on how Claude displays plugin skills.
+- Codex: `$planbridge-open` for the manual open skill, installed to `~/.agents/skills/planbridge-open/SKILL.md`.
 
 ## Adding a new harness
 
 Skill rendering iterates `SKILL_RENDERABLE_HARNESSES` from `@contextbridge/harness`. To add another agentskills.io-compliant harness:
 
 1. In `packages/harness/src/types.ts`, widen `HarnessId` with the new id.
-2. In `packages/harness/src/registry.ts`, append an entry to `HARNESSES`. Set `skillRendering` with `installName` and `destDir` (relative to repo root; the path under `harnessIntegrations/<id>/skills` is the convention). Set `installUrl` if the CLI installs into this harness.
+2. In `packages/harness/src/registry.ts`, append an entry to `HARNESSES`. Set `skillDestDir` to the output directory (relative to repo root; the path under `harnessIntegrations/<id>/skills` is the convention). Set `installUrl` if the CLI installs into this harness.
 3. `bun run skills:generate` picks up the new entry — no edits to `packages/skills/`.
 4. If the harness is installable, add a `<X>Installer` extending `ScopedHarnessInstaller` and register it in `packages/cli/src/harnesses/installers.ts`. If it has a hook surface, add `packages/cli/src/commands/hook<X>.ts` and register it in `commands/index.ts`.

--- a/harnessIntegrations/claude/skills/planbridge-open/SKILL.md
+++ b/harnessIntegrations/claude/skills/planbridge-open/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: open
+name: planbridge-open
 description: Open a markdown file, document, or piece of content in the PlanBridge browser UI for human annotation. Use when the user wants to give human feedback on a file, draft, plan, spec, or any markdown content.
 ---
 

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -48,7 +48,7 @@ stdin / [path]  ─▶  contextbridge plan
                        { status: "approved" | "changes_requested", annotations: [...] }
 ```
 
-The loop is kind-agnostic: it serves a markdown document into the annotation UI and emits a structured result on stdout. Sibling entrypoints on this same loop today: `plan` (plan-mode handoffs from Claude Code and Codex hooks) and `open` (manual annotation of a markdown file or piped content, surfaced as `/planbridge:open` in Claude and `$planbridge-open` in Codex). The CLI process owns the server and the browser lifecycle. When the user submits in the browser, the server shuts down and the CLI emits its structured result to stdout. That stdout contract is what harness hooks (Claude `exitPlanMode`, Codex Stop hook, etc.) consume.
+The loop is kind-agnostic: it serves a markdown document into the annotation UI and emits a structured result on stdout. Sibling entrypoints on this same loop today: `plan` (plan-mode handoffs from Claude Code and Codex hooks) and `open` (manual annotation of a markdown file or piped content, surfaced as `/planbridge-open` or `/planbridge:planbridge-open` in Claude and `$planbridge-open` in Codex). The CLI process owns the server and the browser lifecycle. When the user submits in the browser, the server shuts down and the CLI emits its structured result to stdout. That stdout contract is what harness hooks (Claude `exitPlanMode`, Codex Stop hook, etc.) consume.
 
 ## Build: embedded annotation UI
 

--- a/packages/harness/AGENTS.md
+++ b/packages/harness/AGENTS.md
@@ -5,13 +5,13 @@ The single source of truth for which agent harnesses PlanBridge knows about and 
 ## What lives here
 
 - `HarnessId` — the closed union of harness identifiers.
-- `HarnessDescriptor` — runtime identity: `id`, `displayName`, `binaryName`, optional `installUrl`, optional `skillRendering` rules.
+- `HarnessDescriptor` — runtime identity: `id`, `displayName`, `binaryName`, optional `installUrl`, optional `skillDestDir`.
 - `HARNESSES` — the canonical registry, one entry per `HarnessId`.
-- Derived views: `INSTALLABLE_HARNESSES` (entries with `installUrl`), `SKILL_RENDERABLE_HARNESSES` (entries with `skillRendering`), plus type-narrowed lookup helpers.
+- Derived views: `INSTALLABLE_HARNESSES` (entries with `installUrl`), `SKILL_RENDERABLE_HARNESSES` (entries with `skillDestDir`), plus type-narrowed lookup helpers.
 
 ## Adding a new harness
 
-Append one entry to `HARNESSES` in `src/registry.ts` after widening `HarnessId` in `src/types.ts`. Set `installUrl` if PlanBridge can install itself into the harness, and `skillRendering` if the harness consumes agentskills.io-style SKILL.md content. Skills regeneration (`bun run skills:generate`) picks up the new entry without further edits.
+Append one entry to `HARNESSES` in `src/registry.ts` after widening `HarnessId` in `src/types.ts`. Set `installUrl` if PlanBridge can install itself into the harness, and `skillDestDir` (the output directory for rendered SKILL.md files, relative to the repo root) if the harness consumes agentskills.io-style SKILL.md content. Skills regeneration (`bun run skills:generate`) picks up the new entry without further edits.
 
 If the new harness is installable, `@contextbridge/cli` also needs an installer and (optionally) a hook command — see `packages/cli/AGENTS.md`.
 

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,10 +1,4 @@
-export type {
-  HarnessDescriptor,
-  HarnessId,
-  InstallableHarness,
-  SkillRenderableHarness,
-  SkillRenderingRules,
-} from './types.ts';
+export type { HarnessDescriptor, HarnessId, InstallableHarness, SkillRenderableHarness } from './types.ts';
 export {
   HARNESSES,
   INSTALLABLE_HARNESSES,

--- a/packages/harness/src/registry.test.ts
+++ b/packages/harness/src/registry.test.ts
@@ -13,18 +13,6 @@ describe('HARNESSES', () => {
     const ids: HarnessId[] = ['claude', 'codex', 'gemini', 'cursor', 'aider', 'opencode', 'aether'];
     expect(HARNESSES.map((h) => h.id).sort()).toEqual([...ids].sort());
   });
-
-  it('claude installs skills with the logical name and no prefix', () => {
-    const claude = getHarness('claude');
-    expect(claude.skillRendering?.installName('open')).toBe('open');
-    expect(claude.skillRendering?.destDir).toBe('harnessIntegrations/claude/skills');
-  });
-
-  it('codex installs skills with the planbridge- prefix', () => {
-    const codex = getHarness('codex');
-    expect(codex.skillRendering?.installName('open')).toBe('planbridge-open');
-    expect(codex.skillRendering?.destDir).toBe('harnessIntegrations/codex/skills');
-  });
 });
 
 describe('INSTALLABLE_HARNESSES', () => {

--- a/packages/harness/src/registry.ts
+++ b/packages/harness/src/registry.ts
@@ -6,20 +6,14 @@ export const HARNESSES: readonly HarnessDescriptor[] = [
     displayName: 'Claude Code',
     binaryName: 'claude',
     installUrl: 'https://docs.claude.com/en/docs/claude-code/setup',
-    skillRendering: {
-      installName: (name) => name,
-      destDir: 'harnessIntegrations/claude/skills',
-    },
+    skillDestDir: 'harnessIntegrations/claude/skills',
   },
   {
     id: 'codex',
     displayName: 'Codex CLI',
     binaryName: 'codex',
     installUrl: 'https://developers.openai.com/codex/cli/',
-    skillRendering: {
-      installName: (name) => `planbridge-${name}`,
-      destDir: 'harnessIntegrations/codex/skills',
-    },
+    skillDestDir: 'harnessIntegrations/codex/skills',
   },
   { id: 'gemini', displayName: 'Gemini CLI', binaryName: 'gemini' },
   { id: 'cursor', displayName: 'Cursor', binaryName: 'cursor' },
@@ -49,5 +43,5 @@ function isInstallable(harness: HarnessDescriptor): harness is InstallableHarnes
 }
 
 function isSkillRenderable(harness: HarnessDescriptor): harness is SkillRenderableHarness {
-  return harness.skillRendering !== undefined;
+  return harness.skillDestDir !== undefined;
 }

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -1,21 +1,14 @@
 export type HarnessId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'aider' | 'opencode' | 'aether';
 
-export interface SkillRenderingRules {
-  /** On-disk install directory name for this harness. e.g. `(n) => n` for Claude, `(n) => `planbridge-${n}`` for Codex. */
-  readonly installName: (logicalName: string) => string;
-  /** Output directory for rendered SKILL.md files, relative to the repo root. */
-  readonly destDir: string;
-}
-
 export interface HarnessDescriptor {
   readonly id: HarnessId;
   readonly displayName: string;
   readonly binaryName: string;
   /** Set when PlanBridge can install itself into this harness; absent for detection-only harnesses. */
   readonly installUrl?: string;
-  /** Set when this harness consumes agentskills.io-style SKILL.md content. */
-  readonly skillRendering?: SkillRenderingRules;
+  /** Output directory for rendered SKILL.md files, relative to the repo root. Set when this harness consumes agentskills.io-style SKILL.md content. */
+  readonly skillDestDir?: string;
 }
 
 export type InstallableHarness = HarnessDescriptor & { readonly installUrl: string };
-export type SkillRenderableHarness = HarnessDescriptor & { readonly skillRendering: SkillRenderingRules };
+export type SkillRenderableHarness = HarnessDescriptor & { readonly skillDestDir: string };

--- a/packages/skills/AGENTS.md
+++ b/packages/skills/AGENTS.md
@@ -6,16 +6,16 @@ PlanBridge skill sources, per-harness rendering, and drift detection.
 
 A skill is `sources/<name>/SKILL.md` following the [agentskills.io specification](https://agentskills.io/specification):
 
-- Required frontmatter: `name` (kebab-case logical name — `open`, not `planbridge-open`), `description`.
+- Required frontmatter: `name` (canonical/public kebab-case skill name, for example `planbridge-open`), `description`.
 - Optional frontmatter: `license`, `compatibility`, `metadata`, `allowed-tools`. Unknown keys reject.
-- Body is harness-neutral prose passed through verbatim. Per-harness divergence happens only in frontmatter (`name`, set via `skillRendering.installName`).
+- Body is harness-neutral prose passed through verbatim. Per-harness divergence happens only inside Handlebars conditionals in the body (see `## Templating`); frontmatter is identical across rendered outputs.
 
 ## Rendered outputs
 
-`bun run skills:generate` writes one SKILL.md per skill-renderable harness listed in `@contextbridge/harness`. The output directory is `harness.skillRendering.destDir` (relative to the repo root) and the on-disk skill folder is `harness.skillRendering.installName(<name>)`. Today:
+`bun run skills:generate` writes one SKILL.md per skill-renderable harness listed in `@contextbridge/harness`. The output directory is `harness.skillDestDir` (relative to the repo root) and the on-disk skill folder is the skill's canonical frontmatter `name`. Today:
 
 - `harnessIntegrations/claude/skills/<name>/SKILL.md` — read off disk by Claude's plugin marketplace.
-- `harnessIntegrations/codex/skills/planbridge-<name>/SKILL.md` — embedded into the CLI binary at build time, written to `~/.agents/skills/planbridge-<name>/SKILL.md` on Codex install.
+- `harnessIntegrations/codex/skills/<name>/SKILL.md` — embedded into the CLI binary at build time, written to `~/.agents/skills/<name>/SKILL.md` on Codex install.
 
 All files are committed. `bun run skills:check` (wired into `just verify` and the lint CI job) regenerates in-memory and fails on byte-diff.
 
@@ -37,16 +37,18 @@ Partials emit content directly. Wrap them in a `{{#if (eq harness.id "…")}}` b
 
 ## Rendering
 
-`render(skill, harness)` in `src/render.ts` takes a parsed `Skill` and a `HarnessDescriptor` from `@contextbridge/harness`. The descriptor's `skillRendering` rules supply `installName(name)` — the frontmatter `name` field in the rendered output. The body is compiled as a Handlebars template (see `## Templating`).
+`render(skill, harness)` in `src/render.ts` takes a parsed `Skill` and a `HarnessDescriptor` from `@contextbridge/harness`. Frontmatter passes through verbatim; the body is compiled as a Handlebars template against `{ harness }` (see `## Templating`).
 
 ## Adding a skill
 
 1. Write `sources/<name>/SKILL.md`.
-2. Add an import + body to the array in `src/codex.ts` (the registry the CLI embeds for Codex install). `installId` is derived from the body's frontmatter.
+2. Add an import + body to the array in `src/codex.ts` (the registry the CLI embeds for Codex install), importing from `harnessIntegrations/codex/skills/<name>/SKILL.md`. `installId` is derived from the body's frontmatter.
 3. `bun run skills:generate`.
 4. `bun run skills:check && bun run --cwd packages/cli test`.
 5. Commit `sources/`, every `harnessIntegrations/<id>/skills/...`, and the `codex.ts` change together.
 
+For the manual open skill, Claude may expose `/planbridge-open` or `/planbridge:planbridge-open`; Codex exposes `$planbridge-open`.
+
 ## Adding a new harness
 
-Defined in `@contextbridge/harness` — see that package's `AGENTS.md`. Once a descriptor's `skillRendering` is set, this package picks it up automatically; no edits here.
+Defined in `@contextbridge/harness` — see that package's `AGENTS.md`. Once a descriptor's `skillDestDir` is set, this package picks it up automatically; no edits here.

--- a/packages/skills/scripts/renderTargets.ts
+++ b/packages/skills/scripts/renderTargets.ts
@@ -29,11 +29,11 @@ export function targetsFor(skill: Skill): ResultAsync<RenderTarget[], Error> {
 }
 
 export function outDirFor(harness: SkillRenderableHarness): string {
-  return join(REPO_ROOT, harness.skillRendering.destDir);
+  return join(REPO_ROOT, harness.skillDestDir);
 }
 
 function targetFor(skill: Skill, harness: SkillRenderableHarness): ResultAsync<RenderTarget, Error> {
-  const path = join(outDirFor(harness), harness.skillRendering.installName(skill.frontmatter.name), 'SKILL.md');
+  const path = join(outDirFor(harness), skill.frontmatter.name, 'SKILL.md');
   const rendered = render(skill, harness);
   if (rendered.isErr()) return errAsync(rendered.error);
 

--- a/packages/skills/sources/planbridge-open/SKILL.md
+++ b/packages/skills/sources/planbridge-open/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: open
+name: planbridge-open
 description: Open a markdown file, document, or piece of content in the PlanBridge browser UI for human annotation. Use when the user wants to give human feedback on a file, draft, plan, spec, or any markdown content.
 ---
 

--- a/packages/skills/src/codex.ts
+++ b/packages/skills/src/codex.ts
@@ -1,4 +1,4 @@
-import openSkill from '../../../harnessIntegrations/codex/skills/planbridge-open/SKILL.md' with { type: 'text' };
+import planbridgeOpenSkill from '../../../harnessIntegrations/codex/skills/planbridge-open/SKILL.md' with { type: 'text' };
 import { parseSkill } from './skills.ts';
 
 export interface BundledSkill {
@@ -8,7 +8,7 @@ export interface BundledSkill {
   readonly body: string;
 }
 
-export const bundledSkills: readonly BundledSkill[] = [openSkill].map((body) => ({
+export const bundledSkills: readonly BundledSkill[] = [planbridgeOpenSkill].map((body) => ({
   installId: parseSkill(body).frontmatter.name,
   body,
 }));

--- a/packages/skills/src/render.test.ts
+++ b/packages/skills/src/render.test.ts
@@ -10,7 +10,7 @@ const codex = getHarness('codex');
 describe('render(skill, claude)', () => {
   it('preserves the source byte-for-byte', () => {
     const source = `---
-name: open
+name: planbridge-open
 description: Open a thing.
 ---
 
@@ -26,9 +26,9 @@ Some content.
 });
 
 describe('render(skill, codex)', () => {
-  it('rewrites the frontmatter name with the planbridge- prefix', () => {
+  it('preserves the canonical frontmatter name for Codex', () => {
     const canonical = parseSkill(`---
-name: open
+name: planbridge-open
 description: Open a thing.
 ---
 
@@ -48,9 +48,9 @@ body
     `);
   });
 
-  it('only rewrites the name field, leaving other frontmatter lines untouched', () => {
+  it('preserves frontmatter values that contain `name:` inside their prose', () => {
     const canonical = parseSkill(`---
-name: open
+name: planbridge-open
 description: "Open a thing. The description mentions name: something as part of its prose."
 ---
 
@@ -69,26 +69,12 @@ body
       "
     `);
   });
-
-  it('returns an error when the harness has no skill rendering rules', () => {
-    const canonical = parseSkill(`---
-name: open
-description: Open.
----
-
-body
-`);
-    const result = render(canonical, getHarness('gemini'));
-
-    assert(result.isErr());
-    expect(result.error.message).toMatch(/no skill rendering rules/);
-  });
 });
 
 describe('render(skill, …) template evaluation', () => {
   it('evaluates an eq-based conditional against the harness id', () => {
     const source = `---
-name: open
+name: planbridge-open
 description: Open a thing.
 ---
 
@@ -112,7 +98,7 @@ Post.
 
   it('renders bodies without any template directives byte-equivalent to the source body', () => {
     const source = `---
-name: open
+name: planbridge-open
 description: Open a thing.
 ---
 
@@ -126,7 +112,7 @@ Plain markdown with no directives.
 
   it('expands partials registered from sources/_partials/', () => {
     const source = `---
-name: open
+name: planbridge-open
 description: Open a thing.
 ---
 
@@ -145,7 +131,7 @@ After.
 
   it('omits content cleanly when a partial reference is wrapped in a false conditional', () => {
     const source = `---
-name: open
+name: planbridge-open
 description: Open a thing.
 ---
 
@@ -169,7 +155,7 @@ After.
 
   it('returns a clear error when a template references a missing partial', () => {
     const source = `---
-name: open
+name: planbridge-open
 description: Open a thing.
 ---
 
@@ -178,6 +164,6 @@ description: Open a thing.
     const result = render(parseSkill(source), codex);
 
     assert(result.isErr());
-    expect(result.error.message).toMatch(/open.*codex\/does-not-exist/);
+    expect(result.error.message).toMatch(/planbridge-open.*codex\/does-not-exist/);
   });
 });

--- a/packages/skills/src/render.ts
+++ b/packages/skills/src/render.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import type { HarnessDescriptor } from '@contextbridge/harness';
-import { Result, err } from 'neverthrow';
+import { Result } from 'neverthrow';
 import { stringify as yamlStringify } from 'yaml';
 import { type HandlebarsEnv, createHandlebars } from './handlebars.ts';
 import type { Skill } from './skills.ts';
@@ -8,14 +8,9 @@ import type { Skill } from './skills.ts';
 const PARTIALS_DIR = join(import.meta.dirname, '..', 'sources', '_partials');
 
 export function render(skill: Skill, harness: HarnessDescriptor): Result<string, Error> {
-  const rules = harness.skillRendering;
-  if (!rules) {
-    return err(new Error(`Harness ${harness.id} has no skill rendering rules`));
-  }
   return Result.fromThrowable(
     () => {
-      const frontmatter = { ...skill.frontmatter, name: rules.installName(skill.frontmatter.name) };
-      const frontmatterText = yamlStringify(frontmatter, { lineWidth: 0 });
+      const frontmatterText = yamlStringify(skill.frontmatter, { lineWidth: 0 });
       const env = createHandlebars(PARTIALS_DIR);
       const body = compileBody(env, skill, harness);
       return `---\n${frontmatterText}---\n\n${body}`;

--- a/packages/skills/src/skills.test.ts
+++ b/packages/skills/src/skills.test.ts
@@ -8,10 +8,13 @@ import { loadAllFrom, parseSkill } from './skills.ts';
 describe('parseSkill', () => {
   it('extracts frontmatter and body', () => {
     const skill = parseSkill(
-      frontmatter({ name: 'open', description: 'Open a thing for review.' }, '# Body heading\n\nBody content.\n'),
+      frontmatter(
+        { name: 'planbridge-open', description: 'Open a thing for review.' },
+        '# Body heading\n\nBody content.\n',
+      ),
     );
 
-    expect(skill.frontmatter.name).toBe('open');
+    expect(skill.frontmatter.name).toBe('planbridge-open');
     expect(skill.frontmatter.description).toBe('Open a thing for review.');
     expect(skill.body).toBe('# Body heading\n\nBody content.\n');
   });
@@ -33,7 +36,7 @@ describe('parseSkill', () => {
   it('parses optional metadata field', () => {
     const skill = parseSkill(
       frontmatter(
-        { name: 'open', description: 'Valid.', metadata: { author: 'contextbridge-ai', version: '1.0' } },
+        { name: 'planbridge-open', description: 'Valid.', metadata: { author: 'contextbridge-ai', version: '1.0' } },
         'body\n',
       ),
     );
@@ -53,9 +56,12 @@ describe('loadAllFrom', () => {
   });
 
   it('returns one skill per `<name>/SKILL.md` entry, alphabetically by directory name', () => {
-    mkdirSync(join(dir, 'open'), { recursive: true });
+    mkdirSync(join(dir, 'planbridge-open'), { recursive: true });
     mkdirSync(join(dir, 'review'), { recursive: true });
-    writeFileSync(join(dir, 'open', 'SKILL.md'), frontmatter({ name: 'open', description: 'Open a thing.' }, 'body\n'));
+    writeFileSync(
+      join(dir, 'planbridge-open', 'SKILL.md'),
+      frontmatter({ name: 'planbridge-open', description: 'Open a thing.' }, 'body\n'),
+    );
     writeFileSync(
       join(dir, 'review', 'SKILL.md'),
       frontmatter({ name: 'review', description: 'Review a change.' }, 'body\n'),
@@ -63,17 +69,17 @@ describe('loadAllFrom', () => {
 
     const skills = loadAllFrom(dir);
 
-    expect(skills.map((s) => s.frontmatter.name)).toEqual(['open', 'review']);
+    expect(skills.map((s) => s.frontmatter.name)).toEqual(['planbridge-open', 'review']);
   });
 
   it('rejects when a directory name does not match the frontmatter name field', () => {
-    mkdirSync(join(dir, 'open'), { recursive: true });
+    mkdirSync(join(dir, 'planbridge-open'), { recursive: true });
     writeFileSync(
-      join(dir, 'open', 'SKILL.md'),
-      frontmatter({ name: 'review', description: 'Mismatched name.' }, 'body\n'),
+      join(dir, 'planbridge-open', 'SKILL.md'),
+      frontmatter({ name: 'open', description: 'Mismatched name.' }, 'body\n'),
     );
 
-    expect(() => loadAllFrom(dir)).toThrow(/directory name 'open' does not match frontmatter name 'review'/);
+    expect(() => loadAllFrom(dir)).toThrow(/directory name 'planbridge-open' does not match frontmatter name 'open'/);
   });
 
   it('returns an empty array when no skills exist', () => {
@@ -81,14 +87,17 @@ describe('loadAllFrom', () => {
   });
 
   it('ignores directories whose name starts with an underscore', () => {
-    mkdirSync(join(dir, 'open'), { recursive: true });
+    mkdirSync(join(dir, 'planbridge-open'), { recursive: true });
     mkdirSync(join(dir, '_partials', 'codex'), { recursive: true });
-    writeFileSync(join(dir, 'open', 'SKILL.md'), frontmatter({ name: 'open', description: 'Open a thing.' }, 'body\n'));
+    writeFileSync(
+      join(dir, 'planbridge-open', 'SKILL.md'),
+      frontmatter({ name: 'planbridge-open', description: 'Open a thing.' }, 'body\n'),
+    );
     writeFileSync(join(dir, '_partials', 'codex', 'sandbox-escalation.md'), 'shared snippet\n');
 
     const skills = loadAllFrom(dir);
 
-    expect(skills.map((s) => s.frontmatter.name)).toEqual(['open']);
+    expect(skills.map((s) => s.frontmatter.name)).toEqual(['planbridge-open']);
   });
 });
 

--- a/packages/website/src/components/Faq.astro
+++ b/packages/website/src/components/Faq.astro
@@ -14,7 +14,7 @@ const faqs = [
   {
     question: 'Can I open a file in PlanBridge without going through plan mode?',
     answer:
-      'Yes. The <code class="font-mono">/planbridge:open</code> skill (Claude Code) and <code class="font-mono">$planbridge-open</code> skill (Codex CLI) open any markdown file in the PlanBridge UI on demand. See <a href="/usage/open/" class="underline underline-offset-4">Open arbitrary content</a>.',
+      'Yes. The <code class="font-mono">/planbridge-open</code> skill (Claude Code) and <code class="font-mono">$planbridge-open</code> skill (Codex CLI) open any markdown file in the PlanBridge UI on demand. See <a href="/usage/open/" class="underline underline-offset-4">Open arbitrary content</a>.',
   },
   {
     question: 'Does PlanBridge take over my agent workflow?',

--- a/packages/website/src/components/IntegrationCards.astro
+++ b/packages/website/src/components/IntegrationCards.astro
@@ -71,7 +71,7 @@ import InstallActions from './InstallActions.astro';
         href="/usage/open/"
         class="text-foreground underline underline-offset-4"
       >
-        Open any file manually with the /planbridge:open skill &rarr;
+        Open any file manually with the /planbridge-open skill &rarr;
       </a>
     </p>
 

--- a/packages/website/src/content/docs/usage/claude-code.mdx
+++ b/packages/website/src/content/docs/usage/claude-code.mdx
@@ -60,7 +60,7 @@ Or `contextbridge uninstall` to remove PlanBridge plugin and hook entries from e
 
 ## Open a file manually
 
-The plan-mode hook fires automatically. If you want to pull an arbitrary markdown file into the PlanBridge UI on demand (a design doc, an RFC, a plan written outside of plan mode), use the `/planbridge:open` skill that ships with the plugin. See [Open arbitrary content](/usage/open/).
+The plan-mode hook fires automatically. If you want to pull an arbitrary markdown file into the PlanBridge UI on demand (a design doc, an RFC, a plan written outside of plan mode), use the `/planbridge-open` skill that ships with the plugin. Claude Code may show it as `/planbridge:planbridge-open` in the slash-command picker. See [Open arbitrary content](/usage/open/).
 
 ## Reference
 

--- a/packages/website/src/content/docs/usage/index.mdx
+++ b/packages/website/src/content/docs/usage/index.mdx
@@ -7,7 +7,7 @@ PlanBridge has two paths into the browser review UI.
 
 **As a harness hook.** Your AI coding agent calls `contextbridge` through its standard plugin or hook system at decision points, a human annotates in the browser, and the decision flows back to the agent. The [install script](/install/) adds those entries for any supported harness it detects.
 
-**As a manual skill.** You invoke `/planbridge:open <path>` in Claude Code or `$planbridge-open <path>` in Codex CLI and your agent opens any markdown file in the browser for review. See [Open arbitrary content](/usage/open/).
+**As a manual skill.** You invoke `/planbridge-open <path>` in Claude Code or `$planbridge-open <path>` in Codex CLI and your agent opens any markdown file in the browser for review. See [Open arbitrary content](/usage/open/).
 
 ## Supported harnesses
 

--- a/packages/website/src/content/docs/usage/open.mdx
+++ b/packages/website/src/content/docs/usage/open.mdx
@@ -5,7 +5,7 @@ description: Ask your coding agent to open any markdown file in the PlanBridge b
 
 import { Code } from 'astro-expressive-code/components';
 
-<Code code="/planbridge:open docs/spec.md" lang="text" title="Claude Code" />
+<Code code="/planbridge-open docs/spec.md" lang="text" title="Claude Code" />
 
 <Code code="$planbridge-open docs/spec.md" lang="text" title="Codex CLI" />
 
@@ -21,13 +21,15 @@ This is the manual sibling to the automatic hook flow. Hooks fire when your agen
 
 ## Claude Code
 
-The `open` skill ships with the `planbridge@contextbridge` Claude plugin. Invoke it inside Claude Code with:
+The `planbridge-open` skill ships with the `planbridge@contextbridge` Claude plugin. Invoke it inside Claude Code with:
 
-<Code code="/planbridge:open path/to/file.md" lang="text" title="Claude Code" />
+<Code code="/planbridge-open path/to/file.md" lang="text" title="Claude Code" />
+
+Claude Code may display the same plugin skill as `/planbridge:planbridge-open`. Use that form if it appears in your slash-command picker.
 
 You can also describe the file in plain language and Claude resolves it:
 
-<Code code="/planbridge:open the design doc we drafted yesterday" lang="text" title="Claude Code" />
+<Code code="/planbridge-open the design doc we drafted yesterday" lang="text" title="Claude Code" />
 
 ## Codex CLI
 


### PR DESCRIPTION
## Summary

Renames the manual open skill from `open` to `planbridge-open` so Claude Code surfaces it as `/planbridge-open` (or `/planbridge:planbridge-open`) regardless of whether the unprefixed name collides with another plugin's skill. Codex already invoked it as `$planbridge-open`, so both harnesses now agree on the canonical name. Once both renderable harnesses used the canonical name verbatim, the `installName` / `skillRendering` indirection in `@contextbridge/harness` became dead weight, so it's flattened to a single `skillDestDir` field in a follow-on commit.

Closes #133

## Review focus

The simplification commit takes the rename a step further than strictly necessary: it removes the `installName` seam entirely. The original plan ([`docs/aether/plans/planbridge-open-skill-rename-plan.md`](https://github.com/contextbridge/planbridge/blob/133-planbridge-open-rename/docs/aether/plans/planbridge-open-skill-rename-plan.md)) called for keeping the abstraction even after Codex went identity. I'm proposing to remove it instead — `render()` no longer touches harness rendering rules at all, and `renderTargets.ts` writes to `<skillDestDir>/<skill.frontmatter.name>` directly. If we expect a future harness that needs to rewrite the skill name (e.g. install-time prefixing), we'd have to reintroduce some seam, but reintroducing a single function is cheaper than carrying unused indirection.

## Commits

- [`f605d18`](https://github.com/contextbridge/planbridge/pull/136/commits/f605d182aef08c411238f583364d443c4302224d) — feat: rename open skill to planbridge-open (source + generated outputs + website docs + Claude rule)
- [`cab5bfd`](https://github.com/contextbridge/planbridge/pull/136/commits/cab5bfd5f0d4e27a16c28d3b217598a26b65295c) — refactor(harness): drop `installName` indirection now that skills use canonical names