### PR TITLE
chore(agents): Fix Dockerfile which required node for agents to run a…

### DIFF
--- a/.contextbridge/Dockerfile
+++ b/.contextbridge/Dockerfile
@@ -10,11 +10,10 @@ FROM debian:bookworm-slim
 ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 ARG ASDF_VERSION=0.18.0
-ARG NODE_VERSION=24.15.0
 
 # Chromium runtime libs drive @contextbridge/annotation's vitest --browser tests.
 # libdbus-1-3 is required by aether's native ACP subprocess.
-# xz-utils unpacks the Node tarball; unzip is needed by the asdf bun plugin.
+# xz-utils unpacks tool archives for asdf plugins; unzip is needed by the asdf bun plugin.
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -41,14 +40,6 @@ RUN apt-get update \
   && curl -fsSL "https://github.com/asdf-vm/asdf/releases/download/v${ASDF_VERSION}/asdf-v${ASDF_VERSION}-linux-$(dpkg --print-architecture).tar.gz" \
     | tar -xz -C /usr/local/bin asdf \
   && chmod +x /usr/local/bin/asdf \
-  && case "$(dpkg --print-architecture)" in \
-       amd64) NODE_ARCH=x64 ;; \
-       arm64) NODE_ARCH=arm64 ;; \
-       *) echo "Unsupported arch: $(dpkg --print-architecture)" >&2; exit 1 ;; \
-     esac \
-  && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
-    | tar -xJ -C /usr/local --strip-components=1 --no-same-owner \
-      --exclude='*.md' --exclude='LICENSE' \
   && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g "${AGENT_GID}" agent \
@@ -65,6 +56,7 @@ COPY --chown=agent:agent .tool-versions /home/agent/.tool-versions
 WORKDIR /home/agent
 RUN asdf plugin add bun \
   && asdf plugin add just \
+  && asdf plugin add nodejs \
   && asdf install \
   && asdf reshim
 

--- a/.contextbridge/Dockerfile
+++ b/.contextbridge/Dockerfile
@@ -1,37 +1,34 @@
 # Dev-container image for ContextBridge agents.
 #
 # - The repo is cloned and mounted at runtime — do not COPY source in
-# - `/workspace/repo` must be writable by the non-root `bun` user
+# - `/workspace/repo` must be writable by the non-root `agent` user
 # - The cb-bot agent task overrides this image's entrypoint with the staged
 #   protocol script at /workspace/agent/customer-entrypoint.sh, so this image
 #   intentionally has no ENTRYPOINT/CMD of its own
 
-FROM oven/bun:1.3.13-debian
-ARG JUST_VERSION=1.49.0
+FROM debian:bookworm-slim
 ARG AGENT_UID=1000
 ARG AGENT_GID=1000
+ARG ASDF_VERSION=0.18.0
+ARG NODE_VERSION=24.15.0
 
-USER root
-RUN groupmod -g "${AGENT_GID}" bun \
-  && usermod -u "${AGENT_UID}" -g "${AGENT_GID}" bun \
-  && chown -R "${AGENT_UID}:${AGENT_GID}" /home/bun
-
-# nodejs is required so `bun run vitest` resolves vitest's `#!/usr/bin/env node`
-# shebang to a real Node — under Bun's runtime, vitest browser mode hangs silently
-# before any tests run. Chromium runtime libs are for Playwright (drives
-# @contextbridge/annotation's vitest --browser tests).
+# Chromium runtime libs drive @contextbridge/annotation's vitest --browser tests.
+# libdbus-1-3 is required by aether's native ACP subprocess.
+# xz-utils unpacks the Node tarball; unzip is needed by the asdf bun plugin.
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     git \
     jq \
-    nodejs \
+    unzip \
+    xz-utils \
     libasound2 \
     libatk1.0-0 \
     libatk-bridge2.0-0 \
     libcairo2 \
     libcups2 \
+    libdbus-1-3 \
     libdrm2 \
     libgbm1 \
     libnss3 \
@@ -41,13 +38,34 @@ RUN apt-get update \
     libxfixes3 \
     libxkbcommon0 \
     libxrandr2 \
+  && curl -fsSL "https://github.com/asdf-vm/asdf/releases/download/v${ASDF_VERSION}/asdf-v${ASDF_VERSION}-linux-$(dpkg --print-architecture).tar.gz" \
+    | tar -xz -C /usr/local/bin asdf \
+  && chmod +x /usr/local/bin/asdf \
+  && case "$(dpkg --print-architecture)" in \
+       amd64) NODE_ARCH=x64 ;; \
+       arm64) NODE_ARCH=arm64 ;; \
+       *) echo "Unsupported arch: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+     esac \
+  && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
+    | tar -xJ -C /usr/local --strip-components=1 --no-same-owner \
+      --exclude='*.md' --exclude='LICENSE' \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-$(uname -m)-unknown-linux-musl.tar.gz" \
-    | tar -xz -C /usr/local/bin just
+RUN groupadd -g "${AGENT_GID}" agent \
+  && useradd -m -u "${AGENT_UID}" -g "${AGENT_GID}" -s /bin/bash agent \
+  && mkdir -p /workspace/repo \
+  && chown -R agent:agent /workspace
 
-RUN mkdir -p /workspace/repo && chown -R bun:bun /workspace
+USER agent
+ENV HOME=/home/agent
+ENV ASDF_DATA_DIR=/home/agent/.asdf
+ENV PATH="/home/agent/.asdf/shims:${PATH}"
 
-USER bun
-ENV HOME=/home/bun
+COPY --chown=agent:agent .tool-versions /home/agent/.tool-versions
+WORKDIR /home/agent
+RUN asdf plugin add bun \
+  && asdf plugin add just \
+  && asdf install \
+  && asdf reshim
+
 WORKDIR /workspace


### PR DESCRIPTION

This PR fixes some issues with our agent's Dockerfile, changes are in response to an AWS error. Previously we were installing an old version of node (18), but we need a newer version to avoid runtime errors that depend on `AsyncDisposableStack`