### PR TITLE
fix: avoid losing annotation edits on beforeunload

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,18 @@ const rawImgRestrictedSelector = {
     "Use <Image /> or <Picture /> from astro:assets, and import images from src/assets/. Raw <img> bypasses Astro's asset pipeline.",
 };
 
+const annotationRuntimeWindowRestrictedSelectors = [
+  {
+    selector: "CallExpression[callee.object.name='window'][callee.property.name=/^(close|setTimeout|clearTimeout)$/]",
+    message: 'Production annotation runtime code must use FrontendContext.browser for window lifecycle APIs.',
+  },
+  {
+    selector:
+      "CallExpression[callee.object.name='window'][callee.property.name=/^(addEventListener|removeEventListener)$/][arguments.0.value='beforeunload']",
+    message: 'Production annotation runtime code must use FrontendContext.browser for beforeunload guards.',
+  },
+];
+
 export default defineConfig(
   ...baseConfig,
   {
@@ -128,6 +140,18 @@ export default defineConfig(
   {
     files: reactFiles,
     extends: [reactHooks.configs.flat.recommended],
+  },
+  {
+    files: ['packages/annotation/src/**/*.{ts,tsx}'],
+    ignores: [
+      'packages/annotation/src/**/*.test.{ts,tsx}',
+      'packages/annotation/src/**/*.stories.{ts,tsx}',
+      'packages/annotation/src/demo/**',
+      'packages/annotation/src/testHelpers/**',
+    ],
+    rules: {
+      'no-restricted-syntax': ['error', ...dateRestrictedSelectors, ...annotationRuntimeWindowRestrictedSelectors],
+    },
   },
   {
     files: ['packages/website/**/*.astro'],

--- a/packages/annotation/.storybook/appContextDecorator.tsx
+++ b/packages/annotation/.storybook/appContextDecorator.tsx
@@ -6,13 +6,16 @@ import { AnnotationAppContext } from '../src/useAppContext.ts';
 export function createStoryAppContext(overrides?: Partial<AnnotationAppContextValue>): AnnotationAppContextValue {
   return {
     ...fakeFrontendContext({
-      scheduleTimeout: (callback, delayMs) => {
-        const id = window.setTimeout(callback, delayMs);
-        return () => {
-          window.clearTimeout(id);
-        };
+      browser: {
+        closeWindow: () => {},
+        scheduleTimeout: (callback, delayMs) => {
+          const id = window.setTimeout(callback, delayMs);
+          return () => {
+            window.clearTimeout(id);
+          };
+        },
+        addBeforeUnloadGuard: () => () => {},
       },
-      closeWindow: () => {},
     }),
     fetchPayload: () => Promise.resolve({ content: '', contentKind: 'plan' }),
     fetchUpdateNotice: () => Promise.resolve(null),

--- a/packages/annotation/src/App.demo.stories.tsx
+++ b/packages/annotation/src/App.demo.stories.tsx
@@ -217,8 +217,17 @@ export const FullDemo: Story = {
     withAppContext({
       submitAnnotation: () => new Promise((resolve) => setTimeout(resolve, 350)),
       autoCloseDelaySeconds: AUTO_CLOSE_SECONDS,
-      closeWindow: () => {
-        window.__demoCloseBrowser?.();
+      browser: {
+        closeWindow: () => {
+          window.__demoCloseBrowser?.();
+        },
+        scheduleTimeout: (callback, delayMs) => {
+          const id = window.setTimeout(callback, delayMs);
+          return () => {
+            window.clearTimeout(id);
+          };
+        },
+        addBeforeUnloadGuard: () => () => {},
       },
       buildInfo: buildInfoFactory.build({ version: '0.2.0' }),
     }),

--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -602,6 +602,52 @@ Run \`${longCode}\` now.
       expect(feedbackButton).toHaveTextContent('Feedback');
     });
   });
+
+  describe('beforeunload guard', () => {
+    it('registers a guard on mount even with no feedback', () => {
+      const { unloadGuard } = renderApp({ initialPayload: { contentKind: 'plan', content: '# Ready' } });
+
+      expect(unloadGuard.isRegistered()).toBe(true);
+      expect(unloadGuard.trigger().defaultPrevented).toBe(true);
+    });
+
+    it('removes the guard after a successful submission', async () => {
+      const user = userEvent.setup();
+      const { unloadGuard } = renderApp({ initialPayload: { contentKind: 'plan', content: '# Ship it' } });
+
+      await user.click(screen.getByTestId(submitBarTestIds.button));
+      await screen.findByTestId(submitBarTestIds.countdown);
+
+      expect(unloadGuard.isRegistered()).toBe(false);
+    });
+
+    it('keeps the guard attached after a failed submission', async () => {
+      const user = userEvent.setup();
+      const submitAnnotation = vi
+        .fn<(submission: AnnotationSubmission) => Promise<void>>()
+        .mockRejectedValue(new Error('network down'));
+      const { unloadGuard } = renderApp(
+        { initialPayload: { contentKind: 'plan', content: '# Ship it' } },
+        { submitAnnotation },
+      );
+
+      await user.click(screen.getByTestId(submitBarTestIds.button));
+      await waitFor(() => {
+        expect(submitAnnotation).toHaveBeenCalledTimes(1);
+      });
+
+      expect(unloadGuard.isRegistered()).toBe(true);
+      expect(unloadGuard.trigger().defaultPrevented).toBe(true);
+    });
+
+    it('removes the guard on unmount', () => {
+      const { result, unloadGuard } = renderApp({ initialPayload: { contentKind: 'plan', content: '# Ready' } });
+
+      result.unmount();
+
+      expect(unloadGuard.isRegistered()).toBe(false);
+    });
+  });
 });
 
 /** Assert that `child`'s right edge does not extend beyond `parent`'s right border. */

--- a/packages/annotation/src/App.tsx
+++ b/packages/annotation/src/App.tsx
@@ -41,7 +41,13 @@ export interface AppProps {
 }
 
 export function App({ initialPayload, initialThreads, initialGlobalComment }: AppProps = {}) {
-  const { fetchPayload, fetchUpdateNotice, analytics, buildInfo } = useAnnotationAppContext();
+  const {
+    fetchPayload,
+    fetchUpdateNotice,
+    analytics,
+    buildInfo,
+    browser: { addBeforeUnloadGuard },
+  } = useAnnotationAppContext();
   const [payload, setPayload] = useState<AnnotationPayload | null>(initialPayload ?? null);
   const [updateNotice, setUpdateNotice] = useState<UpdateNotice | null>(null);
   const [updateNoticeDismissed, setUpdateNoticeDismissed] = useState(false);
@@ -73,6 +79,16 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
       .then(setUpdateNotice)
       .catch(() => {});
   }, [fetchUpdateNotice]);
+
+  const { submitted } = reviewState.submission;
+  useEffect(() => {
+    if (submitted) {
+      return;
+    }
+    return addBeforeUnloadGuard((event) => {
+      event.preventDefault();
+    });
+  }, [submitted, addBeforeUnloadGuard]);
 
   const documentTitle = resolveDocumentTitle(payload);
 

--- a/packages/annotation/src/testHelpers/createFakeAppContext.ts
+++ b/packages/annotation/src/testHelpers/createFakeAppContext.ts
@@ -1,4 +1,4 @@
-import type { ScheduleTimeout } from '@contextbridge/context/frontend';
+import type { AddBeforeUnloadGuard, ScheduleTimeout } from '@contextbridge/context/frontend';
 import {
   type FakeAnalytics,
   type FakeFrontendTelemetry,
@@ -17,9 +17,16 @@ export interface AutoCloseTimers {
   lastCancel: () => Mock<() => void> | undefined;
 }
 
+export interface UnloadGuardHarness {
+  addBeforeUnloadGuard: AddBeforeUnloadGuard;
+  isRegistered: () => boolean;
+  trigger: () => BeforeUnloadEvent;
+}
+
 export interface FakeAppContextResult {
   context: AnnotationAppContext;
   timers: AutoCloseTimers;
+  unloadGuard: UnloadGuardHarness;
   submitAnnotation: Mock<(submission: AnnotationSubmission) => Promise<void>>;
   fetchPayload: Mock<() => Promise<AnnotationPayload>>;
   fetchUpdateNotice: Mock<() => Promise<UpdateNotice | null>>;
@@ -29,6 +36,7 @@ export interface FakeAppContextResult {
 
 export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>): FakeAppContextResult {
   const timers = createAutoCloseTimers();
+  const unloadGuard = createUnloadGuard();
   const submitAnnotation = vi.fn<(submission: AnnotationSubmission) => Promise<void>>().mockResolvedValue(undefined);
   const fetchPayload = vi
     .fn<() => Promise<AnnotationPayload>>()
@@ -36,8 +44,11 @@ export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>):
   const fetchUpdateNotice = vi.fn<() => Promise<UpdateNotice | null>>().mockResolvedValue(null);
   const context: AnnotationAppContext = {
     ...fakeFrontendContext({
-      scheduleTimeout: timers.scheduleTimeout,
-      closeWindow: timers.closeWindow,
+      browser: {
+        scheduleTimeout: timers.scheduleTimeout,
+        closeWindow: timers.closeWindow,
+        addBeforeUnloadGuard: unloadGuard.addBeforeUnloadGuard,
+      },
     }),
     fetchPayload,
     fetchUpdateNotice,
@@ -48,11 +59,32 @@ export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>):
   return {
     context,
     timers,
+    unloadGuard,
     submitAnnotation,
     fetchPayload,
     fetchUpdateNotice,
     analytics: context.analytics as FakeAnalytics,
     telemetry: context.telemetry as FakeFrontendTelemetry,
+  };
+}
+
+function createUnloadGuard(): UnloadGuardHarness {
+  const handlers = new Set<(event: BeforeUnloadEvent) => void>();
+  return {
+    addBeforeUnloadGuard: (handler) => {
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
+    },
+    isRegistered: () => handlers.size > 0,
+    trigger: () => {
+      const event = new Event('beforeunload', { cancelable: true });
+      handlers.forEach((handler) => {
+        handler(event);
+      });
+      return event;
+    },
   };
 }
 

--- a/packages/annotation/src/useAnnotationState.ts
+++ b/packages/annotation/src/useAnnotationState.ts
@@ -35,7 +35,11 @@ type PendingDraftAction =
   | { kind: 'remove'; threadId: string };
 
 export function useAnnotationState({ initialThreads, initialGlobalComment }: UseAnnotationStateArgs = {}) {
-  const { submitAnnotation, scheduleTimeout, closeWindow, autoCloseDelaySeconds } = useAnnotationAppContext();
+  const {
+    submitAnnotation,
+    browser: { scheduleTimeout, closeWindow },
+    autoCloseDelaySeconds,
+  } = useAnnotationAppContext();
 
   const [threads, setThreads] = useState<CommentThread[]>(() =>
     (initialThreads ?? []).filter(isAnnotationCommentThread),

--- a/packages/context/AGENTS.md
+++ b/packages/context/AGENTS.md
@@ -12,7 +12,7 @@ Shared root of the DI context inheritance chain. Every surface (CLI, server, fro
   - `analytics` — `Analytics` interface (PostHog wrapper or noop)
   - `telemetry` — `Telemetry` interface (Sentry wrapper or noop)
 - **`isTelemetryDisabled({ buildInfo, env? })`** — the single canonical rule. Returns `true` if a known opt-out env var is set (`DO_NOT_TRACK`, `CONTEXTBRIDGE_TELEMETRY_DISABLED`) or the build isn't production. The CLI calls this once with `{ buildInfo, env }`, stores the answer on BaseContext, and ships it over the wire to the annotation UI via `FrontendConfig.telemetryDisabled` — the browser trusts that boolean rather than re-deriving.
-- **`FrontendContext extends BaseContext`** (exported from `@contextbridge/context/frontend`) — narrows `telemetry` to `FrontendTelemetry` (adds `ErrorBoundary`), adds browser primitives (`closeWindow`, `scheduleTimeout`). Package-specific frontend contexts extend this (e.g. `AnnotationAppContext`).
+- **`FrontendContext extends BaseContext`** (exported from `@contextbridge/context/frontend`) — narrows `telemetry` to `FrontendTelemetry` (adds `ErrorBoundary`) and exposes browser lifecycle primitives under `browser` (`closeWindow`, `scheduleTimeout`, `addBeforeUnloadGuard`). Package-specific frontend contexts extend this (e.g. `AnnotationAppContext`).
 
 ## Factory pattern
 

--- a/packages/context/src/frontend.test.ts
+++ b/packages/context/src/frontend.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test';
+import pino from 'pino';
+import { createFrontendContext } from './frontend.ts';
+import { buildInfo } from './testFactories.ts';
+
+describe('createFrontendContext', () => {
+  const config = {
+    distinctId: 'test-distinct-id',
+    telemetryDisabled: true,
+  };
+
+  it('exposes browser lifecycle defaults through a browser adapter', () => {
+    const ctx = createFrontendContext({
+      config,
+      surface: 'test',
+      buildInfo: buildInfo.build(),
+      logger: pino({ level: 'silent' }),
+    });
+
+    expect(typeof ctx.browser.closeWindow).toBe('function');
+    expect(typeof ctx.browser.scheduleTimeout).toBe('function');
+    expect(typeof ctx.browser.addBeforeUnloadGuard).toBe('function');
+    expect('closeWindow' in ctx).toBe(false);
+    expect('scheduleTimeout' in ctx).toBe(false);
+  });
+
+  it('applies browser overrides over the defaults', () => {
+    let closed = false;
+    let guarded = false;
+    const ctx = createFrontendContext({
+      config,
+      surface: 'test',
+      buildInfo: buildInfo.build(),
+      logger: pino({ level: 'silent' }),
+      browser: {
+        closeWindow: () => {
+          closed = true;
+        },
+        addBeforeUnloadGuard: () => {
+          guarded = true;
+          return () => {};
+        },
+      },
+    });
+
+    ctx.browser.closeWindow();
+    ctx.browser.addBeforeUnloadGuard(() => {});
+
+    expect(closed).toBe(true);
+    expect(guarded).toBe(true);
+    expect(typeof ctx.browser.scheduleTimeout).toBe('function');
+  });
+});

--- a/packages/context/src/frontend.ts
+++ b/packages/context/src/frontend.ts
@@ -18,11 +18,17 @@ export { type BuildInfo, BUILD_INFO } from './buildInfo.ts';
 export { type FrontendTelemetry } from '@contextbridge/instrumentation/frontend';
 
 export type ScheduleTimeout = (handler: () => void, delayMs: number) => () => void;
+export type AddBeforeUnloadGuard = (handler: (event: BeforeUnloadEvent) => void) => () => void;
+
+export interface FrontendBrowser {
+  readonly closeWindow: () => void;
+  readonly scheduleTimeout: ScheduleTimeout;
+  readonly addBeforeUnloadGuard: AddBeforeUnloadGuard;
+}
 
 export interface FrontendContext extends BaseContext {
   readonly telemetry: FrontendTelemetry;
-  readonly closeWindow: () => void;
-  readonly scheduleTimeout: ScheduleTimeout;
+  readonly browser: FrontendBrowser;
 }
 
 export interface CreateFrontendContextInput {
@@ -30,19 +36,11 @@ export interface CreateFrontendContextInput {
   readonly surface: string;
   readonly buildInfo?: BuildInfo;
   readonly logger?: Logger;
-  readonly closeWindow?: () => void;
-  readonly scheduleTimeout?: ScheduleTimeout;
+  readonly browser?: Partial<FrontendBrowser>;
 }
 
 export function createFrontendContext(input: CreateFrontendContextInput): FrontendContext {
-  const {
-    config,
-    surface,
-    buildInfo = BUILD_INFO,
-    logger: loggerOverride,
-    closeWindow = defaultCloseWindow,
-    scheduleTimeout = defaultScheduleTimeout,
-  } = input;
+  const { config, surface, buildInfo = BUILD_INFO, logger: loggerOverride, browser: browserOverride } = input;
 
   const { distinctId, telemetryDisabled } = config;
 
@@ -62,18 +60,27 @@ export function createFrontendContext(input: CreateFrontendContextInput): Fronte
   return Object.freeze({
     ...createBaseContext({ buildInfo, logger, distinctId, telemetryDisabled, analytics, telemetry }),
     telemetry,
-    closeWindow,
-    scheduleTimeout,
+    browser: Object.freeze({
+      ...defaultFrontendBrowser,
+      ...browserOverride,
+    }),
   });
 }
 
-function defaultCloseWindow(): void {
-  window.close();
-}
-
-function defaultScheduleTimeout(handler: () => void, delayMs: number): () => void {
-  const id = window.setTimeout(handler, delayMs);
-  return () => {
-    window.clearTimeout(id);
-  };
-}
+const defaultFrontendBrowser: FrontendBrowser = Object.freeze({
+  closeWindow: () => {
+    window.close();
+  },
+  scheduleTimeout: (handler: () => void, delayMs: number) => {
+    const id = window.setTimeout(handler, delayMs);
+    return () => {
+      window.clearTimeout(id);
+    };
+  },
+  addBeforeUnloadGuard: (handler: (event: BeforeUnloadEvent) => void) => {
+    window.addEventListener('beforeunload', handler);
+    return () => {
+      window.removeEventListener('beforeunload', handler);
+    };
+  },
+});

--- a/packages/context/src/testHelpers/fakeBaseContext.test.ts
+++ b/packages/context/src/testHelpers/fakeBaseContext.test.ts
@@ -26,15 +26,17 @@ describe('fakeFrontendContext', () => {
   it('returns a FrontendContext with no-op browser hooks and a passthrough ErrorBoundary', () => {
     const ctx = fakeFrontendContext();
     expect(ctx.buildInfo.version).toBe('test');
-    expect(typeof ctx.closeWindow).toBe('function');
-    expect(typeof ctx.scheduleTimeout).toBe('function');
+    expect(typeof ctx.browser.closeWindow).toBe('function');
+    expect(typeof ctx.browser.scheduleTimeout).toBe('function');
+    expect(typeof ctx.browser.addBeforeUnloadGuard).toBe('function');
     expect(typeof ctx.telemetry.ErrorBoundary).toBe('function');
   });
 
   it('applies overrides', () => {
     let closed = false;
-    const ctx = fakeFrontendContext({ closeWindow: () => (closed = true) });
-    ctx.closeWindow();
+    const browser = fakeFrontendContext().browser;
+    const ctx = fakeFrontendContext({ browser: { ...browser, closeWindow: () => (closed = true) } });
+    ctx.browser.closeWindow();
     expect(closed).toBe(true);
   });
 });

--- a/packages/context/src/testHelpers/fakeFrontendContext.ts
+++ b/packages/context/src/testHelpers/fakeFrontendContext.ts
@@ -6,8 +6,11 @@ export function fakeFrontendContext(overrides: Partial<FrontendContext> = {}): F
   return {
     ...fakeBaseContext(),
     telemetry: createFakeFrontendTelemetry(),
-    closeWindow: () => {},
-    scheduleTimeout: () => () => {},
+    browser: {
+      closeWindow: () => {},
+      scheduleTimeout: () => () => {},
+      addBeforeUnloadGuard: () => () => {},
+    },
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Fixes the annotation UI's unsaved-work protection by moving beforeunload guard registration behind the shared frontend browser adapter. The same adapter now owns app-level window lifecycle APIs for close and timers, which keeps production behavior injectable without wrapping lower-level selection, range, and viewport DOM interactions.

## Review focus

Please check the DI boundary: the adapter intentionally covers only app-level lifecycle APIs needed to prevent losing user data, while lower-level DOM interaction paths remain direct browser code.

## Commits

- [`7ac4f21`](https://github.com/contextbridge/planbridge/commit/7ac4f2150c333d91db20536cf3181afc8e797010) — move frontend lifecycle APIs into browser adapter
