### PR TITLE
fix: prevent data loss with onbeforeunload warning

### DIFF
--- a/.claude/rules/test-copy-constants.md
+++ b/.claude/rules/test-copy-constants.md
@@ -1,0 +1,36 @@
+---
+paths:
+  - "packages/**/*.test.ts"
+  - "packages/**/*.test.tsx"
+  - "packages/**/*.tsx"
+  - "packages/**/src/**/*.ts"
+---
+
+# Test copy constants
+
+- **Extract user-visible dialog / notice copy into an exported constant when a test asserts against it.** When a component renders fixed copy (dialog titles, descriptions, primary button labels) that a test needs to verify, define an exported `xxxCopy` object next to the component or in the hook that owns the variant logic, and import it in both places. Tests reference the constant rather than literal strings, so a copy edit is a one-line change in one file. Applies to multi-variant surfaces (e.g. a dialog whose title / description differ by state) and to any prose string that more than one site reads.
+
+  This complements — does not replace — the `xxxTestIds` pattern in `.contextbridge/rules/testing-patterns.md`: test ids stay the primary handle for locating an element; the copy constant is for asserting against rendered text once the element is in hand.
+
+  **Good:**
+
+  ```ts
+  // useAnnotationState.ts
+  export const closeReviewDialogCopy = {
+    empty: {
+      title: 'Approve plan before closing?',
+      description:
+        'No comments have been added. Select Approve Plan to tell the agent to proceed with the plan as written.',
+      primaryActionLabel: 'Approve Plan',
+    },
+    feedback: {
+      title: 'Submit feedback before closing?',
+      description: 'You have unsent feedback. Select Submit Feedback before closing, otherwise your comments will be lost.',
+      primaryActionLabel: 'Submit Feedback',
+    },
+  } as const;
+
+  // App.test.tsx
+  import { closeReviewDialogCopy } from './useAnnotationState.ts';
+  expect(dialog).toHaveTextContent(closeReviewDialogCopy.empty.description);
+  ```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,6 +74,19 @@ const annotationBrowserWindowRestrictedProperties = [
     property: 'clearTimeout',
     message: 'Use the cancel callback returned by browser.scheduleTimeout() instead of window.clearTimeout().',
   },
+  {
+    object: 'window',
+    property: 'onbeforeunload',
+    message: 'Use browser.addBeforeUnloadGuard() from AnnotationAppContext instead of window.onbeforeunload.',
+  },
+];
+
+const annotationBrowserWindowRestrictedSelectors = [
+  {
+    selector:
+      "CallExpression[callee.object.name='window'][callee.property.name=/^(addEventListener|removeEventListener)$/][arguments.0.value='beforeunload']",
+    message: 'Use browser.addBeforeUnloadGuard() from AnnotationAppContext instead of direct beforeunload listeners.',
+  },
 ];
 
 const rawImgRestrictedSelector = {
@@ -128,7 +141,12 @@ export default defineConfig(
   {
     files: ['packages/annotation/src/**/*.{ts,tsx}'],
     rules: {
-      'no-restricted-syntax': ['error', ...dateRestrictedSelectors, consoleRestrictedSelector],
+      'no-restricted-syntax': [
+        'error',
+        ...dateRestrictedSelectors,
+        consoleRestrictedSelector,
+        ...annotationBrowserWindowRestrictedSelectors,
+      ],
       'no-restricted-properties': [
         'error',
         ...processRestrictedProperties,

--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -3,7 +3,7 @@ import { DOCS_URL, FEEDBACK_URL, GITHUB_REPO_URL, SLACK_COMMUNITY_URL } from '@c
 import { createDeferred } from '@contextbridge/shared/testHelpers';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
 import { headerTestIds } from '@contextbridge/ui/components/Header';
-import { act, cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { annotatedMarkdownTestIds } from './AnnotatedMarkdown.tsx';
@@ -155,6 +155,63 @@ describe('App', () => {
         },
       ],
     });
+  });
+
+  it('opens the approval close dialog after staying on an attempted close with no comments', async () => {
+    const user = userEvent.setup();
+    const { browser, submitAnnotation } = renderApp({ initialPayload: { contentKind: 'plan', content: '# Ship it' } });
+
+    await act(async () => {
+      browser.triggerBeforeUnload();
+      await Promise.resolve();
+    });
+
+    const dialog = await screen.findByTestId(appTestIds.closeReviewDialog);
+    expect(dialog).toHaveTextContent('Approve plan before closing?');
+    expect(dialog).toHaveTextContent(
+      'No comments have been added. Select Approve Plan to tell the agent to proceed with the plan as written.',
+    );
+    expect(within(dialog).getByRole('button', { name: 'Keep Reviewing' })).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Approve Plan' })).toBeInTheDocument();
+    expect(within(dialog).queryByRole('button', { name: 'Close Anyway' })).not.toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole('button', { name: 'Keep Reviewing' }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(appTestIds.closeReviewDialog)).not.toBeInTheDocument();
+    });
+    expect(submitAnnotation).not.toHaveBeenCalled();
+  });
+
+  it('opens the submit-feedback close dialog after staying on an attempted close with feedback', async () => {
+    const user = userEvent.setup();
+    const { browser, submitAnnotation } = renderApp({ initialPayload: { contentKind: 'plan', content: '# Ship it' } });
+
+    await user.type(screen.getByTestId(globalCommentComposerTestIds.textarea), 'Needs rollback details');
+
+    await act(async () => {
+      browser.triggerBeforeUnload();
+      await Promise.resolve();
+    });
+
+    const dialog = await screen.findByTestId(appTestIds.closeReviewDialog);
+    expect(dialog).toHaveTextContent('Submit feedback before closing?');
+    expect(dialog).toHaveTextContent(
+      'You have unsent feedback. Select Submit Feedback before closing, otherwise your comments will be lost.',
+    );
+    expect(within(dialog).getByRole('button', { name: 'Keep Reviewing' })).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Submit Feedback' })).toBeInTheDocument();
+    expect(within(dialog).queryByRole('button', { name: 'Close Anyway' })).not.toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole('button', { name: 'Submit Feedback' }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(appTestIds.closeReviewDialog)).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(submitAnnotation).toHaveBeenCalledTimes(1);
+    });
+    expect(submitAnnotation.mock.calls[0]?.[0]).toMatchObject({ status: 'changes_requested' });
   });
 
   it('does not submit again from the global shortcut while submitting', async () => {

--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -13,6 +13,7 @@ import { globalCommentComposerTestIds } from './GlobalCommentComposer.tsx';
 import { submitBarTestIds } from './SubmitBar.tsx';
 import { drag, pressSubmitShortcut, renderApp } from './testHelpers/index.tsx';
 import { updateNoticeCardTestIds } from './UpdateNoticeCard.tsx';
+import { closeReviewDialogCopy } from './useAnnotationState.ts';
 
 describe('App', () => {
   afterEach(() => {
@@ -167,12 +168,12 @@ describe('App', () => {
     });
 
     const dialog = await screen.findByTestId(appTestIds.closeReviewDialog);
-    expect(dialog).toHaveTextContent('Approve plan before closing?');
-    expect(dialog).toHaveTextContent(
-      'No comments have been added. Select Approve Plan to tell the agent to proceed with the plan as written.',
-    );
+    expect(dialog).toHaveTextContent(closeReviewDialogCopy.empty.title);
+    expect(dialog).toHaveTextContent(closeReviewDialogCopy.empty.description);
     expect(screen.getByTestId(appTestIds.closeReviewDialogCancelButton)).toHaveTextContent('Keep Reviewing');
-    expect(screen.getByTestId(appTestIds.closeReviewDialogActionButton)).toHaveTextContent('Approve Plan');
+    expect(screen.getByTestId(appTestIds.closeReviewDialogActionButton)).toHaveTextContent(
+      closeReviewDialogCopy.empty.primaryActionLabel,
+    );
     expect(dialog).not.toHaveTextContent('Close Anyway');
 
     await user.click(screen.getByTestId(appTestIds.closeReviewDialogCancelButton));
@@ -195,12 +196,12 @@ describe('App', () => {
     });
 
     const dialog = await screen.findByTestId(appTestIds.closeReviewDialog);
-    expect(dialog).toHaveTextContent('Submit feedback before closing?');
-    expect(dialog).toHaveTextContent(
-      'You have unsent feedback. Select Submit Feedback before closing, otherwise your comments will be lost.',
-    );
+    expect(dialog).toHaveTextContent(closeReviewDialogCopy.feedback.title);
+    expect(dialog).toHaveTextContent(closeReviewDialogCopy.feedback.description);
     expect(screen.getByTestId(appTestIds.closeReviewDialogCancelButton)).toHaveTextContent('Keep Reviewing');
-    expect(screen.getByTestId(appTestIds.closeReviewDialogActionButton)).toHaveTextContent('Submit Feedback');
+    expect(screen.getByTestId(appTestIds.closeReviewDialogActionButton)).toHaveTextContent(
+      closeReviewDialogCopy.feedback.primaryActionLabel,
+    );
     expect(dialog).not.toHaveTextContent('Close Anyway');
 
     await user.click(screen.getByTestId(appTestIds.closeReviewDialogActionButton));

--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -3,7 +3,7 @@ import { DOCS_URL, FEEDBACK_URL, GITHUB_REPO_URL, SLACK_COMMUNITY_URL } from '@c
 import { createDeferred } from '@contextbridge/shared/testHelpers';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
 import { headerTestIds } from '@contextbridge/ui/components/Header';
-import { act, cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { annotatedMarkdownTestIds } from './AnnotatedMarkdown.tsx';
@@ -171,11 +171,11 @@ describe('App', () => {
     expect(dialog).toHaveTextContent(
       'No comments have been added. Select Approve Plan to tell the agent to proceed with the plan as written.',
     );
-    expect(within(dialog).getByRole('button', { name: 'Keep Reviewing' })).toBeInTheDocument();
-    expect(within(dialog).getByRole('button', { name: 'Approve Plan' })).toBeInTheDocument();
-    expect(within(dialog).queryByRole('button', { name: 'Close Anyway' })).not.toBeInTheDocument();
+    expect(screen.getByTestId(appTestIds.closeReviewDialogCancelButton)).toHaveTextContent('Keep Reviewing');
+    expect(screen.getByTestId(appTestIds.closeReviewDialogActionButton)).toHaveTextContent('Approve Plan');
+    expect(dialog).not.toHaveTextContent('Close Anyway');
 
-    await user.click(within(dialog).getByRole('button', { name: 'Keep Reviewing' }));
+    await user.click(screen.getByTestId(appTestIds.closeReviewDialogCancelButton));
 
     await waitFor(() => {
       expect(screen.queryByTestId(appTestIds.closeReviewDialog)).not.toBeInTheDocument();
@@ -199,11 +199,11 @@ describe('App', () => {
     expect(dialog).toHaveTextContent(
       'You have unsent feedback. Select Submit Feedback before closing, otherwise your comments will be lost.',
     );
-    expect(within(dialog).getByRole('button', { name: 'Keep Reviewing' })).toBeInTheDocument();
-    expect(within(dialog).getByRole('button', { name: 'Submit Feedback' })).toBeInTheDocument();
-    expect(within(dialog).queryByRole('button', { name: 'Close Anyway' })).not.toBeInTheDocument();
+    expect(screen.getByTestId(appTestIds.closeReviewDialogCancelButton)).toHaveTextContent('Keep Reviewing');
+    expect(screen.getByTestId(appTestIds.closeReviewDialogActionButton)).toHaveTextContent('Submit Feedback');
+    expect(dialog).not.toHaveTextContent('Close Anyway');
 
-    await user.click(within(dialog).getByRole('button', { name: 'Submit Feedback' }));
+    await user.click(screen.getByTestId(appTestIds.closeReviewDialogActionButton));
 
     await waitFor(() => {
       expect(screen.queryByTestId(appTestIds.closeReviewDialog)).not.toBeInTheDocument();

--- a/packages/annotation/src/App.tsx
+++ b/packages/annotation/src/App.tsx
@@ -32,6 +32,7 @@ export const appTestIds = {
   emptyState: 'plan-review-empty-state',
   removeDialog: 'plan-review-remove-dialog',
   discardDraftDialog: 'plan-review-discard-draft-dialog',
+  closeReviewDialog: 'plan-review-close-review-dialog',
 };
 
 export interface AppProps {
@@ -197,6 +198,28 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
                   <AlertDialogCancel>Keep Editing</AlertDialogCancel>
                   <AlertDialogAction onClick={reviewState.draft.confirmDiscard} variant="destructive">
                     Discard
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+
+            <AlertDialog
+              onOpenChange={(open) => {
+                if (!open) {
+                  reviewState.closeReview.dismissDialog();
+                }
+              }}
+              open={reviewState.closeReview.dialogOpen}
+            >
+              <AlertDialogContent data-testid={appTestIds.closeReviewDialog} size="sm">
+                <AlertDialogHeader>
+                  <AlertDialogTitle>{reviewState.closeReview.title}</AlertDialogTitle>
+                  <AlertDialogDescription>{reviewState.closeReview.description}</AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Keep Reviewing</AlertDialogCancel>
+                  <AlertDialogAction onClick={() => void reviewState.closeReview.confirmRecommendedAction()}>
+                    {reviewState.closeReview.primaryActionLabel}
                   </AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>

--- a/packages/annotation/src/App.tsx
+++ b/packages/annotation/src/App.tsx
@@ -33,6 +33,8 @@ export const appTestIds = {
   removeDialog: 'plan-review-remove-dialog',
   discardDraftDialog: 'plan-review-discard-draft-dialog',
   closeReviewDialog: 'plan-review-close-review-dialog',
+  closeReviewDialogCancelButton: 'plan-review-close-review-dialog-cancel',
+  closeReviewDialogActionButton: 'plan-review-close-review-dialog-action',
 };
 
 export interface AppProps {
@@ -217,8 +219,13 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
                   <AlertDialogDescription>{reviewState.closeReview.description}</AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
-                  <AlertDialogCancel>Keep Reviewing</AlertDialogCancel>
-                  <AlertDialogAction onClick={() => void reviewState.closeReview.confirmRecommendedAction()}>
+                  <AlertDialogCancel data-testid={appTestIds.closeReviewDialogCancelButton}>
+                    Keep Reviewing
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    data-testid={appTestIds.closeReviewDialogActionButton}
+                    onClick={() => void reviewState.closeReview.confirmRecommendedAction()}
+                  >
                     {reviewState.closeReview.primaryActionLabel}
                   </AlertDialogAction>
                 </AlertDialogFooter>

--- a/packages/annotation/src/useAnnotationState.test.ts
+++ b/packages/annotation/src/useAnnotationState.test.ts
@@ -1,3 +1,4 @@
+import type { FakeFrontendBrowser } from '@contextbridge/context/testHelpers';
 import type { AnnotationSubmission, CommentThread } from '@contextbridge/shared/annotationSchema';
 import { annotationAnchor, annotationThread } from '@contextbridge/shared/testFactories';
 import { act, cleanup } from '@testing-library/react';
@@ -85,6 +86,60 @@ describe('useAnnotationState', () => {
     });
   });
 
+  describe('beforeunload guard', () => {
+    it('guards an empty unsubmitted review', () => {
+      const { browser } = renderAnnotationHook(() => useAnnotationState({}));
+
+      expectBeforeUnloadGuard(browser);
+    });
+
+    it('guards a review with saved annotation threads', () => {
+      const { browser } = renderAnnotationHook(() =>
+        useAnnotationState({ initialThreads: [annotationThread.build({ id: 'thr_guarded' })] }),
+      );
+
+      expectBeforeUnloadGuard(browser);
+    });
+
+    it('guards a review with a non-whitespace global comment', () => {
+      const { result, browser } = renderAnnotationHook(() => useAnnotationState({}));
+
+      act(() => {
+        result.current.globalComment.setBody('Include rollback steps.');
+      });
+
+      expectBeforeUnloadGuard(browser);
+    });
+
+    it('guards a review with a dirty active draft', () => {
+      const { result, browser } = renderAnnotationHook(() => useAnnotationState({}));
+
+      act(() => {
+        openDraft(result, { body: 'Unsaved draft feedback' });
+      });
+
+      expectBeforeUnloadGuard(browser);
+    });
+
+    it('removes the guard after a successful submission', async () => {
+      const { result, browser } = renderAnnotationHook(() => useAnnotationState({}));
+
+      await act(async () => {
+        await result.current.submission.submit();
+      });
+
+      expectNoBeforeUnloadGuard(browser);
+    });
+
+    it('removes the guard on unmount', () => {
+      const { unmount, browser } = renderAnnotationHook(() => useAnnotationState({}));
+
+      unmount();
+
+      expectNoBeforeUnloadGuard(browser);
+    });
+  });
+
   describe('submission.submit', () => {
     it('emits status "approved" when there are no threads and no global comment', async () => {
       const { result, submitAnnotation } = renderAnnotationHook(() => useAnnotationState({}));
@@ -144,8 +199,8 @@ describe('useAnnotationState', () => {
       expect(submitAnnotation.mock.calls[0]?.[0]?.threads).toEqual([]);
     });
 
-    it('captures the error message and leaves submitted=false on failure', async () => {
-      const { result } = renderAnnotationHook(() => useAnnotationState({}), {
+    it('captures the error message, leaves submitted=false, and keeps the unload guard on failure', async () => {
+      const { result, browser } = renderAnnotationHook(() => useAnnotationState({}), {
         contextOverrides: {
           submitAnnotation: vi
             .fn<(submission: AnnotationSubmission) => Promise<void>>()
@@ -159,6 +214,7 @@ describe('useAnnotationState', () => {
 
       expect(result.current.submission.submitted).toBe(false);
       expect(result.current.submission.error).toBe('network down');
+      expectBeforeUnloadGuard(browser);
     });
 
     it('steps the countdown down and closes the window after the final tick', async () => {
@@ -450,6 +506,16 @@ describe('useAnnotationState', () => {
 });
 
 type AnnotationHookResult = RenderAnnotationHookResult<ReturnType<typeof useAnnotationState>, unknown>['result'];
+
+function expectBeforeUnloadGuard(browser: FakeFrontendBrowser): void {
+  expect(browser.isBeforeUnloadGuarded()).toBe(true);
+  expect(browser.triggerBeforeUnload()).toMatchObject({ defaultPrevented: true, returnValue: '' });
+}
+
+function expectNoBeforeUnloadGuard(browser: FakeFrontendBrowser): void {
+  expect(browser.isBeforeUnloadGuarded()).toBe(false);
+  expect(browser.triggerBeforeUnload()).toMatchObject({ defaultPrevented: false, returnValue: 'unset' });
+}
 
 function openDraft(result: AnnotationHookResult, { body = '' }: { body?: string } = {}): void {
   result.current.draft.open({

--- a/packages/annotation/src/useAnnotationState.test.ts
+++ b/packages/annotation/src/useAnnotationState.test.ts
@@ -1,4 +1,4 @@
-import type { FakeFrontendBrowser } from '@contextbridge/context/testHelpers';
+import type { FakeBeforeUnloadEvent, FakeFrontendBrowser } from '@contextbridge/context/testHelpers';
 import type { AnnotationSubmission, CommentThread } from '@contextbridge/shared/annotationSchema';
 import { annotationAnchor, annotationThread } from '@contextbridge/shared/testFactories';
 import { act, cleanup } from '@testing-library/react';
@@ -87,21 +87,35 @@ describe('useAnnotationState', () => {
   });
 
   describe('beforeunload guard', () => {
-    it('guards an empty unsubmitted review', () => {
-      const { browser } = renderAnnotationHook(() => useAnnotationState({}));
+    it('opens the approval close dialog for an empty unsubmitted review', () => {
+      const { result, browser } = renderAnnotationHook(() => useAnnotationState({}));
 
       expectBeforeUnloadGuard(browser);
+
+      expectCloseReviewDialog(result, {
+        title: 'Approve plan before closing?',
+        description:
+          'No comments have been added. Select Approve Plan to tell the agent to proceed with the plan as written.',
+        primaryActionLabel: 'Approve Plan',
+      });
     });
 
-    it('guards a review with saved annotation threads', () => {
-      const { browser } = renderAnnotationHook(() =>
+    it('opens the submit-feedback close dialog for saved annotation threads', () => {
+      const { result, browser } = renderAnnotationHook(() =>
         useAnnotationState({ initialThreads: [annotationThread.build({ id: 'thr_guarded' })] }),
       );
 
       expectBeforeUnloadGuard(browser);
+
+      expectCloseReviewDialog(result, {
+        title: 'Submit feedback before closing?',
+        description:
+          'You have unsent feedback. Select Submit Feedback before closing, otherwise your comments will be lost.',
+        primaryActionLabel: 'Submit Feedback',
+      });
     });
 
-    it('guards a review with a non-whitespace global comment', () => {
+    it('opens the submit-feedback close dialog for a non-whitespace global comment', () => {
       const { result, browser } = renderAnnotationHook(() => useAnnotationState({}));
 
       act(() => {
@@ -109,9 +123,16 @@ describe('useAnnotationState', () => {
       });
 
       expectBeforeUnloadGuard(browser);
+
+      expectCloseReviewDialog(result, {
+        title: 'Submit feedback before closing?',
+        description:
+          'You have unsent feedback. Select Submit Feedback before closing, otherwise your comments will be lost.',
+        primaryActionLabel: 'Submit Feedback',
+      });
     });
 
-    it('guards a review with a dirty active draft', () => {
+    it('opens the close dialog without discarding a dirty active draft', () => {
       const { result, browser } = renderAnnotationHook(() => useAnnotationState({}));
 
       act(() => {
@@ -119,6 +140,38 @@ describe('useAnnotationState', () => {
       });
 
       expectBeforeUnloadGuard(browser);
+
+      expect(result.current.closeReview.dialogOpen).toBe(true);
+      expect(result.current.draft.active?.body).toBe('Unsaved draft feedback');
+    });
+
+    it('keeps reviewing by closing only the custom dialog', () => {
+      const { result, browser } = renderAnnotationHook(() => useAnnotationState({}));
+
+      expectBeforeUnloadGuard(browser);
+
+      act(() => {
+        result.current.closeReview.dismissDialog();
+      });
+
+      expect(result.current.closeReview.dialogOpen).toBe(false);
+      expect(result.current.submission.submitted).toBe(false);
+      expect(browser.isBeforeUnloadGuarded()).toBe(true);
+    });
+
+    it('submits the recommended action from the custom dialog', async () => {
+      const { result, browser, submitAnnotation } = renderAnnotationHook(() => useAnnotationState({}));
+
+      expectBeforeUnloadGuard(browser);
+
+      await act(async () => {
+        await result.current.closeReview.confirmRecommendedAction();
+      });
+
+      expect(submitAnnotation).toHaveBeenCalledTimes(1);
+      expect(submitAnnotation.mock.calls[0]?.[0]?.status).toBe('approved');
+      expect(result.current.closeReview.dialogOpen).toBe(false);
+      expect(result.current.submission.submitted).toBe(true);
     });
 
     it('removes the guard after a successful submission', async () => {
@@ -509,12 +562,35 @@ type AnnotationHookResult = RenderAnnotationHookResult<ReturnType<typeof useAnno
 
 function expectBeforeUnloadGuard(browser: FakeFrontendBrowser): void {
   expect(browser.isBeforeUnloadGuarded()).toBe(true);
-  expect(browser.triggerBeforeUnload()).toMatchObject({ defaultPrevented: true, returnValue: '' });
+  expect(triggerBeforeUnload(browser)).toMatchObject({ defaultPrevented: true, returnValue: '' });
 }
 
 function expectNoBeforeUnloadGuard(browser: FakeFrontendBrowser): void {
   expect(browser.isBeforeUnloadGuarded()).toBe(false);
-  expect(browser.triggerBeforeUnload()).toMatchObject({ defaultPrevented: false, returnValue: 'unset' });
+  expect(triggerBeforeUnload(browser)).toMatchObject({ defaultPrevented: false, returnValue: 'unset' });
+}
+
+function expectCloseReviewDialog(
+  result: AnnotationHookResult,
+  expected: { title: string; description: string; primaryActionLabel: string },
+): void {
+  expect(result.current.closeReview).toMatchObject({
+    dialogOpen: true,
+    ...expected,
+  });
+}
+
+function triggerBeforeUnload(browser: FakeFrontendBrowser): FakeBeforeUnloadEvent {
+  let event: FakeBeforeUnloadEvent | null = null;
+  act(() => {
+    event = browser.triggerBeforeUnload();
+  });
+
+  if (!event) {
+    throw new Error('expected beforeunload event to be returned');
+  }
+
+  return event;
 }
 
 function openDraft(result: AnnotationHookResult, { body = '' }: { body?: string } = {}): void {

--- a/packages/annotation/src/useAnnotationState.ts
+++ b/packages/annotation/src/useAnnotationState.ts
@@ -34,6 +34,12 @@ type PendingDraftAction =
   | { kind: 'replace'; draft: OpenAnnotationCommentDraftArgs }
   | { kind: 'remove'; threadId: string };
 
+interface CloseReviewDialogContent {
+  readonly title: string;
+  readonly description: string;
+  readonly primaryActionLabel: string;
+}
+
 export function useAnnotationState({ initialThreads, initialGlobalComment }: UseAnnotationStateArgs = {}) {
   const { submitAnnotation, browser, autoCloseDelaySeconds } = useAnnotationAppContext();
 
@@ -47,9 +53,11 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
   const [globalCommentBody, setGlobalCommentBody] = useState(initialGlobalComment ?? '');
   const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
   const [closeCountdownSeconds, setCloseCountdownSeconds] = useState<number | null>(null);
+  const [closeReviewDialogOpen, setCloseReviewDialogOpen] = useState(false);
 
   const trimmedGlobal = globalCommentBody.trim();
   const feedbackCount = getFeedbackCount(threads, trimmedGlobal);
+  const closeReviewDialogContent = getCloseReviewDialogContent(feedbackCount);
   const submitLabel = submitted ? 'Submitted' : feedbackCount === 0 ? 'Approve Plan' : 'Submit Feedback';
 
   const [pendingDraftAction, setPendingDraftAction] = useState<PendingDraftAction | null>(null);
@@ -166,6 +174,15 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
     await submitThreads(threads);
   };
 
+  const dismissCloseReviewDialog = () => {
+    setCloseReviewDialogOpen(false);
+  };
+
+  const confirmCloseReviewRecommendedAction = async () => {
+    setCloseReviewDialogOpen(false);
+    await submit();
+  };
+
   const confirmDiscardDraft = () => {
     if (!pendingDraftAction) {
       return;
@@ -196,7 +213,9 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
       return;
     }
 
-    return browser.addBeforeUnloadGuard();
+    return browser.addBeforeUnloadGuard({
+      onAttemptedUnload: () => setCloseReviewDialogOpen(true),
+    });
   }, [browser, submitted]);
 
   useEffect(() => {
@@ -247,6 +266,12 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
       label: submitLabel,
       feedbackCount,
     },
+    closeReview: {
+      dialogOpen: closeReviewDialogOpen,
+      dismissDialog: dismissCloseReviewDialog,
+      confirmRecommendedAction: confirmCloseReviewRecommendedAction,
+      ...closeReviewDialogContent,
+    },
     removal: {
       pendingId: pendingRemoveId,
       request: requestRemove,
@@ -267,6 +292,24 @@ function getDraftDirty(draft: ActiveCommentDraft, threads: CommentThread[]): boo
 
 function getFeedbackCount(threads: CommentThread[], trimmedGlobal: string): number {
   return threads.length + (trimmedGlobal.length > 0 ? 1 : 0);
+}
+
+function getCloseReviewDialogContent(feedbackCount: number): CloseReviewDialogContent {
+  if (feedbackCount === 0) {
+    return {
+      title: 'Approve plan before closing?',
+      description:
+        'No comments have been added. Select Approve Plan to tell the agent to proceed with the plan as written.',
+      primaryActionLabel: 'Approve Plan',
+    };
+  }
+
+  return {
+    title: 'Submit feedback before closing?',
+    description:
+      'You have unsent feedback. Select Submit Feedback before closing, otherwise your comments will be lost.',
+    primaryActionLabel: 'Submit Feedback',
+  };
 }
 
 function getSubmitStatus(threads: CommentThread[], trimmedGlobal: string): AnnotationStatus {

--- a/packages/annotation/src/useAnnotationState.ts
+++ b/packages/annotation/src/useAnnotationState.ts
@@ -192,6 +192,14 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
   }
 
   useEffect(() => {
+    if (submitted) {
+      return;
+    }
+
+    return browser.addBeforeUnloadGuard();
+  }, [browser, submitted]);
+
+  useEffect(() => {
     if (!submitted) {
       return;
     }

--- a/packages/annotation/src/useAnnotationState.ts
+++ b/packages/annotation/src/useAnnotationState.ts
@@ -294,22 +294,23 @@ function getFeedbackCount(threads: CommentThread[], trimmedGlobal: string): numb
   return threads.length + (trimmedGlobal.length > 0 ? 1 : 0);
 }
 
-function getCloseReviewDialogContent(feedbackCount: number): CloseReviewDialogContent {
-  if (feedbackCount === 0) {
-    return {
-      title: 'Approve plan before closing?',
-      description:
-        'No comments have been added. Select Approve Plan to tell the agent to proceed with the plan as written.',
-      primaryActionLabel: 'Approve Plan',
-    };
-  }
-
-  return {
+export const closeReviewDialogCopy = {
+  empty: {
+    title: 'Approve plan before closing?',
+    description:
+      'No comments have been added. Select Approve Plan to tell the agent to proceed with the plan as written.',
+    primaryActionLabel: 'Approve Plan',
+  },
+  feedback: {
     title: 'Submit feedback before closing?',
     description:
       'You have unsent feedback. Select Submit Feedback before closing, otherwise your comments will be lost.',
     primaryActionLabel: 'Submit Feedback',
-  };
+  },
+} as const;
+
+function getCloseReviewDialogContent(feedbackCount: number): CloseReviewDialogContent {
+  return feedbackCount === 0 ? closeReviewDialogCopy.empty : closeReviewDialogCopy.feedback;
 }
 
 function getSubmitStatus(threads: CommentThread[], trimmedGlobal: string): AnnotationStatus {

--- a/packages/context/src/FrontendBrowserImpl.test.ts
+++ b/packages/context/src/FrontendBrowserImpl.test.ts
@@ -34,8 +34,13 @@ describe('FrontendBrowserImpl', () => {
   it('registers beforeunload guards through the injected window and returns a cleanup callback', () => {
     const browserWindow = createBrowserWindow();
     const browser = new FrontendBrowserImpl(browserWindow);
+    let attemptedUnloadCalls = 0;
 
-    const cleanup = browser.addBeforeUnloadGuard();
+    const cleanup = browser.addBeforeUnloadGuard({
+      onAttemptedUnload: () => {
+        attemptedUnloadCalls += 1;
+      },
+    });
 
     const handler = browserWindow.beforeUnloadHandlers[0];
     if (!handler) {
@@ -45,6 +50,7 @@ describe('FrontendBrowserImpl', () => {
     const event = createBeforeUnloadEvent();
     handler(event);
 
+    expect(attemptedUnloadCalls).toBe(1);
     expect(event.defaultPrevented).toBe(true);
     expect(event.returnValue).toBe('');
 

--- a/packages/context/src/FrontendBrowserImpl.test.ts
+++ b/packages/context/src/FrontendBrowserImpl.test.ts
@@ -30,6 +30,29 @@ describe('FrontendBrowserImpl', () => {
     cancel();
     expect(browserWindow.clearedTimeoutIds).toEqual([1]);
   });
+
+  it('registers beforeunload guards through the injected window and returns a cleanup callback', () => {
+    const browserWindow = createBrowserWindow();
+    const browser = new FrontendBrowserImpl(browserWindow);
+
+    const cleanup = browser.addBeforeUnloadGuard();
+
+    const handler = browserWindow.beforeUnloadHandlers[0];
+    if (!handler) {
+      throw new Error('expected beforeunload handler to be registered');
+    }
+
+    const event = createBeforeUnloadEvent();
+    handler(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.returnValue).toBe('');
+
+    cleanup();
+
+    expect(browserWindow.beforeUnloadHandlers).toEqual([]);
+    expect(browserWindow.removedBeforeUnloadHandlers).toEqual([handler]);
+  });
 });
 
 interface RecordedTimeout {
@@ -41,6 +64,8 @@ interface RecordedTimeout {
 interface FakeBrowserWindow extends FrontendBrowserWindow {
   readonly scheduledTimeouts: RecordedTimeout[];
   readonly clearedTimeoutIds: number[];
+  readonly beforeUnloadHandlers: Array<(event: BeforeUnloadEvent) => void>;
+  readonly removedBeforeUnloadHandlers: Array<(event: BeforeUnloadEvent) => void>;
   readonly closeCalls: number;
 }
 
@@ -49,6 +74,8 @@ function createBrowserWindow(): FakeBrowserWindow {
   let nextTimeoutId = 1;
   const scheduledTimeouts: RecordedTimeout[] = [];
   const clearedTimeoutIds: number[] = [];
+  const beforeUnloadHandlers: Array<(event: BeforeUnloadEvent) => void> = [];
+  const removedBeforeUnloadHandlers: Array<(event: BeforeUnloadEvent) => void> = [];
 
   return {
     get closeCalls() {
@@ -56,6 +83,8 @@ function createBrowserWindow(): FakeBrowserWindow {
     },
     scheduledTimeouts,
     clearedTimeoutIds,
+    beforeUnloadHandlers,
+    removedBeforeUnloadHandlers,
     close: () => {
       closeCalls += 1;
     },
@@ -68,5 +97,28 @@ function createBrowserWindow(): FakeBrowserWindow {
     clearTimeout: (timeoutId) => {
       clearedTimeoutIds.push(timeoutId);
     },
+    addEventListener: (_type, handler) => {
+      beforeUnloadHandlers.push(handler);
+    },
+    removeEventListener: (_type, handler) => {
+      removedBeforeUnloadHandlers.push(handler);
+      const index = beforeUnloadHandlers.indexOf(handler);
+      if (index !== -1) {
+        beforeUnloadHandlers.splice(index, 1);
+      }
+    },
   };
+}
+
+function createBeforeUnloadEvent(): BeforeUnloadEvent {
+  let defaultPrevented = false;
+  return {
+    get defaultPrevented() {
+      return defaultPrevented;
+    },
+    returnValue: 'unset',
+    preventDefault: () => {
+      defaultPrevented = true;
+    },
+  } as BeforeUnloadEvent;
 }

--- a/packages/context/src/FrontendBrowserImpl.ts
+++ b/packages/context/src/FrontendBrowserImpl.ts
@@ -4,10 +4,14 @@ export type TimeoutCancel = () => void;
 
 export type ScheduleTimeout = (handler: () => void, delayMs: number) => TimeoutCancel;
 
+export interface BeforeUnloadGuardOptions {
+  readonly onAttemptedUnload?: () => void;
+}
+
 export interface FrontendBrowser {
   closeWindow(): void;
   scheduleTimeout(handler: () => void, delayMs: number): TimeoutCancel;
-  addBeforeUnloadGuard(): () => void;
+  addBeforeUnloadGuard(options?: BeforeUnloadGuardOptions): () => void;
 }
 
 export interface FrontendBrowserWindow {
@@ -36,8 +40,10 @@ export class FrontendBrowserImpl implements FrontendBrowser {
     };
   }
 
-  addBeforeUnloadGuard(): () => void {
+  addBeforeUnloadGuard(options: BeforeUnloadGuardOptions = {}): () => void {
+    const { onAttemptedUnload } = options;
     const handler = (event: BeforeUnloadEvent) => {
+      onAttemptedUnload?.();
       event.preventDefault();
       event.returnValue = '';
     };

--- a/packages/context/src/FrontendBrowserImpl.ts
+++ b/packages/context/src/FrontendBrowserImpl.ts
@@ -7,12 +7,15 @@ export type ScheduleTimeout = (handler: () => void, delayMs: number) => TimeoutC
 export interface FrontendBrowser {
   closeWindow(): void;
   scheduleTimeout(handler: () => void, delayMs: number): TimeoutCancel;
+  addBeforeUnloadGuard(): () => void;
 }
 
 export interface FrontendBrowserWindow {
   readonly close: () => void;
   readonly setTimeout: (handler: () => void, delayMs: number) => number;
   readonly clearTimeout: (timeoutId: number) => void;
+  addEventListener(type: 'beforeunload', handler: (event: BeforeUnloadEvent) => void): void;
+  removeEventListener(type: 'beforeunload', handler: (event: BeforeUnloadEvent) => void): void;
 }
 
 export class FrontendBrowserImpl implements FrontendBrowser {
@@ -30,6 +33,18 @@ export class FrontendBrowserImpl implements FrontendBrowser {
     const timeoutId = this.#window.setTimeout(handler, delayMs);
     return () => {
       this.#window.clearTimeout(timeoutId);
+    };
+  }
+
+  addBeforeUnloadGuard(): () => void {
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    this.#window.addEventListener('beforeunload', handler);
+    return () => {
+      this.#window.removeEventListener('beforeunload', handler);
     };
   }
 }

--- a/packages/context/src/frontend.ts
+++ b/packages/context/src/frontend.ts
@@ -17,6 +17,7 @@ export {
 export { type BaseContext, isTelemetryDisabled } from './base.ts';
 export { type BuildInfo, BUILD_INFO } from './buildInfo.ts';
 export {
+  type BeforeUnloadGuardOptions,
   type FrontendBrowser,
   FrontendBrowserImpl,
   type FrontendBrowserWindow,

--- a/packages/context/src/testHelpers/FakeFrontendBrowser.test.ts
+++ b/packages/context/src/testHelpers/FakeFrontendBrowser.test.ts
@@ -42,4 +42,20 @@ describe('FakeFrontendBrowser', () => {
     expect(browser.clearedTimeoutIds).toEqual([1]);
     expect(fired).toBe(false);
   });
+
+  it('records beforeunload guards and triggers fake prevented unload events', () => {
+    const browser = new FakeFrontendBrowser();
+
+    const cleanup = browser.addBeforeUnloadGuard();
+
+    expect(browser.activeBeforeUnloadGuardIds).toEqual([1]);
+    expect(browser.isBeforeUnloadGuarded()).toBe(true);
+    expect(browser.triggerBeforeUnload()).toMatchObject({ defaultPrevented: true, returnValue: '' });
+
+    cleanup();
+
+    expect(browser.removedBeforeUnloadGuardIds).toEqual([1]);
+    expect(browser.isBeforeUnloadGuarded()).toBe(false);
+    expect(browser.triggerBeforeUnload()).toMatchObject({ defaultPrevented: false, returnValue: 'unset' });
+  });
 });

--- a/packages/context/src/testHelpers/FakeFrontendBrowser.test.ts
+++ b/packages/context/src/testHelpers/FakeFrontendBrowser.test.ts
@@ -45,17 +45,24 @@ describe('FakeFrontendBrowser', () => {
 
   it('records beforeunload guards and triggers fake prevented unload events', () => {
     const browser = new FakeFrontendBrowser();
+    let attemptedUnloadCalls = 0;
 
-    const cleanup = browser.addBeforeUnloadGuard();
+    const cleanup = browser.addBeforeUnloadGuard({
+      onAttemptedUnload: () => {
+        attemptedUnloadCalls += 1;
+      },
+    });
 
     expect(browser.activeBeforeUnloadGuardIds).toEqual([1]);
     expect(browser.isBeforeUnloadGuarded()).toBe(true);
     expect(browser.triggerBeforeUnload()).toMatchObject({ defaultPrevented: true, returnValue: '' });
+    expect(attemptedUnloadCalls).toBe(1);
 
     cleanup();
 
     expect(browser.removedBeforeUnloadGuardIds).toEqual([1]);
     expect(browser.isBeforeUnloadGuarded()).toBe(false);
     expect(browser.triggerBeforeUnload()).toMatchObject({ defaultPrevented: false, returnValue: 'unset' });
+    expect(attemptedUnloadCalls).toBe(1);
   });
 });

--- a/packages/context/src/testHelpers/FakeFrontendBrowser.ts
+++ b/packages/context/src/testHelpers/FakeFrontendBrowser.ts
@@ -6,6 +6,11 @@ export interface ScheduledFakeTimeout {
   readonly handler: () => void;
 }
 
+export interface FakeBeforeUnloadEvent {
+  readonly defaultPrevented: boolean;
+  readonly returnValue: string;
+}
+
 export interface FakeFrontendBrowserOptions {
   readonly closeWindow?: () => void;
   readonly timers?: 'manual' | 'real';
@@ -14,12 +19,15 @@ export interface FakeFrontendBrowserOptions {
 export class FakeFrontendBrowser implements FrontendBrowser {
   readonly scheduledTimeouts: ScheduledFakeTimeout[] = [];
   readonly clearedTimeoutIds: number[] = [];
+  readonly activeBeforeUnloadGuardIds: number[] = [];
+  readonly removedBeforeUnloadGuardIds: number[] = [];
 
   closeWindowCallCount = 0;
 
   readonly #closeWindow: () => void;
   readonly #timers: 'manual' | 'real';
   #nextTimeoutId = 1;
+  #nextBeforeUnloadGuardId = 1;
 
   constructor(options: FakeFrontendBrowserOptions = {}) {
     const { closeWindow = () => {}, timers = 'manual' } = options;
@@ -48,6 +56,27 @@ export class FakeFrontendBrowser implements FrontendBrowser {
     };
   }
 
+  addBeforeUnloadGuard(): () => void {
+    const id = this.#nextBeforeUnloadGuardId;
+    this.#nextBeforeUnloadGuardId += 1;
+    this.activeBeforeUnloadGuardIds.push(id);
+    return () => {
+      this.#removeBeforeUnloadGuard(id);
+    };
+  }
+
+  isBeforeUnloadGuarded(): boolean {
+    return this.activeBeforeUnloadGuardIds.length > 0;
+  }
+
+  triggerBeforeUnload(): FakeBeforeUnloadEvent {
+    const defaultPrevented = this.isBeforeUnloadGuarded();
+    return {
+      defaultPrevented,
+      returnValue: defaultPrevented ? '' : 'unset',
+    };
+  }
+
   clearTimeout(timeoutId: number): void {
     this.clearedTimeoutIds.push(timeoutId);
     const index = this.scheduledTimeouts.findIndex((timeout) => timeout.id === timeoutId);
@@ -63,6 +92,14 @@ export class FakeFrontendBrowser implements FrontendBrowser {
   runAllTimers(): void {
     while (this.scheduledTimeouts.length > 0) {
       this.advance();
+    }
+  }
+
+  #removeBeforeUnloadGuard(id: number): void {
+    this.removedBeforeUnloadGuardIds.push(id);
+    const index = this.activeBeforeUnloadGuardIds.indexOf(id);
+    if (index !== -1) {
+      this.activeBeforeUnloadGuardIds.splice(index, 1);
     }
   }
 }

--- a/packages/context/src/testHelpers/FakeFrontendBrowser.ts
+++ b/packages/context/src/testHelpers/FakeFrontendBrowser.ts
@@ -1,4 +1,4 @@
-import type { FrontendBrowser, TimeoutCancel } from '../FrontendBrowserImpl.ts';
+import type { BeforeUnloadGuardOptions, FrontendBrowser, TimeoutCancel } from '../FrontendBrowserImpl.ts';
 
 export interface ScheduledFakeTimeout {
   readonly id: number;
@@ -16,6 +16,11 @@ export interface FakeFrontendBrowserOptions {
   readonly timers?: 'manual' | 'real';
 }
 
+interface ActiveBeforeUnloadGuard {
+  readonly id: number;
+  readonly onAttemptedUnload: (() => void) | undefined;
+}
+
 export class FakeFrontendBrowser implements FrontendBrowser {
   readonly scheduledTimeouts: ScheduledFakeTimeout[] = [];
   readonly clearedTimeoutIds: number[] = [];
@@ -26,6 +31,7 @@ export class FakeFrontendBrowser implements FrontendBrowser {
 
   readonly #closeWindow: () => void;
   readonly #timers: 'manual' | 'real';
+  readonly #beforeUnloadGuards: ActiveBeforeUnloadGuard[] = [];
   #nextTimeoutId = 1;
   #nextBeforeUnloadGuardId = 1;
 
@@ -56,10 +62,12 @@ export class FakeFrontendBrowser implements FrontendBrowser {
     };
   }
 
-  addBeforeUnloadGuard(): () => void {
+  addBeforeUnloadGuard(options: BeforeUnloadGuardOptions = {}): () => void {
+    const { onAttemptedUnload } = options;
     const id = this.#nextBeforeUnloadGuardId;
     this.#nextBeforeUnloadGuardId += 1;
     this.activeBeforeUnloadGuardIds.push(id);
+    this.#beforeUnloadGuards.push({ id, onAttemptedUnload });
     return () => {
       this.#removeBeforeUnloadGuard(id);
     };
@@ -71,6 +79,12 @@ export class FakeFrontendBrowser implements FrontendBrowser {
 
   triggerBeforeUnload(): FakeBeforeUnloadEvent {
     const defaultPrevented = this.isBeforeUnloadGuarded();
+    if (defaultPrevented) {
+      for (const guard of this.#beforeUnloadGuards) {
+        guard.onAttemptedUnload?.();
+      }
+    }
+
     return {
       defaultPrevented,
       returnValue: defaultPrevented ? '' : 'unset',
@@ -100,6 +114,11 @@ export class FakeFrontendBrowser implements FrontendBrowser {
     const index = this.activeBeforeUnloadGuardIds.indexOf(id);
     if (index !== -1) {
       this.activeBeforeUnloadGuardIds.splice(index, 1);
+    }
+
+    const guardIndex = this.#beforeUnloadGuards.findIndex((guard) => guard.id === id);
+    if (guardIndex !== -1) {
+      this.#beforeUnloadGuards.splice(guardIndex, 1);
     }
   }
 }

--- a/packages/context/src/testHelpers/index.ts
+++ b/packages/context/src/testHelpers/index.ts
@@ -2,6 +2,7 @@ export { fakeBaseContext } from './fakeBaseContext.ts';
 export { fakeFrontendContext } from './fakeFrontendContext.ts';
 export { type FakeFetchCall, FakeFetcher } from './FakeFetcher.ts';
 export {
+  type FakeBeforeUnloadEvent,
   FakeFrontendBrowser,
   type FakeFrontendBrowserOptions,
   type ScheduledFakeTimeout,


### PR DESCRIPTION
## Summary

Adds a custom close-review dialog when a user attempts to leave an unsubmitted annotation review. The dialog now recommends approving an empty review or submitting existing feedback, while keeping the browser beforeunload guard in place.

### No comments

<img width="364" height="246" alt="Screenshot 2026-05-20 at 09 55 44" src="https://github.com/user-attachments/assets/fbe89788-3bc2-45fc-87c7-edb439f676ca" />

### With comments

<img width="394" height="305" alt="Screenshot 2026-05-20 at 09 56 07" src="https://github.com/user-attachments/assets/d7595eb2-1bc9-4f33-9218-b24f2162586b" />

## Review focus

Please look closely at the `FrontendBrowser.addBeforeUnloadGuard` callback shape and whether triggering React dialog state from the beforeunload path is the right API boundary.

## Commits

- [`75f4d32`](https://github.com/contextbridge/planbridge/commit/75f4d32) — prompt before closing annotation review
