### PR TITLE
chore: group drizzle-orm and drizzle-kit in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,5 +32,10 @@ updates:
     ignore:
       - dependency-name: "@types/bun"
     groups:
+      # drizzle-orm and drizzle-kit must stay in lockstep on the same beta version.
+      # Once Drizzle 1.x is released from beta, we can remove this group.
+      drizzle:
+        patterns: ["drizzle-orm", "drizzle-kit"]
       npm-minor-patch:
         update-types: ["minor", "patch"]
+        exclude-patterns: ["drizzle-orm", "drizzle-kit"]


### PR DESCRIPTION
## Summary

Adds a `drizzle` group to `.github/dependabot.yml` so `drizzle-orm` and `drizzle-kit` bump together in a single PR. They ship from the same `drizzle-team/drizzle-orm` monorepo and must stay in lockstep on the same beta version; without the group, Dependabot opens separate PRs (e.g. #201 + #202) that have to be landed together by hand. Mirrors cb-bot's dependabot config.

## Review focus

`npm-minor-patch` also gains `exclude-patterns: ["drizzle-orm", "drizzle-kit"]`. Without that, a future drizzle minor/patch bump could land in `npm-minor-patch` instead of the `drizzle` group depending on group-ordering, defeating the lockstep guarantee. This only affects future Dependabot runs — it does not retroactively combine existing PRs.

## Commits

- [`a61af43`](https://github.com/contextbridge/planbridge/commit/a61af43) — chore: group drizzle-orm and drizzle-kit in dependabot
