### PR TITLE
chore(ci): drop unused app token from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,19 +27,9 @@ jobs:
       id-token: write
       packages: read
     steps:
-      - name: Generate ContextBridge app token
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          client-id: ${{ secrets.CB_PR_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.CB_PR_AUTOMATION_APP_PRIVATE_KEY }}
-          owner: contextbridge
-          repositories: planbridge
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - uses: ./.github/actions/bootstrap


### PR DESCRIPTION
## Summary

The ContextBridge app token in `release.yml` is unused — it's minted, piped into `actions/checkout`, and then thrown away (the checkout uses `persist-credentials: false`, so no later step can pick it up). It was originally there to clone the `planbridge-private` submodule but both the submodule and that referenced repository were removed in May 2026 ([`cc08fde`](https://github.com/contextbridge/planbridge/commit/cc08fde), [`55e3cde`](https://github.com/contextbridge/planbridge/commit/55e3cde)) and the token step was never cleaned up. This PR deletes it; `actions/checkout` falls back to the default `secrets.GITHUB_TOKEN`, which already has `contents: write` at the job level.

Independent of #154 (least-privilege scoping of the *still-used* tokens). Whichever lands second will need a trivial rebase.

## Review focus

The question to satisfy yourself on is: **is the app token really only used by the checkout step?** I verified via `grep` that `steps.app-token.outputs.token` is referenced exactly once in `release.yml` (the old line 42), and that GoReleaser explicitly uses `secrets.GITHUB_TOKEN` (not the app token) for the release publish. Steelman table for keeping the token anyway:

| Reason | Applies? |
|---|---|
| Cross-repo / submodule clone | No — submodules removed in `cc08fde` |
| Bypass branch protection on push | No — nothing in this job pushes to `planbridge` |
| Trigger downstream `on: release` workflows | No — GoReleaser uses `secrets.GITHUB_TOKEN` for the release, not the app token |
| Higher API rate limits | No — only `actions/checkout` consumed the token |
| LFS auth | No — no `.lfsconfig` |
| Audit-log attribution | No — release author is whoever holds the token GoReleaser uses |

Plus `persist-credentials: false` already guarantees the token isn't reachable past the checkout step. So removal is a strict reduction in attack surface with no behavior change.

## Commits

- [`202e5f2`](https://github.com/contextbridge/planbridge/commit/202e5f2) — delete `Generate ContextBridge app token` step and the corresponding `token:` input on `actions/checkout`