### PR TITLE
chore(agents): Add github action to push agent docker image to ECR

### DIFF
--- a/.github/workflows/build-contextbridge-image.yml
+++ b/.github/workflows/build-contextbridge-image.yml
@@ -1,0 +1,56 @@
+name: Build .contextbridge image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".tool-versions"
+      - ".contextbridge/**"
+      - ".github/workflows/build-contextbridge-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: contextbridge-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and push
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # AWS OIDC role assumption
+      actions: write # docker/build-push-action writes GitHub Actions cache entries
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          role-to-assume: ${{ secrets.CONTEXTBRIDGE_ECR_PUSH_ROLE_ARN }}
+          aws-region: ${{ secrets.CONTEXTBRIDGE_ECR_PUSH_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: .contextbridge/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.ecr.outputs.registry }}/${{ secrets.CONTEXTBRIDGE_ECR_REPOSITORY }}:${{ github.repository_id }}-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          secrets: |
+            github_token=${{ github.token }}


### PR DESCRIPTION
## Summary

This PR sets up pushing agent Docker images (for cloud agents) to our ECR repo 