### PR TITLE
refactor: extract user-visible copy into colocated constants

### DIFF
--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -8,7 +8,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { annotatedMarkdownTestIds } from './AnnotatedMarkdown.tsx';
 import { annotationPopoverTestIds } from './AnnotationPopover.tsx';
-import { appTestIds } from './App.tsx';
+import { appCopy, appTestIds } from './App.tsx';
 import { globalCommentComposerTestIds } from './GlobalCommentComposer.tsx';
 import { submitBarTestIds } from './SubmitBar.tsx';
 import { drag, pressSubmitShortcut, renderApp } from './testHelpers/index.tsx';
@@ -45,7 +45,7 @@ describe('App', () => {
   it('shows an empty state when the plan content is blank', () => {
     renderApp({ initialPayload: { contentKind: 'plan', content: '' } });
 
-    expect(screen.getByTestId(appTestIds.emptyState)).toHaveTextContent('No content was provided.');
+    expect(screen.getByTestId(appTestIds.emptyState)).toHaveTextContent(appCopy.emptyState);
   });
 
   it('renders the update-notice card when /update-notice resolves with a notice', async () => {
@@ -170,11 +170,12 @@ describe('App', () => {
     const dialog = await screen.findByTestId(appTestIds.closeReviewDialog);
     expect(dialog).toHaveTextContent(closeReviewDialogCopy.empty.title);
     expect(dialog).toHaveTextContent(closeReviewDialogCopy.empty.description);
-    expect(screen.getByTestId(appTestIds.closeReviewDialogCancelButton)).toHaveTextContent('Keep Reviewing');
+    expect(screen.getByTestId(appTestIds.closeReviewDialogCancelButton)).toHaveTextContent(
+      closeReviewDialogCopy.cancelLabel,
+    );
     expect(screen.getByTestId(appTestIds.closeReviewDialogActionButton)).toHaveTextContent(
       closeReviewDialogCopy.empty.primaryActionLabel,
     );
-    expect(dialog).not.toHaveTextContent('Close Anyway');
 
     await user.click(screen.getByTestId(appTestIds.closeReviewDialogCancelButton));
 
@@ -198,11 +199,12 @@ describe('App', () => {
     const dialog = await screen.findByTestId(appTestIds.closeReviewDialog);
     expect(dialog).toHaveTextContent(closeReviewDialogCopy.feedback.title);
     expect(dialog).toHaveTextContent(closeReviewDialogCopy.feedback.description);
-    expect(screen.getByTestId(appTestIds.closeReviewDialogCancelButton)).toHaveTextContent('Keep Reviewing');
+    expect(screen.getByTestId(appTestIds.closeReviewDialogCancelButton)).toHaveTextContent(
+      closeReviewDialogCopy.cancelLabel,
+    );
     expect(screen.getByTestId(appTestIds.closeReviewDialogActionButton)).toHaveTextContent(
       closeReviewDialogCopy.feedback.primaryActionLabel,
     );
-    expect(dialog).not.toHaveTextContent('Close Anyway');
 
     await user.click(screen.getByTestId(appTestIds.closeReviewDialogActionButton));
 

--- a/packages/annotation/src/App.tsx
+++ b/packages/annotation/src/App.tsx
@@ -37,6 +37,10 @@ export const appTestIds = {
   closeReviewDialogActionButton: 'plan-review-close-review-dialog-action',
 };
 
+export const appCopy = {
+  emptyState: 'No content was provided.',
+} as const;
+
 export interface AppProps {
   initialPayload?: AnnotationPayload;
   initialThreads?: CommentThread[];
@@ -131,7 +135,7 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
                     className="rounded-md border border-dashed border-border px-4 py-8 text-sm text-muted-foreground"
                     data-testid={appTestIds.emptyState}
                   >
-                    No content was provided.
+                    {appCopy.emptyState}
                   </div>
                 )}
               </section>
@@ -220,7 +224,7 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
                 </AlertDialogHeader>
                 <AlertDialogFooter>
                   <AlertDialogCancel data-testid={appTestIds.closeReviewDialogCancelButton}>
-                    Keep Reviewing
+                    {reviewState.closeReview.cancelLabel}
                   </AlertDialogCancel>
                   <AlertDialogAction
                     data-testid={appTestIds.closeReviewDialogActionButton}

--- a/packages/annotation/src/UpdateNoticeCard.test.tsx
+++ b/packages/annotation/src/UpdateNoticeCard.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createFakeAppContext } from './testHelpers/createFakeAppContext.ts';
-import { UpdateNoticeCard, updateNoticeCardTestIds } from './UpdateNoticeCard.tsx';
+import { UpdateNoticeCard, updateNoticeCardCopy, updateNoticeCardTestIds } from './UpdateNoticeCard.tsx';
 import { AnnotationAppContext } from './useAppContext.ts';
 
 const NOTICE: UpdateNotice = {
@@ -31,10 +31,10 @@ describe('UpdateNoticeCard', () => {
     renderCard();
     const container = screen.getByTestId(updateNoticeCardTestIds.container);
     expect(container).toBeInTheDocument();
-    expect(container).toHaveTextContent('Update available: v0.2.0');
-    expect(container).toHaveTextContent("You're on v0.1.0");
-    expect(container).toHaveTextContent('Run to upgrade');
-    expect(container).toHaveTextContent('contextbridge update');
+    expect(container).toHaveTextContent(`${updateNoticeCardCopy.titlePrefix} v0.2.0`);
+    expect(container).toHaveTextContent(`${updateNoticeCardCopy.currentVersionPrefix}0.1.0`);
+    expect(container).toHaveTextContent(updateNoticeCardCopy.currentVersionSuffix);
+    expect(container).toHaveTextContent(updateNoticeCardCopy.updateCommand);
   });
 
   it('fires update_notice_viewed analytics on first render', () => {

--- a/packages/annotation/src/UpdateNoticeCard.tsx
+++ b/packages/annotation/src/UpdateNoticeCard.tsx
@@ -6,7 +6,14 @@ import { Sparkles, X } from 'lucide-react';
 import { useEffect } from 'react';
 import { useAnnotationAppContext } from './useAppContext.ts';
 
-const UPDATE_COMMAND = 'contextbridge update';
+export const updateNoticeCardCopy = {
+  titlePrefix: 'Update available:',
+  currentVersionPrefix: "You're on v",
+  currentVersionSuffix: '. Run to upgrade:',
+  updateCommand: 'contextbridge update',
+  copyButtonLabel: 'Copy command',
+  dismissAriaLabel: 'Dismiss update notice',
+} as const;
 
 export const updateNoticeCardTestIds = {
   container: 'update-notice-card',
@@ -29,7 +36,7 @@ export function UpdateNoticeCard({ notice, onDismiss }: UpdateNoticeCardProps) {
 
   const handleCopy = () => {
     analytics.capture('update_command_copied', { latest_version: notice.latestVersion });
-    void navigator.clipboard.writeText(UPDATE_COMMAND).catch(() => {});
+    void navigator.clipboard.writeText(updateNoticeCardCopy.updateCommand).catch(() => {});
   };
 
   const handleDismiss = () => {
@@ -46,7 +53,7 @@ export function UpdateNoticeCard({ notice, onDismiss }: UpdateNoticeCardProps) {
       <Alert data-testid={updateNoticeCardTestIds.container} className="relative py-2.5 pr-8 shadow-lg">
         <Sparkles className="size-3.5" />
         <AlertTitle className="text-xs font-medium">
-          Update available:{' '}
+          {updateNoticeCardCopy.titlePrefix}{' '}
           <a
             href={`${GITHUB_REPO_URL}/releases/tag/v${notice.latestVersion}`}
             target="_blank"
@@ -59,17 +66,21 @@ export function UpdateNoticeCard({ notice, onDismiss }: UpdateNoticeCardProps) {
           </a>
         </AlertTitle>
         <AlertDescription className="text-muted-foreground text-xs">
-          You&apos;re on v{notice.currentVersion}. Run to upgrade:
+          {updateNoticeCardCopy.currentVersionPrefix}
+          {notice.currentVersion}
+          {updateNoticeCardCopy.currentVersionSuffix}
         </AlertDescription>
         <div className="col-start-2 mt-1.5 flex items-center gap-1.5">
-          <code className="bg-muted flex-1 truncate rounded px-1.5 py-0.5 font-mono text-xs">{UPDATE_COMMAND}</code>
+          <code className="bg-muted flex-1 truncate rounded px-1.5 py-0.5 font-mono text-xs">
+            {updateNoticeCardCopy.updateCommand}
+          </code>
           <Button
             size="sm"
             className="h-6 px-2 text-xs"
             onClick={handleCopy}
             data-testid={updateNoticeCardTestIds.copyButton}
           >
-            Copy command
+            {updateNoticeCardCopy.copyButtonLabel}
           </Button>
         </div>
         <Button
@@ -78,7 +89,7 @@ export function UpdateNoticeCard({ notice, onDismiss }: UpdateNoticeCardProps) {
           className="text-muted-foreground hover:text-foreground absolute top-1 right-1 size-5"
           onClick={handleDismiss}
           data-testid={updateNoticeCardTestIds.dismissButton}
-          aria-label="Dismiss update notice"
+          aria-label={updateNoticeCardCopy.dismissAriaLabel}
         >
           <X className="size-3" />
         </Button>

--- a/packages/annotation/src/useAnnotationState.ts
+++ b/packages/annotation/src/useAnnotationState.ts
@@ -270,6 +270,7 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
       dialogOpen: closeReviewDialogOpen,
       dismissDialog: dismissCloseReviewDialog,
       confirmRecommendedAction: confirmCloseReviewRecommendedAction,
+      cancelLabel: closeReviewDialogCopy.cancelLabel,
       ...closeReviewDialogContent,
     },
     removal: {
@@ -295,6 +296,7 @@ function getFeedbackCount(threads: CommentThread[], trimmedGlobal: string): numb
 }
 
 export const closeReviewDialogCopy = {
+  cancelLabel: 'Keep Reviewing',
   empty: {
     title: 'Approve plan before closing?',
     description:


### PR DESCRIPTION
## Summary

Aligns three existing UI surfaces with the test-copy-constants rule introduced in #188 (`.claude/rules/test-copy-constants.md`): `UpdateNoticeCard` text, the close-review dialog's "Keep Reviewing" cancel label, and the empty-state notice now flow through exported `xxxCopy` objects that the corresponding tests import. Also removes two stale `not.toHaveTextContent('Close Anyway')` assertions whose target string never existed in source.

## Review focus

The cancel label is shared by both close-review variants, so I added it as a top-level `closeReviewDialogCopy.cancelLabel` and surfaced it on the hook's `closeReview` return object alongside the variant-driven `title` / `description` / `primaryActionLabel`. The alternative was importing `closeReviewDialogCopy` directly in `App.tsx` and bypassing the hook for the static piece — I went with the hook to keep all dialog copy flowing through one seam, but it's worth a sanity check.

## Commits

- [`a3ce14e`](https://github.com/contextbridge/planbridge/commit/a3ce14eadc16a7d94bd760435faca4dc6788a72a) — refactor: extract user-visible copy into colocated constants