### PR TITLE
fix: clarify Codex Stop hook status message

### DIFF
--- a/packages/cli/src/installers/CodexInstaller.test.ts
+++ b/packages/cli/src/installers/CodexInstaller.test.ts
@@ -35,7 +35,7 @@ describe('CodexInstaller', () => {
         type: 'command',
         command: 'contextbridge hook codex',
         timeout: 345600,
-        statusMessage: 'Opening PlanBridge',
+        statusMessage: 'Waiting for your plan review in PlanBridge...',
       });
       expect(commandRunnerCalls(context, ['features', 'enable', 'hooks'])).toHaveLength(1);
       expect(io.stderr.text()).toContain('PlanBridge hook installed for Codex CLI (scope: user)');

--- a/packages/cli/src/installers/CodexInstaller.ts
+++ b/packages/cli/src/installers/CodexInstaller.ts
@@ -14,7 +14,7 @@ import { INSTALL_SCOPES, type InstallScope, ScopedHarnessInstaller } from './Sco
 
 const CODEX_HOOK_COMMAND = 'contextbridge hook codex';
 const CODEX_HOOK_TIMEOUT_SECONDS = 345600;
-const CODEX_HOOK_STATUS_MESSAGE = 'Opening PlanBridge';
+const CODEX_HOOK_STATUS_MESSAGE = 'Waiting for your plan review in PlanBridge...';
 // 0.129.0 introduced the replacement `hooks` feature flag for the deprecated `codex_hooks` flag.
 const MINIMUM_CODEX_VERSION = '0.129.0';
 


### PR DESCRIPTION
## Summary

The Codex Stop hook's `statusMessage` was `"Opening PlanBridge"`, which Codex CLI surfaces in its UI for the entire duration the hook is running. Once the browser is open and the CLI is blocking on the user's review, that wording reads as a hang. Replace it with `"Waiting for your plan review in PlanBridge..."` so the message accurately describes the blocking state — and stays accurate on the early-return path where `runHookCodex` exits without opening anything because no proposed plan was found in the transcript.

Existing Codex installs won't pick this up until users re-run `contextbridge install codex`, since the message lives in the user's `hooks.json`.

## Review focus

The exit-early path in `hookCodex.ts` (`handleStop` returning `null` when there's no proposed plan) makes any wording that promises "browser is open" misleading. The chosen phrasing avoids that pitfall by describing the blocking semantic rather than the UI state. If there's a wording you'd prefer that handles both paths, push back.

## Commits

- [`53e0b53`](https://github.com/contextbridge/planbridge/commit/53e0b53) — fix(cli): clarify Codex Stop hook status message