### PR TITLE
build: clean up just verify warnings

### DIFF
--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -20,8 +20,7 @@
 @import '@fontsource/ibm-plex-mono/700.css';
 
 /* Tailwind auto-detection skips workspace packages resolved through node_modules.
-   Explicitly register this package's components so shadcn utility classes are emitted.
-   Must sit after all `@import` rules to satisfy PostCSS @import-ordering. */
+   Explicitly register this package's components so shadcn utility classes are emitted. */
 @source "./components/**/*.{ts,tsx}";
 
 /* ESBuild — brand wordmark font. Relative URLs so Vite processes and inlines

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -6,10 +6,6 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
-/* Tailwind auto-detection skips workspace packages resolved through node_modules.
-   Explicitly register this package's components so shadcn utility classes are emitted. */
-@source "./components/**/*.{ts,tsx}";
-
 /* IBM Plex Sans — prose + chrome (loaded via @fontsource, bundled by Vite). */
 @import '@fontsource/ibm-plex-sans/400.css';
 @import '@fontsource/ibm-plex-sans/400-italic.css';
@@ -22,6 +18,11 @@
 @import '@fontsource/ibm-plex-mono/500.css';
 @import '@fontsource/ibm-plex-mono/600.css';
 @import '@fontsource/ibm-plex-mono/700.css';
+
+/* Tailwind auto-detection skips workspace packages resolved through node_modules.
+   Explicitly register this package's components so shadcn utility classes are emitted.
+   Must sit after all `@import` rules to satisfy PostCSS @import-ordering. */
+@source "./components/**/*.{ts,tsx}";
 
 /* ESBuild — brand wordmark font. Relative URLs so Vite processes and inlines
    them for the single-file bundle (public/ dir does not exist inside a lib). */

--- a/packages/website/src/content/docs/404.md
+++ b/packages/website/src/content/docs/404.md
@@ -1,0 +1,15 @@
+---
+title: Page not found
+template: splash
+editUrl: false
+hero:
+  tagline: That URL does not exist on this site.
+  actions:
+    - text: Quickstart
+      link: /quickstart/
+      variant: primary
+      icon: right-arrow
+    - text: CLI reference
+      link: /cli/
+      variant: secondary
+---


### PR DESCRIPTION
## Summary

`just verify` was emitting 10 warnings across two unrelated sources. Both are now silent in the build log and tests/typecheck/lint stay green. One known route-priority warning remains from Starlight (see Review focus).

## Related

CloudFront `CustomErrorResponses` are currently unset on `plan.contextbridge.ai`, so without an accompanying infra change the new `/404.html` is dead weight — users still get the S3 `<Error><Code>AccessDenied</Code>...` XML on missing URLs. Companion PR wires the CloudFront error responses: https://github.com/contextbridge/planbridge-private/pull/25. Land both together.

## Review focus

The Starlight 404 fix is a trade. Creating `packages/website/src/content/docs/404.md` resolves Starlight's `getEntry('docs', '404')` lookup (silences the `Entry docs → 404 was not found` warning that fired every build) and gives users a real 404 page instead of the i18n fallback. But it surfaces a different, benign warning:

```
[WARN] [build] Could not render `/404` from route `/[...slug]` as it conflicts with higher priority route `/404`.
```

Starlight's dynamic `[...slug]` catch-all enumerates `/404` from the new content entry, and Astro's static `/404` route wins on priority — which is what we want. The warning is Astro correctly noting it picked the static route. The only way to silence it without inventing a `src/pages/404.astro` page is `draft: true`, which renders a visible "This content is a draft" banner in dev — worse trade.

I picked the version with the harmless one-line build warning over the version with the visible dev-mode banner. Happy to move to `src/pages/404.astro` if you want zero warnings.

## Commits

- [`27635f3`](https://github.com/contextbridge/planbridge/commit/27635f3) — build: clean up just verify warnings