### PR TITLE
docs(website): add automatic wiring to Superpowers recipe

### DIFF
--- a/packages/website/src/content/docs/recipes/superpowers.mdx
+++ b/packages/website/src/content/docs/recipes/superpowers.mdx
@@ -8,14 +8,17 @@ import { Code } from 'astro-expressive-code/components';
 
 [Superpowers](https://github.com/obra/superpowers) is a Claude Code and Codex plugin that gives the agent a library of process skills (brainstorming, writing plans, executing plans, debugging).
 
-It explicitly tells the agent to not use Plan mode, which breaks our default behavior. However, there are two pause points in that workflow that are good places to utilize PlanBridge for review: brainstorming and spec review.
+There are two pause points in the Superpowers workflow where PlanBridge fits well: design sections during brainstorming, and spec review. You can trigger PlanBridge manually or automatically.
 
-## During brainstorming
+## Manual
 
-The brainstorming skill walks the agent through clarifying questions and presents the design back to you in sections, in the terminal.
-Often, a section might have hundreds of lines of output, making it difficult to provide targeted feedback.
+Trigger PlanBridge yourself with the `planbridge-open` slash command. This allows you to respond to some superpowers sections (like short brainstorming sections) in the terminal UI, while opening larger sections in PlanBridge to provide more precise feedback.
 
-You can pull the most recent section into PlanBridge for annotation:
+### During brainstorming
+
+The brainstorming skill walks the agent through clarifying questions and presents the design back to you in sections, in the terminal. A section can run hundreds of lines, which is hard to give targeted feedback on by typing back into the harness.
+
+Pull the most recent section into PlanBridge:
 
 <Tabs syncKey="harness">
   <TabItem label="Claude Code">
@@ -26,12 +29,11 @@ You can pull the most recent section into PlanBridge for annotation:
   </TabItem>
 </Tabs>
 
-The agent will open the section in PlanBridge for your review and markup. This provides a much more granular way to provide feedback than the input box in your harness.
+The agent opens the section in PlanBridge for your review and markup, then revises based on the annotations you submit.
 
-## Reviewing the spec
+### Reviewing the spec
 
-Once you approve the design, the brainstorming skill writes a spec file under `docs/superpowers/specs/` and pauses for review. This is
-another great time to use PlanBridge to review and annotate the spec. A better spec means cleaner code generation!
+Once you approve the design, the brainstorming skill writes a spec file to `docs/superpowers/specs/` and pauses for review. A better spec means cleaner code generation.
 
 <Tabs syncKey="harness">
   <TabItem label="Claude Code">
@@ -43,6 +45,43 @@ another great time to use PlanBridge to review and annotate the spec. A better s
 </Tabs>
 
 Same loop: annotate inline, submit, and the agent revises the spec or moves on to writing the plan.
+
+## Automatic
+
+If you want PlanBridge to fire at both pause points without you asking, append a snippet to your global agent instructions. Run the command for your harness:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code
+      lang="bash"
+      code={`echo '
+## Superpowers + PlanBridge
+
+When using the Superpowers \`brainstorming\` skill, use the \`/planbridge-open\` slash command at these pause points:
+
+- When presenting design sections for approval (the "Present design" step, covering architecture, components, data flow, error handling, testing), run \`/planbridge-open the section you just wrote\` instead of asking for text approval.
+- When writing a spec file under \`docs/superpowers/specs/\`, run \`/planbridge-open the spec you just wrote\` instead of asking me to review it as text.
+
+Treat the returned annotations as my review feedback. Clarifying questions and approach proposals stay in the terminal.
+' >> ~/.claude/CLAUDE.md`}
+    />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code
+      lang="bash"
+      code={`echo '
+## Superpowers + PlanBridge
+
+When using the Superpowers \`brainstorming\` skill, use the \`$planbridge-open\` slash command at these pause points:
+
+- When presenting design sections for approval (the "Present design" step, covering architecture, components, data flow, error handling, testing), run \`$planbridge-open the section you just wrote\` instead of asking for text approval.
+- When writing a spec file under \`docs/superpowers/specs/\`, run \`$planbridge-open the spec you just wrote\` instead of asking me to review it as text.
+
+Treat the returned annotations as my review feedback. Clarifying questions and approach proposals stay in the terminal.
+' >> ~/.codex/AGENTS.md`}
+    />
+  </TabItem>
+</Tabs>
 
 ## Future Improvements
 

--- a/packages/website/src/content/docs/recipes/superpowers.mdx
+++ b/packages/website/src/content/docs/recipes/superpowers.mdx
@@ -64,7 +64,8 @@ When using the Superpowers \`brainstorming\` skill, use the \`/planbridge-open\`
 
 Treat the returned annotations as my review feedback. Clarifying questions and approach proposals stay in the terminal.
 ' >> ~/.claude/CLAUDE.md`}
-    />
+/>
+
   </TabItem>
   <TabItem label="Codex CLI">
     <Code
@@ -79,7 +80,8 @@ When using the Superpowers \`brainstorming\` skill, use the \`$planbridge-open\`
 
 Treat the returned annotations as my review feedback. Clarifying questions and approach proposals stay in the terminal.
 ' >> ~/.codex/AGENTS.md`}
-    />
+/>
+
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## Summary

Splits the Superpowers recipe into Manual and Automatic sections. The Automatic path is a single `echo` per harness that appends a prompt referencing `/planbridge-open` (`$planbridge-open` for Codex) so both brainstorming design sections and spec review route through PlanBridge without per-pause user input. Closes #146.

## Review focus

The Automatic snippet is an unbounded append to `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md` — no sentinel markers, no idempotency. Worth deciding whether the docs should call that out, or whether the right follow-up is wiring this through `contextbridge install` so it's reversible.

## Commits

- [`3d0559f`](https://github.com/contextbridge/planbridge/commit/3d0559ff2e7bdebaa67801d525980f1f90bdc8d2) — docs(website): add automatic wiring to Superpowers recipe