### PR TITLE
refactor: inject frontend browser effects

### DIFF
--- a/.claude/rules/context-interfaces-and-fakes.md
+++ b/.claude/rules/context-interfaces-and-fakes.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "packages/context/**/*.ts"
+  - "packages/*/src/context.ts"
+  - "packages/*/src/**/*Context*.ts"
+---
+
+# Context Interfaces and Fakes
+
+- **Context dependencies should have a public contract and separate implementations.** When adding an injectable dependency to a context (`BaseContext`, `CliContext`, `ServerContext`, `FrontendContext`, or a package-specific context), define a narrow public interface for the behavior the context exposes.
+
+- **Name the production implementation `XxxImpl`.** The real implementation should implement the public interface and carry environment-specific behavior, external API calls, filesystem access, browser effects, or other side effects. Context fields should be typed as the interface, not the concrete implementation.
+
+- **Name the test implementation `FakeXxx`.** Shared test helpers should implement the same public interface with deterministic, inspectable behavior. Keep fakes focused on the interface contract so tests can swap them in without casts, module mocking, or duplicating production implementation details.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,48 @@ const dateRestrictedSelectors = [
   },
 ];
 
+const consoleRestrictedSelector = {
+  selector: "CallExpression[callee.object.name='console']",
+  message:
+    'Do not use console.* — use ctx.logger for diagnostics (writes to stderr) and ctx.io.stdout for business output.',
+};
+
+const processRestrictedProperties = [
+  {
+    object: 'process',
+    property: 'stdout',
+    message: 'Use ctx.io.stdout (see AGENTS.md DI conventions).',
+  },
+  {
+    object: 'process',
+    property: 'stderr',
+    message: 'Use ctx.io.stderr / ctx.logger (see AGENTS.md DI conventions).',
+  },
+  {
+    object: 'process',
+    property: 'stdin',
+    message: 'Use ctx.io.stdin (see AGENTS.md DI conventions).',
+  },
+];
+
+const annotationBrowserWindowRestrictedProperties = [
+  {
+    object: 'window',
+    property: 'close',
+    message: 'Use browser.closeWindow() from AnnotationAppContext instead of window.close().',
+  },
+  {
+    object: 'window',
+    property: 'setTimeout',
+    message: 'Use browser.scheduleTimeout() from AnnotationAppContext instead of window.setTimeout().',
+  },
+  {
+    object: 'window',
+    property: 'clearTimeout',
+    message: 'Use the cancel callback returned by browser.scheduleTimeout() instead of window.clearTimeout().',
+  },
+];
+
 const rawImgRestrictedSelector = {
   selector: "JSXOpeningElement[name.name='img']",
   message:
@@ -79,32 +121,18 @@ export default defineConfig(
   {
     files: ['packages/*/src/**/*.{ts,tsx}'],
     rules: {
-      'no-restricted-syntax': [
-        'error',
-        ...dateRestrictedSelectors,
-        {
-          selector: "CallExpression[callee.object.name='console']",
-          message:
-            'Do not use console.* — use ctx.logger for diagnostics (writes to stderr) and ctx.io.stdout for business output.',
-        },
-      ],
+      'no-restricted-syntax': ['error', ...dateRestrictedSelectors, consoleRestrictedSelector],
+      'no-restricted-properties': ['error', ...processRestrictedProperties],
+    },
+  },
+  {
+    files: ['packages/annotation/src/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-syntax': ['error', ...dateRestrictedSelectors, consoleRestrictedSelector],
       'no-restricted-properties': [
         'error',
-        {
-          object: 'process',
-          property: 'stdout',
-          message: 'Use ctx.io.stdout (see AGENTS.md DI conventions).',
-        },
-        {
-          object: 'process',
-          property: 'stderr',
-          message: 'Use ctx.io.stderr / ctx.logger (see AGENTS.md DI conventions).',
-        },
-        {
-          object: 'process',
-          property: 'stdin',
-          message: 'Use ctx.io.stdin (see AGENTS.md DI conventions).',
-        },
+        ...processRestrictedProperties,
+        ...annotationBrowserWindowRestrictedProperties,
       ],
     },
   },

--- a/packages/annotation/.storybook/appContextDecorator.tsx
+++ b/packages/annotation/.storybook/appContextDecorator.tsx
@@ -1,5 +1,4 @@
-import { FakeFrontendBrowser } from '@contextbridge/context/testHelpers';
-import { fakeFrontendContext } from '@contextbridge/context/testHelpers';
+import { FakeFrontendBrowser, fakeFrontendContext } from '@contextbridge/context/testHelpers';
 import type { ComponentType, ReactElement } from 'react';
 import type { AnnotationAppContext as AnnotationAppContextValue } from '../src/useAppContext.ts';
 import { AnnotationAppContext } from '../src/useAppContext.ts';
@@ -7,7 +6,7 @@ import { AnnotationAppContext } from '../src/useAppContext.ts';
 export function createStoryAppContext(overrides?: Partial<AnnotationAppContextValue>): AnnotationAppContextValue {
   return {
     ...fakeFrontendContext({
-      browser: createStoryBrowser(),
+      browser: new FakeFrontendBrowser({ timers: 'real' }),
     }),
     fetchPayload: () => Promise.resolve({ content: '', contentKind: 'plan' }),
     fetchUpdateNotice: () => Promise.resolve(null),
@@ -26,8 +25,4 @@ export function withAppContext(overrides?: Partial<AnnotationAppContextValue>) {
       </AnnotationAppContext.Provider>
     );
   };
-}
-
-function createStoryBrowser(): FakeFrontendBrowser {
-  return new FakeFrontendBrowser({ timers: 'real' });
 }

--- a/packages/annotation/.storybook/appContextDecorator.tsx
+++ b/packages/annotation/.storybook/appContextDecorator.tsx
@@ -1,3 +1,4 @@
+import { FakeFrontendBrowser } from '@contextbridge/context/testHelpers';
 import { fakeFrontendContext } from '@contextbridge/context/testHelpers';
 import type { ComponentType, ReactElement } from 'react';
 import type { AnnotationAppContext as AnnotationAppContextValue } from '../src/useAppContext.ts';
@@ -6,13 +7,7 @@ import { AnnotationAppContext } from '../src/useAppContext.ts';
 export function createStoryAppContext(overrides?: Partial<AnnotationAppContextValue>): AnnotationAppContextValue {
   return {
     ...fakeFrontendContext({
-      scheduleTimeout: (callback, delayMs) => {
-        const id = window.setTimeout(callback, delayMs);
-        return () => {
-          window.clearTimeout(id);
-        };
-      },
-      closeWindow: () => {},
+      browser: createStoryBrowser(),
     }),
     fetchPayload: () => Promise.resolve({ content: '', contentKind: 'plan' }),
     fetchUpdateNotice: () => Promise.resolve(null),
@@ -31,4 +26,8 @@ export function withAppContext(overrides?: Partial<AnnotationAppContextValue>) {
       </AnnotationAppContext.Provider>
     );
   };
+}
+
+function createStoryBrowser(): FakeFrontendBrowser {
+  return new FakeFrontendBrowser({ timers: 'real' });
 }

--- a/packages/annotation/src/App.demo.stories.tsx
+++ b/packages/annotation/src/App.demo.stories.tsx
@@ -1,3 +1,4 @@
+import { FakeFrontendBrowser } from '@contextbridge/context/testHelpers';
 import { buildInfo as buildInfoFactory } from '@contextbridge/context/testFactories';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import userEvent from '@testing-library/user-event';
@@ -217,9 +218,12 @@ export const FullDemo: Story = {
     withAppContext({
       submitAnnotation: () => new Promise((resolve) => setTimeout(resolve, 350)),
       autoCloseDelaySeconds: AUTO_CLOSE_SECONDS,
-      closeWindow: () => {
-        window.__demoCloseBrowser?.();
-      },
+      browser: new FakeFrontendBrowser({
+        timers: 'real',
+        closeWindow: () => {
+          window.__demoCloseBrowser?.();
+        },
+      }),
       buildInfo: buildInfoFactory.build({ version: '0.2.0' }),
     }),
   ],

--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -106,7 +106,7 @@ describe('App', () => {
     act(() => timers.advance());
     act(() => timers.advance());
     act(() => timers.advance());
-    expect(timers.closeWindow).toHaveBeenCalledTimes(1);
+    expect(timers.closeWindowCallCount).toBe(1);
   });
 
   it('submits the review with Cmd+Enter from the global comment textarea', async () => {

--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -81,7 +81,7 @@ describe('App', () => {
 
   it('submits a global comment typed into the composer as a global thread', async () => {
     const user = userEvent.setup();
-    const { submitAnnotation, timers } = renderApp({ initialPayload: { contentKind: 'plan', content: '# Ship it' } });
+    const { submitAnnotation, browser } = renderApp({ initialPayload: { contentKind: 'plan', content: '# Ship it' } });
 
     await user.type(screen.getByTestId(globalCommentComposerTestIds.textarea), 'Please spell out rollback steps');
 
@@ -103,10 +103,10 @@ describe('App', () => {
     });
     expect(screen.getByTestId(submitBarTestIds.countdown)).toHaveTextContent('This window will close in 3 seconds.');
 
-    act(() => timers.advance());
-    act(() => timers.advance());
-    act(() => timers.advance());
-    expect(timers.closeWindowCallCount).toBe(1);
+    act(() => browser.advance());
+    act(() => browser.advance());
+    act(() => browser.advance());
+    expect(browser.closeWindowCallCount).toBe(1);
   });
 
   it('submits the review with Cmd+Enter from the global comment textarea', async () => {
@@ -276,7 +276,7 @@ describe('App', () => {
 
   it('updates the visible countdown after submission without waiting on real timers', async () => {
     const user = userEvent.setup();
-    const { timers } = renderApp({ initialPayload: { contentKind: 'plan', content: '# Ship it' } });
+    const { browser } = renderApp({ initialPayload: { contentKind: 'plan', content: '# Ship it' } });
 
     await user.click(screen.getByTestId(submitBarTestIds.button));
 
@@ -284,7 +284,7 @@ describe('App', () => {
       'This window will close in 3 seconds.',
     );
 
-    act(() => timers.advance());
+    act(() => browser.advance());
     expect(screen.getByTestId(submitBarTestIds.countdown)).toHaveTextContent('This window will close in 2 seconds.');
   });
 

--- a/packages/annotation/src/testHelpers/createFakeAppContext.ts
+++ b/packages/annotation/src/testHelpers/createFakeAppContext.ts
@@ -10,11 +10,9 @@ import type { Mock } from 'vitest';
 import { vi } from 'vitest';
 import type { AnnotationAppContext } from '../useAppContext.ts';
 
-export type AutoCloseTimers = FakeFrontendBrowser;
-
 export interface FakeAppContextResult {
   context: AnnotationAppContext;
-  timers: AutoCloseTimers;
+  browser: FakeFrontendBrowser;
   submitAnnotation: Mock<(submission: AnnotationSubmission) => Promise<void>>;
   fetchPayload: Mock<() => Promise<AnnotationPayload>>;
   fetchUpdateNotice: Mock<() => Promise<UpdateNotice | null>>;
@@ -23,7 +21,7 @@ export interface FakeAppContextResult {
 }
 
 export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>): FakeAppContextResult {
-  const timers = new FakeFrontendBrowser();
+  const browser = new FakeFrontendBrowser();
   const submitAnnotation = vi.fn<(submission: AnnotationSubmission) => Promise<void>>().mockResolvedValue(undefined);
   const fetchPayload = vi
     .fn<() => Promise<AnnotationPayload>>()
@@ -31,7 +29,7 @@ export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>):
   const fetchUpdateNotice = vi.fn<() => Promise<UpdateNotice | null>>().mockResolvedValue(null);
   const context: AnnotationAppContext = {
     ...fakeFrontendContext({
-      browser: timers,
+      browser,
     }),
     fetchPayload,
     fetchUpdateNotice,
@@ -41,7 +39,7 @@ export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>):
   };
   return {
     context,
-    timers,
+    browser,
     submitAnnotation,
     fetchPayload,
     fetchUpdateNotice,

--- a/packages/annotation/src/testHelpers/createFakeAppContext.ts
+++ b/packages/annotation/src/testHelpers/createFakeAppContext.ts
@@ -1,6 +1,6 @@
-import type { ScheduleTimeout } from '@contextbridge/context/frontend';
 import {
   type FakeAnalytics,
+  FakeFrontendBrowser,
   type FakeFrontendTelemetry,
   fakeFrontendContext,
 } from '@contextbridge/context/testHelpers';
@@ -10,12 +10,7 @@ import type { Mock } from 'vitest';
 import { vi } from 'vitest';
 import type { AnnotationAppContext } from '../useAppContext.ts';
 
-export interface AutoCloseTimers {
-  scheduleTimeout: ScheduleTimeout;
-  closeWindow: Mock<() => void>;
-  advance: () => void;
-  lastCancel: () => Mock<() => void> | undefined;
-}
+export type AutoCloseTimers = FakeFrontendBrowser;
 
 export interface FakeAppContextResult {
   context: AnnotationAppContext;
@@ -28,7 +23,7 @@ export interface FakeAppContextResult {
 }
 
 export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>): FakeAppContextResult {
-  const timers = createAutoCloseTimers();
+  const timers = new FakeFrontendBrowser();
   const submitAnnotation = vi.fn<(submission: AnnotationSubmission) => Promise<void>>().mockResolvedValue(undefined);
   const fetchPayload = vi
     .fn<() => Promise<AnnotationPayload>>()
@@ -36,8 +31,7 @@ export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>):
   const fetchUpdateNotice = vi.fn<() => Promise<UpdateNotice | null>>().mockResolvedValue(null);
   const context: AnnotationAppContext = {
     ...fakeFrontendContext({
-      scheduleTimeout: timers.scheduleTimeout,
-      closeWindow: timers.closeWindow,
+      browser: timers,
     }),
     fetchPayload,
     fetchUpdateNotice,
@@ -53,27 +47,5 @@ export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>):
     fetchUpdateNotice,
     analytics: context.analytics as FakeAnalytics,
     telemetry: context.telemetry as FakeFrontendTelemetry,
-  };
-}
-
-function createAutoCloseTimers(): AutoCloseTimers {
-  const pending: Array<() => void> = [];
-  const cancels: Array<Mock<() => void>> = [];
-  const closeWindow = vi.fn<() => void>();
-
-  const scheduleTimeout: ScheduleTimeout = (callback) => {
-    pending.push(callback);
-    const cancel = vi.fn<() => void>();
-    cancels.push(cancel);
-    return cancel;
-  };
-
-  return {
-    scheduleTimeout,
-    closeWindow,
-    advance: () => {
-      pending.shift()?.();
-    },
-    lastCancel: () => cancels[cancels.length - 1],
   };
 }

--- a/packages/annotation/src/useAnnotationState.test.ts
+++ b/packages/annotation/src/useAnnotationState.test.ts
@@ -162,25 +162,25 @@ describe('useAnnotationState', () => {
     });
 
     it('steps the countdown down and closes the window after the final tick', async () => {
-      const { result, timers } = renderAnnotationHook(() => useAnnotationState({}));
+      const { result, browser } = renderAnnotationHook(() => useAnnotationState({}));
 
       await act(async () => {
         await result.current.submission.submit();
       });
       expect(result.current.submission.closeCountdownSeconds).toBe(3);
 
-      act(() => timers.advance());
+      act(() => browser.advance());
       expect(result.current.submission.closeCountdownSeconds).toBe(2);
 
-      act(() => timers.advance());
+      act(() => browser.advance());
       expect(result.current.submission.closeCountdownSeconds).toBe(1);
 
-      act(() => timers.advance());
-      expect(timers.closeWindowCallCount).toBe(1);
+      act(() => browser.advance());
+      expect(browser.closeWindowCallCount).toBe(1);
     });
 
     it('cancels the pending auto-close when the hook unmounts', async () => {
-      const { result, unmount, timers } = renderAnnotationHook(() => useAnnotationState({}));
+      const { result, unmount, browser } = renderAnnotationHook(() => useAnnotationState({}));
 
       await act(async () => {
         await result.current.submission.submit();
@@ -188,8 +188,8 @@ describe('useAnnotationState', () => {
 
       unmount();
 
-      expect(timers.clearedTimeoutIds).toEqual([1]);
-      expect(timers.closeWindowCallCount).toBe(0);
+      expect(browser.clearedTimeoutIds).toEqual([1]);
+      expect(browser.closeWindowCallCount).toBe(0);
     });
   });
 

--- a/packages/annotation/src/useAnnotationState.test.ts
+++ b/packages/annotation/src/useAnnotationState.test.ts
@@ -176,7 +176,7 @@ describe('useAnnotationState', () => {
       expect(result.current.submission.closeCountdownSeconds).toBe(1);
 
       act(() => timers.advance());
-      expect(timers.closeWindow).toHaveBeenCalledTimes(1);
+      expect(timers.closeWindowCallCount).toBe(1);
     });
 
     it('cancels the pending auto-close when the hook unmounts', async () => {
@@ -188,8 +188,8 @@ describe('useAnnotationState', () => {
 
       unmount();
 
-      expect(timers.lastCancel()).toHaveBeenCalledTimes(1);
-      expect(timers.closeWindow).not.toHaveBeenCalled();
+      expect(timers.clearedTimeoutIds).toEqual([1]);
+      expect(timers.closeWindowCallCount).toBe(0);
     });
   });
 

--- a/packages/annotation/src/useAnnotationState.ts
+++ b/packages/annotation/src/useAnnotationState.ts
@@ -35,7 +35,7 @@ type PendingDraftAction =
   | { kind: 'remove'; threadId: string };
 
 export function useAnnotationState({ initialThreads, initialGlobalComment }: UseAnnotationStateArgs = {}) {
-  const { submitAnnotation, scheduleTimeout, closeWindow, autoCloseDelaySeconds } = useAnnotationAppContext();
+  const { submitAnnotation, browser, autoCloseDelaySeconds } = useAnnotationAppContext();
 
   const [threads, setThreads] = useState<CommentThread[]>(() =>
     (initialThreads ?? []).filter(isAnnotationCommentThread),
@@ -200,19 +200,19 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
     let cancel: () => void = () => {};
     const tick = () => {
       if (remaining <= 1) {
-        closeWindow();
+        browser.closeWindow();
         return;
       }
       remaining -= 1;
       setCloseCountdownSeconds(remaining);
-      cancel = scheduleTimeout(tick, 1000);
+      cancel = browser.scheduleTimeout(tick, 1000);
     };
-    cancel = scheduleTimeout(tick, 1000);
+    cancel = browser.scheduleTimeout(tick, 1000);
 
     return () => {
       cancel();
     };
-  }, [autoCloseDelaySeconds, scheduleTimeout, closeWindow, submitted]);
+  }, [autoCloseDelaySeconds, browser, submitted]);
 
   return {
     threads,

--- a/packages/context/AGENTS.md
+++ b/packages/context/AGENTS.md
@@ -12,7 +12,7 @@ Shared root of the DI context inheritance chain. Every surface (CLI, server, fro
   - `analytics` — `Analytics` interface (PostHog wrapper or noop)
   - `telemetry` — `Telemetry` interface (Sentry wrapper or noop)
 - **`isTelemetryDisabled({ buildInfo, env? })`** — the single canonical rule. Returns `true` if a known opt-out env var is set (`DO_NOT_TRACK`, `CONTEXTBRIDGE_TELEMETRY_DISABLED`) or the build isn't production. The CLI calls this once with `{ buildInfo, env }`, stores the answer on BaseContext, and ships it over the wire to the annotation UI via `FrontendConfig.telemetryDisabled` — the browser trusts that boolean rather than re-deriving.
-- **`FrontendContext extends BaseContext`** (exported from `@contextbridge/context/frontend`) — narrows `telemetry` to `FrontendTelemetry` (adds `ErrorBoundary`), adds a `FrontendBrowser` interface for browser effects (currently `closeWindow` and `scheduleTimeout`). The real implementation is `FrontendBrowserImpl`; tests and stories should use `FakeFrontendBrowser` from `@contextbridge/context/testHelpers`. Package-specific frontend contexts extend this (e.g. `AnnotationAppContext`).
+- **`FrontendContext extends BaseContext`** (exported from `@contextbridge/context/frontend`) — the shared context for browser-rendered surfaces. Keep browser-wide injectable dependencies here, type context fields as narrow public interfaces, and use the package's lint rules plus code exploration to discover which concrete browser APIs are intentionally wrapped. Package-specific frontend contexts extend this (e.g. `AnnotationAppContext`) rather than forking it.
 
 ## Factory pattern
 

--- a/packages/context/AGENTS.md
+++ b/packages/context/AGENTS.md
@@ -12,7 +12,7 @@ Shared root of the DI context inheritance chain. Every surface (CLI, server, fro
   - `analytics` — `Analytics` interface (PostHog wrapper or noop)
   - `telemetry` — `Telemetry` interface (Sentry wrapper or noop)
 - **`isTelemetryDisabled({ buildInfo, env? })`** — the single canonical rule. Returns `true` if a known opt-out env var is set (`DO_NOT_TRACK`, `CONTEXTBRIDGE_TELEMETRY_DISABLED`) or the build isn't production. The CLI calls this once with `{ buildInfo, env }`, stores the answer on BaseContext, and ships it over the wire to the annotation UI via `FrontendConfig.telemetryDisabled` — the browser trusts that boolean rather than re-deriving.
-- **`FrontendContext extends BaseContext`** (exported from `@contextbridge/context/frontend`) — narrows `telemetry` to `FrontendTelemetry` (adds `ErrorBoundary`), adds browser primitives (`closeWindow`, `scheduleTimeout`). Package-specific frontend contexts extend this (e.g. `AnnotationAppContext`).
+- **`FrontendContext extends BaseContext`** (exported from `@contextbridge/context/frontend`) — narrows `telemetry` to `FrontendTelemetry` (adds `ErrorBoundary`), adds a `FrontendBrowser` interface for browser effects (currently `closeWindow` and `scheduleTimeout`). The real implementation is `FrontendBrowserImpl`; tests and stories should use `FakeFrontendBrowser` from `@contextbridge/context/testHelpers`. Package-specific frontend contexts extend this (e.g. `AnnotationAppContext`).
 
 ## Factory pattern
 

--- a/packages/context/src/FrontendBrowserImpl.test.ts
+++ b/packages/context/src/FrontendBrowserImpl.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test';
+import { FrontendBrowserImpl } from './FrontendBrowserImpl.ts';
+import type { FrontendBrowserWindow } from './FrontendBrowserImpl.ts';
+
+describe('FrontendBrowserImpl', () => {
+  it('closes the injected window', () => {
+    const browserWindow = createBrowserWindow();
+    const browser = new FrontendBrowserImpl(browserWindow);
+
+    browser.closeWindow();
+
+    expect(browserWindow.closeCalls).toBe(1);
+  });
+
+  it('schedules timeout work through the injected window and returns a cancel callback', () => {
+    const browserWindow = createBrowserWindow();
+    const browser = new FrontendBrowserImpl(browserWindow);
+    let fired = false;
+
+    const cancel = browser.scheduleTimeout(() => {
+      fired = true;
+    }, 250);
+
+    expect(browserWindow.scheduledTimeouts).toHaveLength(1);
+    expect(browserWindow.scheduledTimeouts[0]?.delayMs).toBe(250);
+
+    browserWindow.scheduledTimeouts[0]?.handler();
+    expect(fired).toBe(true);
+
+    cancel();
+    expect(browserWindow.clearedTimeoutIds).toEqual([1]);
+  });
+});
+
+interface RecordedTimeout {
+  readonly id: number;
+  readonly delayMs: number;
+  readonly handler: () => void;
+}
+
+interface FakeBrowserWindow extends FrontendBrowserWindow {
+  readonly scheduledTimeouts: RecordedTimeout[];
+  readonly clearedTimeoutIds: number[];
+  readonly closeCalls: number;
+}
+
+function createBrowserWindow(): FakeBrowserWindow {
+  let closeCalls = 0;
+  let nextTimeoutId = 1;
+  const scheduledTimeouts: RecordedTimeout[] = [];
+  const clearedTimeoutIds: number[] = [];
+
+  return {
+    get closeCalls() {
+      return closeCalls;
+    },
+    scheduledTimeouts,
+    clearedTimeoutIds,
+    close: () => {
+      closeCalls += 1;
+    },
+    setTimeout: (handler, delayMs) => {
+      const id = nextTimeoutId;
+      nextTimeoutId += 1;
+      scheduledTimeouts.push({ id, handler, delayMs });
+      return id;
+    },
+    clearTimeout: (timeoutId) => {
+      clearedTimeoutIds.push(timeoutId);
+    },
+  };
+}

--- a/packages/context/src/FrontendBrowserImpl.ts
+++ b/packages/context/src/FrontendBrowserImpl.ts
@@ -1,0 +1,35 @@
+/// <reference lib="dom" />
+
+export type TimeoutCancel = () => void;
+
+export type ScheduleTimeout = (handler: () => void, delayMs: number) => TimeoutCancel;
+
+export interface FrontendBrowser {
+  closeWindow(): void;
+  scheduleTimeout(handler: () => void, delayMs: number): TimeoutCancel;
+}
+
+export interface FrontendBrowserWindow {
+  readonly close: () => void;
+  readonly setTimeout: (handler: () => void, delayMs: number) => number;
+  readonly clearTimeout: (timeoutId: number) => void;
+}
+
+export class FrontendBrowserImpl implements FrontendBrowser {
+  readonly #window: FrontendBrowserWindow;
+
+  constructor(browserWindow: FrontendBrowserWindow = window) {
+    this.#window = browserWindow;
+  }
+
+  closeWindow(): void {
+    this.#window.close();
+  }
+
+  scheduleTimeout(handler: () => void, delayMs: number): TimeoutCancel {
+    const timeoutId = this.#window.setTimeout(handler, delayMs);
+    return () => {
+      this.#window.clearTimeout(timeoutId);
+    };
+  }
+}

--- a/packages/context/src/frontend.ts
+++ b/packages/context/src/frontend.ts
@@ -5,6 +5,7 @@ import type { FrontendConfig } from '@contextbridge/shared/frontendConfigSchema'
 import { type BaseContext, createBaseContext } from './base.ts';
 import { BUILD_INFO, type BuildInfo } from './buildInfo.ts';
 import { type Logger, createLogger } from './frontend/logger.ts';
+import { type FrontendBrowser, FrontendBrowserImpl } from './FrontendBrowserImpl.ts';
 
 export {
   type Logger,
@@ -15,14 +16,18 @@ export {
 } from './frontend/logger.ts';
 export { type BaseContext, isTelemetryDisabled } from './base.ts';
 export { type BuildInfo, BUILD_INFO } from './buildInfo.ts';
+export {
+  type FrontendBrowser,
+  FrontendBrowserImpl,
+  type FrontendBrowserWindow,
+  type ScheduleTimeout,
+  type TimeoutCancel,
+} from './FrontendBrowserImpl.ts';
 export { type FrontendTelemetry } from '@contextbridge/instrumentation/frontend';
-
-export type ScheduleTimeout = (handler: () => void, delayMs: number) => () => void;
 
 export interface FrontendContext extends BaseContext {
   readonly telemetry: FrontendTelemetry;
-  readonly closeWindow: () => void;
-  readonly scheduleTimeout: ScheduleTimeout;
+  readonly browser: FrontendBrowser;
 }
 
 export interface CreateFrontendContextInput {
@@ -30,8 +35,7 @@ export interface CreateFrontendContextInput {
   readonly surface: string;
   readonly buildInfo?: BuildInfo;
   readonly logger?: Logger;
-  readonly closeWindow?: () => void;
-  readonly scheduleTimeout?: ScheduleTimeout;
+  readonly browser?: FrontendBrowser;
 }
 
 export function createFrontendContext(input: CreateFrontendContextInput): FrontendContext {
@@ -40,8 +44,7 @@ export function createFrontendContext(input: CreateFrontendContextInput): Fronte
     surface,
     buildInfo = BUILD_INFO,
     logger: loggerOverride,
-    closeWindow = defaultCloseWindow,
-    scheduleTimeout = defaultScheduleTimeout,
+    browser = new FrontendBrowserImpl(),
   } = input;
 
   const { distinctId, telemetryDisabled } = config;
@@ -62,18 +65,6 @@ export function createFrontendContext(input: CreateFrontendContextInput): Fronte
   return Object.freeze({
     ...createBaseContext({ buildInfo, logger, distinctId, telemetryDisabled, analytics, telemetry }),
     telemetry,
-    closeWindow,
-    scheduleTimeout,
+    browser,
   });
-}
-
-function defaultCloseWindow(): void {
-  window.close();
-}
-
-function defaultScheduleTimeout(handler: () => void, delayMs: number): () => void {
-  const id = window.setTimeout(handler, delayMs);
-  return () => {
-    window.clearTimeout(id);
-  };
 }

--- a/packages/context/src/testHelpers/FakeFrontendBrowser.test.ts
+++ b/packages/context/src/testHelpers/FakeFrontendBrowser.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test';
+import { FakeFrontendBrowser } from './FakeFrontendBrowser.ts';
+
+describe('FakeFrontendBrowser', () => {
+  it('records close calls and invokes the configured close callback', () => {
+    let closed = false;
+    const browser = new FakeFrontendBrowser({ closeWindow: () => (closed = true) });
+
+    browser.closeWindow();
+
+    expect(browser.closeWindowCallCount).toBe(1);
+    expect(closed).toBe(true);
+  });
+
+  it('queues manual timers and advances them deterministically', () => {
+    const browser = new FakeFrontendBrowser();
+    let fired = false;
+
+    browser.scheduleTimeout(() => {
+      fired = true;
+    }, 250);
+
+    expect(browser.scheduledTimeouts).toMatchObject([{ id: 1, delayMs: 250 }]);
+    expect(fired).toBe(false);
+
+    browser.advance();
+
+    expect(fired).toBe(true);
+    expect(browser.scheduledTimeouts).toEqual([]);
+  });
+
+  it('cancels queued manual timers', () => {
+    const browser = new FakeFrontendBrowser();
+    let fired = false;
+
+    const cancel = browser.scheduleTimeout(() => {
+      fired = true;
+    }, 250);
+    cancel();
+    browser.advance();
+
+    expect(browser.clearedTimeoutIds).toEqual([1]);
+    expect(fired).toBe(false);
+  });
+});

--- a/packages/context/src/testHelpers/FakeFrontendBrowser.ts
+++ b/packages/context/src/testHelpers/FakeFrontendBrowser.ts
@@ -1,0 +1,68 @@
+import type { FrontendBrowser, TimeoutCancel } from '../FrontendBrowserImpl.ts';
+
+export interface ScheduledFakeTimeout {
+  readonly id: number;
+  readonly delayMs: number;
+  readonly handler: () => void;
+}
+
+export interface FakeFrontendBrowserOptions {
+  readonly closeWindow?: () => void;
+  readonly timers?: 'manual' | 'real';
+}
+
+export class FakeFrontendBrowser implements FrontendBrowser {
+  readonly scheduledTimeouts: ScheduledFakeTimeout[] = [];
+  readonly clearedTimeoutIds: number[] = [];
+
+  closeWindowCallCount = 0;
+
+  readonly #closeWindow: () => void;
+  readonly #timers: 'manual' | 'real';
+  #nextTimeoutId = 1;
+
+  constructor(options: FakeFrontendBrowserOptions = {}) {
+    const { closeWindow = () => {}, timers = 'manual' } = options;
+    this.#closeWindow = closeWindow;
+    this.#timers = timers;
+  }
+
+  closeWindow(): void {
+    this.closeWindowCallCount += 1;
+    this.#closeWindow();
+  }
+
+  scheduleTimeout(handler: () => void, delayMs: number): TimeoutCancel {
+    if (this.#timers === 'real') {
+      const timeout = setTimeout(handler, delayMs);
+      return () => {
+        clearTimeout(timeout);
+      };
+    }
+
+    const id = this.#nextTimeoutId;
+    this.#nextTimeoutId += 1;
+    this.scheduledTimeouts.push({ id, delayMs, handler });
+    return () => {
+      this.clearTimeout(id);
+    };
+  }
+
+  clearTimeout(timeoutId: number): void {
+    this.clearedTimeoutIds.push(timeoutId);
+    const index = this.scheduledTimeouts.findIndex((timeout) => timeout.id === timeoutId);
+    if (index !== -1) {
+      this.scheduledTimeouts.splice(index, 1);
+    }
+  }
+
+  advance(): void {
+    this.scheduledTimeouts.shift()?.handler();
+  }
+
+  runAllTimers(): void {
+    while (this.scheduledTimeouts.length > 0) {
+      this.advance();
+    }
+  }
+}

--- a/packages/context/src/testHelpers/fakeBaseContext.test.ts
+++ b/packages/context/src/testHelpers/fakeBaseContext.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { buildInfo } from '../testFactories.ts';
 import { fakeBaseContext } from './fakeBaseContext.ts';
+import { FakeFrontendBrowser } from './FakeFrontendBrowser.ts';
 import { fakeFrontendContext } from './fakeFrontendContext.ts';
 
 describe('fakeBaseContext', () => {
@@ -23,18 +24,18 @@ describe('fakeBaseContext', () => {
 });
 
 describe('fakeFrontendContext', () => {
-  it('returns a FrontendContext with no-op browser hooks and a passthrough ErrorBoundary', () => {
+  it('returns a FrontendContext with a browser abstraction and a passthrough ErrorBoundary', () => {
     const ctx = fakeFrontendContext();
     expect(ctx.buildInfo.version).toBe('test');
-    expect(typeof ctx.closeWindow).toBe('function');
-    expect(typeof ctx.scheduleTimeout).toBe('function');
+    expect(ctx.browser).toBeInstanceOf(FakeFrontendBrowser);
     expect(typeof ctx.telemetry.ErrorBoundary).toBe('function');
   });
 
   it('applies overrides', () => {
     let closed = false;
-    const ctx = fakeFrontendContext({ closeWindow: () => (closed = true) });
-    ctx.closeWindow();
+    const browser = new FakeFrontendBrowser({ closeWindow: () => (closed = true) });
+    const ctx = fakeFrontendContext({ browser });
+    ctx.browser.closeWindow();
     expect(closed).toBe(true);
   });
 });

--- a/packages/context/src/testHelpers/fakeFrontendContext.ts
+++ b/packages/context/src/testHelpers/fakeFrontendContext.ts
@@ -1,13 +1,13 @@
 import { createFakeFrontendTelemetry } from '@contextbridge/instrumentation/testHelpers/frontend';
 import type { FrontendContext } from '../frontend.ts';
 import { fakeBaseContext } from './fakeBaseContext.ts';
+import { FakeFrontendBrowser } from './FakeFrontendBrowser.ts';
 
 export function fakeFrontendContext(overrides: Partial<FrontendContext> = {}): FrontendContext {
   return {
     ...fakeBaseContext(),
     telemetry: createFakeFrontendTelemetry(),
-    closeWindow: () => {},
-    scheduleTimeout: () => () => {},
+    browser: new FakeFrontendBrowser(),
     ...overrides,
   };
 }

--- a/packages/context/src/testHelpers/index.ts
+++ b/packages/context/src/testHelpers/index.ts
@@ -2,6 +2,11 @@ export { fakeBaseContext } from './fakeBaseContext.ts';
 export { fakeFrontendContext } from './fakeFrontendContext.ts';
 export { type FakeFetchCall, FakeFetcher } from './FakeFetcher.ts';
 export {
+  FakeFrontendBrowser,
+  type FakeFrontendBrowserOptions,
+  type ScheduledFakeTimeout,
+} from './FakeFrontendBrowser.ts';
+export {
   type FakeAnalytics,
   type FakeTelemetry,
   type RecordedCapture,


### PR DESCRIPTION
## Summary

Refactors the frontend browser-effect surface into a `FrontendBrowser` interface with `FrontendBrowserImpl` as the real implementation and `FakeFrontendBrowser` for tests/stories. The annotation auto-close path, tests, fakes, and demo contexts now use the injected browser contract, and a scoped ESLint guard prevents direct `window.close`, `window.setTimeout`, or `window.clearTimeout` usage in the annotation app.

Also adds a generic Claude rule for future agents documenting the context dependency pattern across all contexts: public interface, `XxxImpl` production implementation, and `FakeXxx` test implementation.

## Review focus

Please sanity-check the boundary of the browser abstraction: it intentionally wraps only effectful close/timer APIs, not selection, measurement, or other direct browser reads. Also worth reviewing whether the lint scope should remain limited to `packages/annotation/src/**/*.{ts,tsx}` given existing global story-file ignores.

## Commits

- [`8b9dce9`](https://github.com/contextbridge/planbridge/commit/8b9dce9) — refactor: inject frontend browser effects
- [`f0c2aa9`](https://github.com/contextbridge/planbridge/commit/f0c2aa9) — chore: guard annotation browser effects
- [`92c035d`](https://github.com/contextbridge/planbridge/commit/92c035d) — docs: document context fake pattern
