### PR TITLE
ci: scope github app token permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,8 @@ jobs:
           private-key: ${{ secrets.CB_PR_AUTOMATION_APP_PRIVATE_KEY }}
           owner: contextbridge
           repositories: planbridge
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
           private-key: ${{ env.HOMEBREW_TAP_APP_PRIVATE_KEY }}
           owner: contextbridge
           repositories: homebrew-tap
+          permission-contents: write
 
       - name: Validate telemetry build config
         shell: bash


### PR DESCRIPTION
## Summary

Zizmor's `github-app` rule was flagging every `actions/create-github-app-token` call in our release workflows because none of them passed `permission-*` inputs — so each minted token inherited the full set of permissions granted to the installed GitHub App. This narrows each remaining token to the minimum it actually uses, closing the open code-scanning alerts.

Rebased after #155 (which deleted the unused ContextBridge app token from `release.yml` entirely). Now scoped to just the two tokens that are actually consumed.

## Review focus

The permission scoping is based on each token's *actual* use, not what the App is theoretically allowed to do:

- **`release-please.yml`** → `contents: write` + `pull-requests: write`. `release-please-action` opens release PRs, pushes the release branch, and creates tags + GitHub Releases. The `contents` permission covers releases per GitHub's permissions schema — same set the job's existing `permissions:` block already declares for `secrets.GITHUB_TOKEN`, mirrored onto the app token.
- **`release.yml` Homebrew tap token** → `contents: write`. GoReleaser uses it to push the updated formula to `contextbridge/homebrew-tap`.

Verified locally: `uvx zizmor .github/workflows/release-please.yml .github/workflows/release.yml` reports *No findings to report*.

## Commits

- [`0ef2a6f`](https://github.com/contextbridge/planbridge/commit/0ef2a6f) — scope each `create-github-app-token` call to its minimum required permissions