### PR TITLE
refactor(server): split annotation routes via Bun routes API

### DIFF
--- a/packages/server/src/annotation.test.ts
+++ b/packages/server/src/annotation.test.ts
@@ -1,200 +1,10 @@
 import { fakeBaseContext } from '@contextbridge/context/testHelpers';
-import type { AnnotationPayload } from '@contextbridge/shared/annotationSchema';
-import type { FrontendConfig } from '@contextbridge/shared/frontendConfigSchema';
-import { annotationThread, globalThread } from '@contextbridge/shared/testFactories';
-import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
+import { annotationPayload, frontendConfig } from '@contextbridge/shared/testFactories';
 import { describe, expect, it } from 'bun:test';
-import { createAnnotationServerApp, resolveListenPort, startServer } from './annotation.ts';
-
-describe('createAnnotationServerApp', () => {
-  const payload: AnnotationPayload = {
-    content: '# plan',
-    contentKind: 'plan',
-    metadata: { entrypoint: 'plan_command' },
-  };
-  const config: FrontendConfig = { distinctId: 'test-distinct-id', telemetryDisabled: false };
-  const ctx = fakeBaseContext();
-
-  it('serves the UI html at /', async () => {
-    const app = createAnnotationServerApp(ctx, {
-      html: Promise.resolve('<html><body>ui</body></html>'),
-      payload,
-      config,
-    });
-    const res = await app.fetch(new Request('http://localhost/'));
-    expect(res.status).toBe(200);
-    expect(res.headers.get('content-type')).toContain('text/html');
-    expect(await res.text()).toContain('<body>ui</body>');
-  });
-
-  it('awaits a Promise<string> for html so callers can begin loading the bundle off the critical path', async () => {
-    let resolveHtml!: (html: string) => void;
-    const htmlPromise = new Promise<string>((resolve) => {
-      resolveHtml = resolve;
-    });
-    const app = createAnnotationServerApp(ctx, { html: htmlPromise, payload, config });
-
-    const responsePromise = app.fetch(new Request('http://localhost/'));
-    resolveHtml('<html><body>deferred</body></html>');
-    const res = await responsePromise;
-
-    expect(res.status).toBe(200);
-    expect(await res.text()).toContain('<body>deferred</body>');
-  });
-
-  it('returns 500 when the html promise rejects', async () => {
-    const app = createAnnotationServerApp(ctx, {
-      html: Promise.reject(new Error('bundle missing')),
-      payload,
-      config,
-    });
-    const res = await app.fetch(new Request('http://localhost/'));
-    expect(res.status).toBe(500);
-  });
-
-  it('serves the submission payload at /payload', async () => {
-    const app = createAnnotationServerApp(ctx, {
-      html: Promise.resolve('<html><body>ui</body></html>'),
-      payload,
-      config,
-    });
-    const res = await app.fetch(new Request('http://localhost/payload'));
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual(payload);
-  });
-
-  it('serves the frontend config at /config', async () => {
-    const app = createAnnotationServerApp(ctx, {
-      html: Promise.resolve('<html><body>ui</body></html>'),
-      payload,
-      config,
-    });
-    const res = await app.fetch(new Request('http://localhost/config'));
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual(config);
-  });
-
-  it('resolves the result promise on a valid POST /submit', async () => {
-    const app = createAnnotationServerApp(ctx, {
-      html: Promise.resolve('<html><body>ui</body></html>'),
-      payload,
-      config,
-    });
-    const submission = {
-      status: 'changes_requested' as const,
-      threads: [annotationThread.build(), globalThread.build()],
-    };
-
-    const res = await app.fetch(
-      new Request('http://localhost/submit', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(submission),
-      }),
-    );
-
-    expect(res.status).toBe(204);
-    expect(res.headers.get('connection')).toBe('close');
-    expect(await app.result).toEqual(submission);
-  });
-
-  it('returns 400 when the submission fails schema validation', async () => {
-    const app = createAnnotationServerApp(ctx, {
-      html: Promise.resolve('<html><body>ui</body></html>'),
-      payload,
-      config,
-    });
-    const res = await app.fetch(
-      new Request('http://localhost/submit', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ status: 'maybe', threads: [] }),
-      }),
-    );
-
-    expect(res.status).toBe(400);
-  });
-
-  it('returns 404 for unknown routes', async () => {
-    const app = createAnnotationServerApp(ctx, {
-      html: Promise.resolve('<html><body>ui</body></html>'),
-      payload,
-      config,
-    });
-    const res = await app.fetch(new Request('http://localhost/nope'));
-    expect(res.status).toBe(404);
-  });
-
-  it('/update-notice returns null when no checkForUpdate callback is provided', async () => {
-    const app = createAnnotationServerApp(ctx, {
-      html: Promise.resolve('<html><body>ui</body></html>'),
-      payload,
-      config,
-    });
-    const res = await app.fetch(new Request('http://localhost/update-notice'));
-    expect(res.status).toBe(200);
-    expect(await res.json()).toBeNull();
-  });
-
-  it('/update-notice invokes checkForUpdate on demand and returns the resolved notice', async () => {
-    const notice: UpdateNotice = {
-      currentVersion: '0.1.0',
-      latestVersion: '0.2.0',
-      channel: 'stable',
-    };
-    let calls = 0;
-    const app = createAnnotationServerApp(ctx, {
-      html: Promise.resolve('<html><body>ui</body></html>'),
-      payload,
-      config,
-      checkForUpdate: () => {
-        calls++;
-        return Promise.resolve(notice);
-      },
-    });
-    const res = await app.fetch(new Request('http://localhost/update-notice'));
-    expect(await res.json()).toEqual(notice);
-    expect(calls).toBe(1);
-  });
-
-  it('/update-notice returns null when checkForUpdate rejects', async () => {
-    const app = createAnnotationServerApp(ctx, {
-      html: Promise.resolve('<html><body>ui</body></html>'),
-      payload,
-      config,
-      checkForUpdate: () => Promise.reject(new Error('boom')),
-    });
-    const res = await app.fetch(new Request('http://localhost/update-notice'));
-    expect(await res.json()).toBeNull();
-  });
-
-  it('/update-notice returns null when checkForUpdate never resolves within the timeout', async () => {
-    const app = createAnnotationServerApp(ctx, {
-      html: Promise.resolve('<html><body>ui</body></html>'),
-      payload,
-      config,
-      // Never resolves — the 3s server-side timeout should fire.
-      checkForUpdate: () => new Promise(() => {}),
-    });
-    // Prove the handler IS waiting (not returning synchronously) by racing
-    // against a tight external timeout — if the handler returned early we'd
-    // see the json, but we should instead see 'still pending' because the
-    // handler is still awaiting the server-side timeout.
-    const notice: unknown = await Promise.race([
-      app.fetch(new Request('http://localhost/update-notice')).then((r) => r.json()),
-      new Promise((resolve) => setTimeout(() => resolve('still pending'), 50)),
-    ]);
-    expect(notice).toBe('still pending');
-  });
-});
+import { resolveListenPort, startServer } from './annotation.ts';
+import { withServer } from './testHelpers.ts';
 
 describe('startServer', () => {
-  const payload: AnnotationPayload = {
-    content: '# plan',
-    contentKind: 'plan',
-    metadata: { entrypoint: 'plan_command' },
-  };
-  const config: FrontendConfig = { distinctId: 'test-distinct-id', telemetryDisabled: false };
   const ctx = fakeBaseContext();
 
   it('uses port 0 by default so the OS chooses an available port', () => {
@@ -205,13 +15,24 @@ describe('startServer', () => {
     expect(resolveListenPort({ port: 3456 })).toBe(3456);
   });
 
+  it('returns 404 for unknown routes', async () => {
+    await withServer(ctx, async (running) => {
+      const res = await fetch(`${running.url}/nope`);
+      expect(res.status).toBe(404);
+    });
+  });
+
   // Regression test for the submit→close race: the /submit response must be
   // fully delivered to the client even though the CLI tears the server down
   // immediately after `running.result` resolves. Pre-fix, this failed with a
   // connection-reset network error because `resolveResult` fired synchronously
   // and `server.stop(true)` ran before Bun flushed the 204.
   it('delivers the /submit response even when close() runs right after result resolves', async () => {
-    const running = startServer(ctx, { html: Promise.resolve('<html><body>ui</body></html>'), payload, config });
+    const running = startServer(ctx, {
+      html: Promise.resolve('<html><body>ui</body></html>'),
+      payload: annotationPayload.build(),
+      config: frontendConfig.build(),
+    });
     const submission = {
       status: 'approved' as const,
       threads: [],

--- a/packages/server/src/annotation.ts
+++ b/packages/server/src/annotation.ts
@@ -1,15 +1,11 @@
-import {
-  type AnnotationPayload,
-  type AnnotationSubmission,
-  AnnotationSubmissionSchema,
-} from '@contextbridge/shared/annotationSchema';
+import type { AnnotationPayload, AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
 import type { FrontendConfig } from '@contextbridge/shared/frontendConfigSchema';
-import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
 import type { ServerContext } from './context.ts';
-
-const UPDATE_NOTICE_TIMEOUT_MS = 3_000;
-
-export type CheckForUpdate = () => Promise<UpdateNotice | null>;
+import { handleConfig } from './routes/config.ts';
+import { handleHtml } from './routes/html.ts';
+import { handlePayload } from './routes/payload.ts';
+import { handleSubmit } from './routes/submit.ts';
+import { type CheckForUpdate, handleUpdateNotice } from './routes/updateNotice.ts';
 
 export interface StartServerOptions {
   /** Annotation UI bundle. Awaited lazily on the first GET /. */
@@ -27,17 +23,25 @@ export interface RunningServer {
   close(): Promise<void>;
 }
 
-export interface AnnotationServerApp {
-  readonly result: Promise<AnnotationSubmission>;
-  fetch: (req: Request) => Promise<Response>;
-}
-
 export function startServer(ctx: ServerContext, opts: StartServerOptions): RunningServer {
   const { logger } = ctx;
-  const app = createAnnotationServerApp(ctx, opts);
+  const { html, payload, config, checkForUpdate } = opts;
+
+  let resolveResult!: (r: AnnotationSubmission) => void;
+  const result = new Promise<AnnotationSubmission>((resolve) => {
+    resolveResult = resolve;
+  });
+
   const server = Bun.serve({
     port: resolveListenPort(opts),
-    fetch: app.fetch,
+    routes: {
+      '/': { GET: () => handleHtml(ctx, html) },
+      '/config': { GET: () => handleConfig(config) },
+      '/payload': { GET: () => handlePayload(payload) },
+      '/update-notice': { GET: () => handleUpdateNotice(checkForUpdate) },
+      '/submit': { POST: (req) => handleSubmit(ctx, req, resolveResult) },
+    },
+    fetch: () => new Response('not found', { status: 404 }),
   });
 
   const port = server.port ?? 0;
@@ -47,81 +51,12 @@ export function startServer(ctx: ServerContext, opts: StartServerOptions): Runni
   return {
     port,
     url,
-    result: app.result,
-    close: () => server.stop(true),
-  };
-}
-
-export function createAnnotationServerApp(ctx: ServerContext, opts: StartServerOptions): AnnotationServerApp {
-  const { html, payload, config, checkForUpdate } = opts;
-  const { logger } = ctx;
-
-  let resolveResult!: (r: AnnotationSubmission) => void;
-  const result = new Promise<AnnotationSubmission>((resolve) => {
-    resolveResult = resolve;
-  });
-
-  return {
     result,
-    fetch: async (req) => {
-      const url = new URL(req.url);
-      if (req.method === 'GET' && url.pathname === '/') {
-        try {
-          const body = await html;
-          return new Response(body, { headers: { 'content-type': 'text/html; charset=utf-8' } });
-        } catch (err) {
-          logger.error({ err }, 'failed to load annotation UI bundle');
-          return new Response('failed to load annotation UI bundle', { status: 500 });
-        }
-      }
-      if (req.method === 'GET' && url.pathname === '/config') {
-        return Response.json(config);
-      }
-      if (req.method === 'GET' && url.pathname === '/payload') {
-        return Response.json(payload);
-      }
-      if (req.method === 'GET' && url.pathname === '/update-notice') {
-        const notice = await resolveUpdateNotice(checkForUpdate);
-        return Response.json(notice);
-      }
-      if (req.method === 'POST' && url.pathname === '/submit') {
-        let body: unknown;
-        try {
-          body = await req.json();
-        } catch {
-          return new Response('invalid JSON', { status: 400 });
-        }
-        const parsed = AnnotationSubmissionSchema.safeParse(body);
-        if (!parsed.success) {
-          logger.warn({ issues: parsed.error.issues }, 'submission failed schema validation');
-          return new Response('invalid submission', { status: 400 });
-        }
-        // Defer resolution to the next macrotask so Bun can flush the 204
-        // onto the socket before the CLI's awaiter unblocks and tears the
-        // server down with `server.stop(true)` — otherwise the browser sees
-        // the connection reset mid-response. `Connection: close` on the
-        // response ensures the browser releases the TCP socket immediately.
-        setTimeout(() => resolveResult(parsed.data), 0);
-        return new Response(null, { status: 204, headers: { connection: 'close' } });
-      }
-      return new Response('not found', { status: 404 });
-    },
+    close: () => server.stop(true),
   };
 }
 
 export function resolveListenPort(opts: Pick<StartServerOptions, 'port'>): number {
   const { port = 0 } = opts;
   return port;
-}
-
-async function resolveUpdateNotice(checkForUpdate: CheckForUpdate | undefined): Promise<UpdateNotice | null> {
-  if (!checkForUpdate) return null;
-  const timeout = new Promise<null>((resolve) => {
-    setTimeout(() => resolve(null), UPDATE_NOTICE_TIMEOUT_MS);
-  });
-  try {
-    return await Promise.race([Promise.resolve().then(checkForUpdate), timeout]);
-  } catch {
-    return null;
-  }
 }

--- a/packages/server/src/routes/config.test.ts
+++ b/packages/server/src/routes/config.test.ts
@@ -1,0 +1,17 @@
+import { fakeBaseContext } from '@contextbridge/context/testHelpers';
+import { frontendConfig } from '@contextbridge/shared/testFactories';
+import { describe, expect, it } from 'bun:test';
+import { withServer } from '#src/testHelpers.ts';
+
+describe('GET /config', () => {
+  const ctx = fakeBaseContext();
+
+  it('serves the frontend config as JSON', async () => {
+    const config = frontendConfig.build();
+    await withServer(ctx, { config }, async (running) => {
+      const res = await fetch(`${running.url}/config`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(config);
+    });
+  });
+});

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -1,0 +1,5 @@
+import type { FrontendConfig } from '@contextbridge/shared/frontendConfigSchema';
+
+export function handleConfig(config: FrontendConfig): Response {
+  return Response.json(config);
+}

--- a/packages/server/src/routes/html.test.ts
+++ b/packages/server/src/routes/html.test.ts
@@ -1,0 +1,48 @@
+import { fakeBaseContext } from '@contextbridge/context/testHelpers';
+import { createDeferred } from '@contextbridge/shared/testHelpers';
+import { describe, expect, it } from 'bun:test';
+import { withServer } from '#src/testHelpers.ts';
+
+describe('GET /', () => {
+  const ctx = fakeBaseContext();
+
+  it('serves the UI html', async () => {
+    await withServer(ctx, async (running) => {
+      const res = await fetch(`${running.url}/`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('text/html');
+      expect(await res.text()).toContain('<body>ui</body>');
+    });
+  });
+
+  it('awaits a Promise<string> for html so callers can begin loading the bundle off the critical path', async () => {
+    const { promise: htmlPromise, resolve: resolveHtml } = createDeferred<string>();
+    await withServer(ctx, { html: htmlPromise }, async (running) => {
+      const responsePromise = fetch(`${running.url}/`);
+
+      // Prove the handler is waiting for html — race against a short timeout.
+      const settledBefore = await Promise.race([
+        responsePromise.then(() => 'fetched'),
+        new Promise<string>((resolve) => setTimeout(() => resolve('still pending'), 50)),
+      ]);
+      expect(settledBefore).toBe('still pending');
+
+      resolveHtml('<html><body>deferred</body></html>');
+      const res = await responsePromise;
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain('<body>deferred</body>');
+    });
+  });
+
+  it('returns 500 when the html promise rejects', async () => {
+    // The route handler awaits `html` lazily, so the rejection is unhandled
+    // from Bun's perspective until a request lands. Suppress the tracker with
+    // a no-op .catch — the handler's try/catch still sees the real rejection.
+    const html = Promise.reject<string>(new Error('bundle missing'));
+    html.catch(() => {});
+    await withServer(ctx, { html }, async (running) => {
+      const res = await fetch(`${running.url}/`);
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/packages/server/src/routes/html.ts
+++ b/packages/server/src/routes/html.ts
@@ -1,0 +1,12 @@
+import type { ServerContext } from '#src/context.ts';
+
+export async function handleHtml(ctx: ServerContext, html: Promise<string>): Promise<Response> {
+  const { logger } = ctx;
+  try {
+    const body = await html;
+    return new Response(body, { headers: { 'content-type': 'text/html; charset=utf-8' } });
+  } catch (err) {
+    logger.error({ err }, 'failed to load annotation UI bundle');
+    return new Response('failed to load annotation UI bundle', { status: 500 });
+  }
+}

--- a/packages/server/src/routes/payload.test.ts
+++ b/packages/server/src/routes/payload.test.ts
@@ -1,0 +1,17 @@
+import { fakeBaseContext } from '@contextbridge/context/testHelpers';
+import { annotationPayload } from '@contextbridge/shared/testFactories';
+import { describe, expect, it } from 'bun:test';
+import { withServer } from '#src/testHelpers.ts';
+
+describe('GET /payload', () => {
+  const ctx = fakeBaseContext();
+
+  it('serves the submission payload as JSON', async () => {
+    const payload = annotationPayload.build();
+    await withServer(ctx, { payload }, async (running) => {
+      const res = await fetch(`${running.url}/payload`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(payload);
+    });
+  });
+});

--- a/packages/server/src/routes/payload.ts
+++ b/packages/server/src/routes/payload.ts
@@ -1,0 +1,5 @@
+import type { AnnotationPayload } from '@contextbridge/shared/annotationSchema';
+
+export function handlePayload(payload: AnnotationPayload): Response {
+  return Response.json(payload);
+}

--- a/packages/server/src/routes/submit.test.ts
+++ b/packages/server/src/routes/submit.test.ts
@@ -1,0 +1,51 @@
+import { fakeBaseContext } from '@contextbridge/context/testHelpers';
+import { annotationThread, globalThread } from '@contextbridge/shared/testFactories';
+import { describe, expect, it } from 'bun:test';
+import { withServer } from '#src/testHelpers.ts';
+
+describe('POST /submit', () => {
+  const ctx = fakeBaseContext();
+
+  it('resolves the result promise on a valid submission and sets connection: close', async () => {
+    await withServer(ctx, async (running) => {
+      const submission = {
+        status: 'changes_requested' as const,
+        threads: [annotationThread.build(), globalThread.build()],
+      };
+
+      const res = await fetch(`${running.url}/submit`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(submission),
+      });
+
+      expect(res.status).toBe(204);
+      expect(res.headers.get('connection')).toBe('close');
+      expect(await running.result).toEqual(submission);
+    });
+  });
+
+  it('returns 400 when the submission fails schema validation', async () => {
+    await withServer(ctx, async (running) => {
+      const res = await fetch(`${running.url}/submit`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ status: 'maybe', threads: [] }),
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  it('returns 400 when the request body is not valid JSON', async () => {
+    await withServer(ctx, async (running) => {
+      const res = await fetch(`${running.url}/submit`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: 'not json',
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/packages/server/src/routes/submit.ts
+++ b/packages/server/src/routes/submit.ts
@@ -1,0 +1,31 @@
+import { type AnnotationSubmission, AnnotationSubmissionSchema } from '@contextbridge/shared/annotationSchema';
+import type { ServerContext } from '#src/context.ts';
+
+export async function handleSubmit(
+  ctx: ServerContext,
+  req: Request,
+  resolveResult: (s: AnnotationSubmission) => void,
+): Promise<Response> {
+  const { logger } = ctx;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response('invalid JSON', { status: 400 });
+  }
+
+  const parsed = AnnotationSubmissionSchema.safeParse(body);
+  if (!parsed.success) {
+    logger.warn({ issues: parsed.error.issues }, 'submission failed schema validation');
+    return new Response('invalid submission', { status: 400 });
+  }
+
+  // Defer resolution to the next macrotask so Bun can flush the 204
+  // onto the socket before the CLI's awaiter unblocks and tears the
+  // server down with `server.stop(true)` — otherwise the browser sees
+  // the connection reset mid-response. `Connection: close` on the
+  // response ensures the browser releases the TCP socket immediately.
+  setTimeout(() => resolveResult(parsed.data), 0);
+  return new Response(null, { status: 204, headers: { connection: 'close' } });
+}

--- a/packages/server/src/routes/updateNotice.test.ts
+++ b/packages/server/src/routes/updateNotice.test.ts
@@ -1,0 +1,61 @@
+import { fakeBaseContext } from '@contextbridge/context/testHelpers';
+import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
+import { describe, expect, it } from 'bun:test';
+import { withServer } from '#src/testHelpers.ts';
+
+describe('GET /update-notice', () => {
+  const ctx = fakeBaseContext();
+
+  it('returns null when no checkForUpdate callback is provided', async () => {
+    await withServer(ctx, async (running) => {
+      const res = await fetch(`${running.url}/update-notice`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toBeNull();
+    });
+  });
+
+  it('invokes checkForUpdate on demand and returns the resolved notice', async () => {
+    const notice: UpdateNotice = {
+      currentVersion: '0.1.0',
+      latestVersion: '0.2.0',
+      channel: 'stable',
+    };
+    let calls = 0;
+    await withServer(
+      ctx,
+      {
+        checkForUpdate: () => {
+          calls++;
+          return Promise.resolve(notice);
+        },
+      },
+      async (running) => {
+        const res = await fetch(`${running.url}/update-notice`);
+        expect(await res.json()).toEqual(notice);
+        expect(calls).toBe(1);
+      },
+    );
+  });
+
+  it('returns null when checkForUpdate rejects', async () => {
+    await withServer(ctx, { checkForUpdate: () => Promise.reject(new Error('boom')) }, async (running) => {
+      const res = await fetch(`${running.url}/update-notice`);
+      expect(await res.json()).toBeNull();
+    });
+  });
+
+  it('returns null when checkForUpdate never resolves within the timeout', async () => {
+    // Never resolves — the 3s server-side timeout should fire.
+    await withServer(ctx, { checkForUpdate: () => new Promise(() => {}) }, async (running) => {
+      // Prove the handler IS waiting (not returning synchronously) by racing
+      // against a tight external timeout — if the handler returned early we'd
+      // see the json, but we should instead see 'still pending' because the
+      // handler is still awaiting the server-side timeout.
+      const notice: unknown = await Promise.race([
+        fetch(`${running.url}/update-notice`).then((r) => r.json()),
+        new Promise((resolve) => setTimeout(() => resolve('still pending'), 50)),
+      ]);
+      expect(notice).toBe('still pending');
+    });
+  });
+});

--- a/packages/server/src/routes/updateNotice.ts
+++ b/packages/server/src/routes/updateNotice.ts
@@ -1,0 +1,22 @@
+import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
+
+const UPDATE_NOTICE_TIMEOUT_MS = 3_000;
+
+export type CheckForUpdate = () => Promise<UpdateNotice | null>;
+
+export async function handleUpdateNotice(checkForUpdate: CheckForUpdate | undefined): Promise<Response> {
+  const notice = await resolveUpdateNotice(checkForUpdate);
+  return Response.json(notice);
+}
+
+async function resolveUpdateNotice(checkForUpdate: CheckForUpdate | undefined): Promise<UpdateNotice | null> {
+  if (!checkForUpdate) return null;
+  const timeout = new Promise<null>((resolve) => {
+    setTimeout(() => resolve(null), UPDATE_NOTICE_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([Promise.resolve().then(checkForUpdate), timeout]);
+  } catch {
+    return null;
+  }
+}

--- a/packages/server/src/testHelpers.ts
+++ b/packages/server/src/testHelpers.ts
@@ -1,0 +1,31 @@
+import { annotationPayload, frontendConfig } from '@contextbridge/shared/testFactories';
+import { type RunningServer, type StartServerOptions, startServer } from '#src/annotation.ts';
+import type { ServerContext } from '#src/context.ts';
+
+const DEFAULT_HTML = '<html><body>ui</body></html>';
+
+export function withServer<T = void>(ctx: ServerContext, fn: (running: RunningServer) => Promise<T>): Promise<T>;
+export function withServer<T = void>(
+  ctx: ServerContext,
+  opts: Partial<StartServerOptions>,
+  fn: (running: RunningServer) => Promise<T>,
+): Promise<T>;
+export async function withServer<T = void>(
+  ctx: ServerContext,
+  optsOrFn: Partial<StartServerOptions> | ((running: RunningServer) => Promise<T>),
+  maybeFn?: (running: RunningServer) => Promise<T>,
+): Promise<T> {
+  const fn = typeof optsOrFn === 'function' ? optsOrFn : maybeFn!;
+  const opts = typeof optsOrFn === 'function' ? {} : optsOrFn;
+  const running = startServer(ctx, {
+    html: Promise.resolve(DEFAULT_HTML),
+    payload: annotationPayload.build(),
+    config: frontendConfig.build(),
+    ...opts,
+  });
+  try {
+    return await fn(running);
+  } finally {
+    await running.close();
+  }
+}

--- a/packages/shared/src/testFactories.ts
+++ b/packages/shared/src/testFactories.ts
@@ -1,11 +1,13 @@
 import { Factory } from 'fishery';
 import type {
+  AnnotationPayload,
   AnnotationSubmission,
   CommentAuthor,
   CommentMessage,
   CommentThread,
   StoredAnnotationAnchor,
 } from './annotationSchema.ts';
+import type { FrontendConfig } from './frontendConfigSchema.ts';
 
 export const LOCAL_AUTHOR = {
   id: 'local-user',
@@ -72,4 +74,15 @@ export const globalThread = Factory.define<CommentThread>(() => {
 export const annotationSubmission = Factory.define<AnnotationSubmission>(() => ({
   status: 'changes_requested',
   threads: [globalThread.build(), annotationThread.build()],
+}));
+
+export const annotationPayload = Factory.define<AnnotationPayload>(() => ({
+  content: '# plan',
+  contentKind: 'plan',
+  metadata: { entrypoint: 'plan_command' },
+}));
+
+export const frontendConfig = Factory.define<FrontendConfig>(() => ({
+  distinctId: 'test-distinct-id',
+  telemetryDisabled: false,
 }));


### PR DESCRIPTION
## Summary

The annotation server's `fetch` handler was a long if/else chain branching on `req.method` and `url.pathname` — felt messy and didn't scale to the upcoming `review` surface. This swaps it for Bun's declarative `Bun.serve({ routes })` API and splits each handler into its own file under `packages/server/src/routes/`, so `annotation.ts` becomes a thin composition layer (routes table + lifecycle) and new routes drop in beside the existing ones.

Tests follow the split: per-route HTTP integration tests live colocated as `routes/<name>.test.ts` and share a `withServer(ctx, opts?, fn)` helper that defaults html/payload/config via new Fishery factories. `annotation.test.ts` keeps smoke + lifecycle coverage (404 fallback, `resolveListenPort`, and the existing submit→close race regression).

## Review focus

- **`/submit` invariants** — the `setTimeout(() => resolveResult(...), 0)` deferral and `connection: close` header are non-negotiable (they prevent Bun from tearing down the socket before the 204 is flushed). They moved into `routes/submit.ts` verbatim and the race regression test in `annotation.test.ts` still passes, but worth a second pair of eyes.
- **Test surface tradeoff** — `app.fetch(req)` in-process is gone; everything is real HTTP against a started server now. Slightly slower per test, but a stronger integration boundary and removes the `createAnnotationServerApp` factory whose only consumer was the tests themselves.
- **`withServer` overload** — opted for two signatures (`(ctx, fn)` vs `(ctx, opts, fn)`) over a required `{}` middle arg. The overload impl is 4 lines of `typeof optsOrFn === 'function'` — let me know if you'd prefer the simpler always-3-arg shape.

## Commits

- 6754e35 — refactor(server): split annotation routes via Bun routes API