### PR TITLE
docs(website): highlight the three PlanBridge use cases across site and docs

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,12 +1,26 @@
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 
-[sandbox_workspace_write]
-network_access = true
-writable_roots = ["~/.bun/install/cache"]
+[mcp_servers.chrome-devtools]
+args = [
+    "-y",
+    "chrome-devtools-mcp@latest",
+    "--isolated",
+]
+command = "npx"
+
+[mcp_servers.chrome-devtools.tools.lighthouse_audit]
+approval_mode = "approve"
 
 [mcp_servers.linear]
 url = "https://mcp.linear.app/mcp"
 
+[mcp_servers.outline]
+url = "https://contextbridge.getoutline.com/mcp"
+
 [mcp_servers.sentry]
 url = "https://mcp.sentry.dev/mcp"
+
+[sandbox_workspace_write]
+network_access = true
+writable_roots = ["~/.bun/install/cache"]

--- a/bun.lock
+++ b/bun.lock
@@ -268,6 +268,7 @@
         "motion": "^12.38.0",
         "react": "catalog:",
         "react-dom": "catalog:",
+        "rehype-external-links": "^3.0.0",
         "sharp": "^0.34.0",
         "starlight-llms-txt": "^0.10.0",
       },
@@ -1848,6 +1849,8 @@
 
     "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
 
+    "is-absolute-url": ["is-absolute-url@4.0.1", "", {}, "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A=="],
+
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
@@ -2431,6 +2434,8 @@
     "rehype": ["rehype@13.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "rehype-parse": "^9.0.0", "rehype-stringify": "^10.0.0", "unified": "^11.0.0" } }, "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A=="],
 
     "rehype-expressive-code": ["rehype-expressive-code@0.41.7", "", { "dependencies": { "expressive-code": "^0.41.7" } }, "sha512-25f8ZMSF1d9CMscX7Cft0TSQIqdwjce2gDOvQ+d/w0FovsMwrSt3ODP4P3Z7wO1jsIJ4eYyaDRnIR/27bd/EMQ=="],
+
+    "rehype-external-links": ["rehype-external-links@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-is-element": "^3.0.0", "is-absolute-url": "^4.0.0", "space-separated-tokens": "^2.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw=="],
 
     "rehype-format": ["rehype-format@5.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-format": "^1.0.0" } }, "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ=="],
 

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig, fontProviders } from 'astro/config';
 import expressiveCode from 'astro-expressive-code';
 import icon from 'astro-icon';
+import rehypeExternalLinks from 'rehype-external-links';
 import starlightLlmsTxt from 'starlight-llms-txt';
 
 export default defineConfig({
@@ -18,6 +19,9 @@ export default defineConfig({
   image: {
     responsiveStyles: true,
     layout: 'constrained',
+  },
+  markdown: {
+    rehypePlugins: [[rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] }]],
   },
   fonts: [
     {
@@ -147,13 +151,22 @@ export default defineConfig({
             { label: 'Overview', slug: 'usage' },
             { label: 'Claude Code', slug: 'usage/claude-code' },
             { label: 'Codex CLI', slug: 'usage/codex' },
-            { label: 'Open arbitrary content', slug: 'usage/open' },
+            { label: 'Plan-mode collaboration', slug: 'usage/plan-mode' },
+            { label: 'Precision feedback on a file', slug: 'usage/open' },
+            { label: 'Annotate last message', slug: 'usage/last' },
             { label: 'Other agents', slug: 'usage/other-agents' },
           ],
         },
         {
           label: 'Recipes',
-          items: [{ label: 'Superpowers', slug: 'recipes/superpowers' }],
+          items: [
+            { label: 'Superpowers', slug: 'recipes/superpowers' },
+            { label: 'Spec Kit', slug: 'recipes/spec-kit' },
+            { label: 'Spec Kitty', slug: 'recipes/spec-kitty' },
+            { label: 'OpenSpec', slug: 'recipes/openspec' },
+            { label: 'BMAD Method', slug: 'recipes/bmad' },
+            { label: 'Agent OS', slug: 'recipes/agent-os' },
+          ],
         },
         {
           label: 'About',

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -28,6 +28,7 @@
     "motion": "^12.38.0",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "rehype-external-links": "^3.0.0",
     "sharp": "^0.34.0",
     "starlight-llms-txt": "^0.10.0"
   },

--- a/packages/website/src/components/DataPrivacy.astro
+++ b/packages/website/src/components/DataPrivacy.astro
@@ -4,7 +4,7 @@ import { Icon } from 'astro-icon/components';
 const flowSteps = [
   {
     icon: 'lucide:file-text',
-    title: 'Plan markdown',
+    title: 'Markdown in',
     body: 'stdin or local file',
   },
   {
@@ -26,7 +26,7 @@ const flowSteps = [
 
 const trustSignals = [
   { icon: 'lucide:monitor', label: 'Localhost UI' },
-  { icon: 'lucide:cloud-off', label: 'No plan upload' },
+  { icon: 'lucide:cloud-off', label: 'No content upload' },
   { icon: 'lucide:user-round-x', label: 'No account' },
   { icon: 'lucide:badge-check', label: 'MIT licensed' },
   { icon: 'lucide:code-2', label: 'Public source' },
@@ -40,7 +40,7 @@ const trustSignals = [
       <div class="bg-background p-8 md:p-12 lg:p-14">
         <p class="font-mono text-base font-bold uppercase tracking-[0.16em] text-foreground">Data Privacy</p>
         <h2 class="mt-8 font-medium leading-[1.0] tracking-tight text-foreground text-[36px] sm:text-[64px]">
-          Your plan stays on your machine.
+          Your content stays on your machine.
         </h2>
         <p class="mt-8 font-sans text-lg leading-relaxed text-foreground sm:text-xl">
           PlanBridge opens a local browser review UI and returns markdown to your agent. There is no remote PlanBridge
@@ -61,7 +61,7 @@ const trustSignals = [
         </h3>
         <p class="m-0 mt-4 max-w-3xl font-sans text-base leading-relaxed text-foreground">
           A local browser window gives you review ergonomics without putting PlanBridge between your agent and your
-          plan.
+          content.
         </p>
       </div>
 

--- a/packages/website/src/components/Faq.astro
+++ b/packages/website/src/components/Faq.astro
@@ -4,7 +4,7 @@ const GITHUB_URL = 'https://github.com/contextbridge/planbridge';
 const faqs = [
   {
     question: 'How does PlanBridge work?',
-    answer: `PlanBridge opens your coding agent's plan as rendered markdown in a local browser. You select the lines that need work, comment inline, and the agent revises with your feedback before writing any code. See the <a href="/quickstart/" class="underline underline-offset-4">docs</a> or the <a href="${GITHUB_URL}" target="_blank" rel="noopener noreferrer" class="underline underline-offset-4">source on GitHub</a>.`,
+    answer: `PlanBridge opens markdown in a local browser where you highlight lines and comment, then your agent acts on your feedback. There are three ways it works. <strong>Plan-mode collaboration:</strong> when your agent finishes a plan, PlanBridge opens automatically in Claude Code or Codex. <strong>Precision feedback on a file:</strong> open any markdown file with <code class="font-mono">/planbridge-open</code> (Claude Code) or <code class="font-mono">$planbridge-open</code> (Codex). <strong>Annotate the last message:</strong> mark up your agent's last reply with <code class="font-mono">/planbridge-last</code> or <code class="font-mono">$planbridge-last</code>. See the <a href="/quickstart/" class="underline underline-offset-4">docs</a> or the <a href="${GITHUB_URL}" target="_blank" rel="noopener noreferrer" class="underline underline-offset-4">source on GitHub</a>.`,
   },
   {
     question: 'What coding agents does this work with?',
@@ -14,7 +14,7 @@ const faqs = [
   {
     question: 'Can I open a file in PlanBridge without going through plan mode?',
     answer:
-      'Yes. The <code class="font-mono">planbridge-open</code> skill opens any markdown file in the PlanBridge UI on demand. Use <code class="font-mono">planbridge-last</code> to annotate the agent&apos;s previous message. See <a href="/usage/open/" class="underline underline-offset-4">Open arbitrary content</a>.',
+      'Yes. The <code class="font-mono">planbridge-open</code> skill opens any markdown file in the PlanBridge UI on demand (<a href="/usage/open/" class="underline underline-offset-4">Precision feedback on a file</a>). Use <code class="font-mono">planbridge-last</code> to annotate the agent&apos;s previous message (<a href="/usage/last/" class="underline underline-offset-4">Annotate the last message</a>).',
   },
   {
     question: 'Does PlanBridge take over my agent workflow?',
@@ -32,7 +32,7 @@ const faqs = [
   {
     question: 'Why did you build this?',
     answer:
-      "Coding agents are optimized for chat, not review. They give you one text input for every revision, so you can't anchor comments to specific lines. Iteration friction wears you down and plans ship less refined than they could be. PlanBridge gives plans the same review experience developers expect from code review.",
+      "Coding agents are optimized for chat, not review. They give you one text input for every revision, so you can't anchor comments to specific lines. That friction wears you down, and what ships is less refined than it could be. PlanBridge gives anything your agent writes the same review experience developers expect from code review, whether it's a plan, a file you open, or the agent's last message.",
   },
   {
     question: 'Where can I request features?',

--- a/packages/website/src/components/Hero.astro
+++ b/packages/website/src/components/Hero.astro
@@ -19,14 +19,13 @@ import InstallCommand from './InstallCommand.astro';
 
   <div class="relative z-10 mx-auto max-w-7xl">
     <h1
-      class="m-0 text-balance font-medium leading-[1.0] tracking-tight text-foreground text-[40px] sm:text-[48px] lg:text-[64px]"
+      class="m-0 font-medium text-balance leading-[1.0] tracking-tight text-foreground text-[40px] sm:text-[48px] lg:text-[64px]"
     >
-      Better code with inline comments on your coding agent plans
+      Give precision feedback on every spec, plan, or message your coding agent writes
     </h1>
 
     <p class="mb-0 mt-6 max-w-4xl text-balance font-sans text-xl leading-8 text-foreground">
-      PlanBridge opens your agent's plan in a local browser, so you can highlight text and comment like you would in a
-      document. It fits into your existing workflow, uses standard hooks, and uninstalls easily if you change your mind.
+      Select text & comment on rendered markdown in a local browser so your agent can act with precision
     </p>
 
     <div class="mt-8 inline-flex max-w-full flex-col">

--- a/packages/website/src/components/IntegrationCards.astro
+++ b/packages/website/src/components/IntegrationCards.astro
@@ -32,7 +32,10 @@ import InstallActions from './InstallActions.astro';
         />
         <div>
           <h3 class="font-mono text-2xl font-bold tracking-tight">Claude Code</h3>
-          <p class="mt-2 font-sans text-base">Claude plugin hook on ExitPlanMode.</p>
+          <p class="mt-2 font-sans text-base">
+            Plugin hook on ExitPlanMode, plus the <code class="font-mono">/planbridge-open</code> and{' '}
+            <code class="font-mono">/planbridge-last</code> skills.
+          </p>
         </div>
       </a>
       <a
@@ -50,7 +53,10 @@ import InstallActions from './InstallActions.astro';
         />
         <div>
           <h3 class="font-mono text-2xl font-bold tracking-tight">Codex</h3>
-          <p class="mt-2 font-sans text-base">Codex Stop hook entry.</p>
+          <p class="mt-2 font-sans text-base">
+            Stop hook entry, plus the <code class="font-mono">$planbridge-open</code> and{' '}
+            <code class="font-mono">$planbridge-last</code> skills.
+          </p>
         </div>
       </a>
     </div>
@@ -63,7 +69,13 @@ import InstallActions from './InstallActions.astro';
 
     <p class="mt-4 font-sans text-base text-foreground">
       <a href="/usage/open/" class="text-foreground underline underline-offset-4">
-        Open files or the agent's last message manually &rarr;
+        Give feedback on a file manually &rarr;
+      </a>
+    </p>
+
+    <p class="mt-4 font-sans text-base text-foreground">
+      <a href="/usage/last/" class="text-foreground underline underline-offset-4">
+        Annotate the agent's last message &rarr;
       </a>
     </p>
 

--- a/packages/website/src/components/ReviewLoop.astro
+++ b/packages/website/src/components/ReviewLoop.astro
@@ -1,22 +1,23 @@
 ---
-import { ReviewLoopDiagram } from './ReviewLoopDiagram';
+import { UseCaseFlows } from './ReviewLoopDiagram';
 ---
 
 <section class="border-t border-foreground bg-background px-8 py-32">
   <div class="mx-auto max-w-7xl">
     <p class="font-mono text-base font-bold uppercase tracking-[0.16em] text-foreground">How it works</p>
     <h2 class="mt-8 font-medium leading-[1.0] tracking-tight text-foreground text-[40px] sm:text-[64px] lg:text-[80px]">
-      The cheapest time to fix code is before it's written.
+      How each one flows through PlanBridge.
     </h2>
 
     <p class="mt-8 max-w-3xl font-sans text-2xl leading-relaxed text-foreground">
-      Iterate on the plan first. Save the tokens and the rework.
+      Pick a use case to trace the loop. You comment, your agent acts, and the cheapest time to fix code is before it's
+      written.
     </p>
 
     <div class="mt-16 h-px w-full bg-foreground"></div>
 
     <div class="mt-16">
-      <ReviewLoopDiagram client:visible />
+      <UseCaseFlows client:visible />
     </div>
   </div>
 </section>

--- a/packages/website/src/components/ReviewLoopDiagram.tsx
+++ b/packages/website/src/components/ReviewLoopDiagram.tsx
@@ -1,9 +1,121 @@
-import { AppWindow, CheckCircle2, Code2, FileText, MessageSquare, TerminalSquare } from 'lucide-react';
+import { AppWindow, CheckCircle2, Code2, FileText, type LucideIcon, MessageSquare, TerminalSquare } from 'lucide-react';
 import { type Transition, motion, useInView, useReducedMotion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 
 const DESKTOP_LOOP_HEIGHT = 60;
 const MOBILE_LOOP_INSET = 12;
+
+export type FlowVariantId = 'plan' | 'file' | 'last';
+
+interface NodeConfig {
+  icon: LucideIcon;
+  heading: string;
+  chip: string[];
+  chipMono?: boolean;
+  description: string;
+}
+
+export interface FlowVariant {
+  id: FlowVariantId;
+  tabLabel: string;
+  input: NodeConfig;
+  pill: { icon: LucideIcon; label: string };
+  output: NodeConfig;
+}
+
+export const flowVariants: FlowVariant[] = [
+  {
+    id: 'plan',
+    tabLabel: 'Plan-mode collaboration',
+    input: { icon: TerminalSquare, heading: 'Coding Agent', chip: ['Plan mode'], description: 'Generates plan' },
+    pill: { icon: FileText, label: 'Plan' },
+    output: { icon: Code2, heading: 'Coding Agent', chip: ['Accept edits'], description: 'Implements plan' },
+  },
+  {
+    id: 'file',
+    tabLabel: 'Precision feedback on a file',
+    input: {
+      icon: FileText,
+      heading: 'You',
+      chip: ['/planbridge-open', '$planbridge-open'],
+      chipMono: true,
+      description: 'Open a file',
+    },
+    pill: { icon: FileText, label: 'File' },
+    output: { icon: Code2, heading: 'Coding Agent', chip: ['Applies notes'], description: 'Revises the file' },
+  },
+  {
+    id: 'last',
+    tabLabel: 'Annotate the last message',
+    input: {
+      icon: MessageSquare,
+      heading: 'Coding Agent',
+      chip: ['/planbridge-last', '$planbridge-last'],
+      chipMono: true,
+      description: 'Wrote a reply',
+    },
+    pill: { icon: MessageSquare, label: 'Message' },
+    output: { icon: Code2, heading: 'Coding Agent', chip: ['Revises'], description: 'Revises the reply' },
+  },
+];
+
+export function UseCaseFlows() {
+  const [activeId, setActiveId] = useState<FlowVariantId>('plan');
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const active = flowVariants.find((v) => v.id === activeId);
+
+  const onKeyDown = (event: React.KeyboardEvent, index: number) => {
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+    event.preventDefault();
+    const direction = event.key === 'ArrowRight' ? 1 : -1;
+    const nextIndex = (index + direction + flowVariants.length) % flowVariants.length;
+    const nextVariant = flowVariants[nextIndex];
+    if (!nextVariant) return;
+    setActiveId(nextVariant.id);
+    tabRefs.current[nextIndex]?.focus();
+  };
+
+  return (
+    <div>
+      <div
+        role="tablist"
+        aria-label="PlanBridge use cases"
+        className="flex flex-wrap gap-px bg-foreground border border-foreground"
+      >
+        {flowVariants.map((variant, index) => {
+          const selected = variant.id === activeId;
+          return (
+            <button
+              key={variant.id}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
+              role="tab"
+              type="button"
+              id={`flow-tab-${variant.id}`}
+              aria-selected={selected}
+              aria-controls={`flow-panel-${variant.id}`}
+              tabIndex={selected ? 0 : -1}
+              onClick={() => setActiveId(variant.id)}
+              onKeyDown={(event) => onKeyDown(event, index)}
+              className={`flex-1 whitespace-nowrap px-5 py-3 font-mono text-sm font-bold uppercase tracking-[0.12em] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-foreground ${
+                selected ? 'bg-foreground text-background' : 'bg-background text-foreground hover:bg-muted'
+              }`}
+            >
+              {variant.tabLabel}
+            </button>
+          );
+        })}
+      </div>
+
+      {active && (
+        <div role="tabpanel" id={`flow-panel-${active.id}`} aria-labelledby={`flow-tab-${active.id}`} className="mt-px">
+          <ReviewLoopDiagram key={active.id} variant={active} />
+        </div>
+      )}
+    </div>
+  );
+}
 
 interface Box {
   cx: number;
@@ -32,16 +144,16 @@ interface MobileLayout {
   midY: number;
 }
 
-export function ReviewLoopDiagram() {
+export function ReviewLoopDiagram({ variant }: { variant: FlowVariant }) {
   return (
     <div className="w-full max-w-full mx-auto border border-foreground bg-background p-8 md:p-16 overflow-hidden">
-      <DesktopDiagram />
-      <MobileDiagram />
+      <DesktopDiagram variant={variant} />
+      <MobileDiagram variant={variant} />
     </div>
   );
 }
 
-function DesktopDiagram() {
+function DesktopDiagram({ variant }: { variant: FlowVariant }) {
   const desktopRef = useRef<HTMLDivElement>(null);
   const box1Ref = useRef<HTMLDivElement>(null);
   const box2Ref = useRef<HTMLDivElement>(null);
@@ -178,7 +290,7 @@ function DesktopDiagram() {
           animate={{ opacity: target }}
           transition={fade(0.5)}
         >
-          <PlanPill />
+          <InputPill icon={variant.pill.icon} label={variant.pill.label} />
         </motion.div>
       )}
 
@@ -220,8 +332,8 @@ function DesktopDiagram() {
             ref={box1Ref}
             className="w-full max-w-[240px] bg-background border border-foreground p-8 text-center flex flex-col items-center gap-4"
           >
-            <CodingAgentIcon size="desktop" />
-            <CodingAgentBody mode="plan" size="desktop" />
+            <NodeIcon icon={variant.input.icon} />
+            <NodeBody node={variant.input} />
           </div>
         </div>
 
@@ -230,8 +342,8 @@ function DesktopDiagram() {
             ref={box2Ref}
             className="w-full max-w-[240px] bg-foreground text-background border border-foreground p-8 text-center flex flex-col items-center gap-4"
           >
-            <PlanBridgeIcon size="desktop" />
-            <PlanBridgeBody size="desktop" />
+            <PlanBridgeIcon />
+            <PlanBridgeBody />
           </div>
         </div>
 
@@ -240,8 +352,8 @@ function DesktopDiagram() {
             ref={box3Ref}
             className="w-full max-w-[240px] bg-background border border-foreground p-8 text-center flex flex-col items-center gap-4"
           >
-            <CodingAgentIcon size="desktop" implement />
-            <CodingAgentBody mode="accept" size="desktop" />
+            <NodeIcon icon={variant.output.icon} />
+            <NodeBody node={variant.output} />
           </div>
         </div>
       </div>
@@ -249,7 +361,7 @@ function DesktopDiagram() {
   );
 }
 
-function MobileDiagram() {
+function MobileDiagram({ variant }: { variant: FlowVariant }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const b1Ref = useRef<HTMLDivElement>(null);
   const b2Ref = useRef<HTMLDivElement>(null);
@@ -388,7 +500,7 @@ function MobileDiagram() {
           animate={{ opacity: target }}
           transition={fade(0.4)}
         >
-          <PlanPill />
+          <InputPill icon={variant.pill.icon} label={variant.pill.label} />
         </motion.div>
       )}
 
@@ -429,24 +541,24 @@ function MobileDiagram() {
           ref={b1Ref}
           className="bg-background border border-foreground p-6 flex flex-col items-center text-center gap-4"
         >
-          <CodingAgentIcon size="mobile" />
-          <CodingAgentBody mode="plan" size="mobile" />
+          <NodeIcon icon={variant.input.icon} />
+          <NodeBody node={variant.input} />
         </div>
 
         <div
           ref={b2Ref}
           className="bg-foreground text-background border border-foreground p-6 flex flex-col items-center text-center gap-4"
         >
-          <PlanBridgeIcon size="mobile" />
-          <PlanBridgeBody size="mobile" />
+          <PlanBridgeIcon />
+          <PlanBridgeBody />
         </div>
 
         <div
           ref={b3Ref}
           className="bg-background border border-foreground p-6 flex flex-col items-center text-center gap-4"
         >
-          <CodingAgentIcon size="mobile" implement />
-          <CodingAgentBody mode="accept" size="mobile" />
+          <NodeIcon icon={variant.output.icon} />
+          <NodeBody node={variant.output} />
         </div>
       </div>
     </div>
@@ -492,40 +604,51 @@ function fadeTrans(reduce: boolean | null) {
 
 // --- Shared visual atoms ---
 
-function CodingAgentIcon({ size, implement }: { size: 'desktop' | 'mobile'; implement?: boolean }) {
-  const iconSize = size === 'desktop' ? 'w-8 h-8' : 'w-6 h-6';
-  const Icon = implement ? Code2 : TerminalSquare;
+function NodeIcon({ icon: Icon }: { icon: LucideIcon }) {
   return (
     <div className="p-2 border border-foreground text-foreground flex-shrink-0">
-      <Icon className={iconSize} />
+      <Icon className="w-8 h-8 md:w-6 md:h-6" />
     </div>
   );
 }
 
-function CodingAgentBody({ mode }: { mode: 'plan' | 'accept'; size: 'desktop' | 'mobile' }) {
-  const label = mode === 'plan' ? 'Plan mode' : 'Accept Edits';
-  const description = mode === 'plan' ? 'Generates plan' : 'Implements plan';
+function NodeBody({ node }: { node: NodeConfig }) {
   return (
     <div>
-      <h3 className="font-mono font-bold text-foreground text-base uppercase tracking-tight">Coding Agent</h3>
+      <h3 className="font-mono font-bold text-foreground text-base uppercase tracking-tight">{node.heading}</h3>
       <div className="mt-4 flex justify-center">
-        <ModeChip>{label}</ModeChip>
+        <NodeChip lines={node.chip} mono={node.chipMono} />
       </div>
-      <p className="text-base text-foreground mt-4 font-sans">{description}</p>
+      <p className="text-base text-foreground mt-4 font-sans">{node.description}</p>
     </div>
   );
 }
 
-function PlanBridgeIcon({ size }: { size: 'desktop' | 'mobile' }) {
-  const iconSize = size === 'desktop' ? 'w-8 h-8' : 'w-6 h-6';
+function NodeChip({ lines, mono }: { lines: string[]; mono?: boolean }) {
+  return (
+    <span
+      className={`inline-flex flex-col items-center border border-foreground px-2 py-2 font-mono text-foreground ${
+        mono ? 'text-sm gap-0.5' : 'text-base uppercase tracking-[0.16em]'
+      }`}
+    >
+      {lines.map((line) => (
+        <span key={line} className="whitespace-nowrap">
+          {line}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function PlanBridgeIcon() {
   return (
     <div className="p-2 border border-background text-background flex-shrink-0">
-      <AppWindow className={iconSize} />
+      <AppWindow className="w-8 h-8 md:w-6 md:h-6" />
     </div>
   );
 }
 
-function PlanBridgeBody({ size: _size }: { size: 'desktop' | 'mobile' }) {
+function PlanBridgeBody() {
   return (
     <div>
       <h3 className="font-mono font-bold text-background text-base uppercase tracking-tight">PlanBridge</h3>
@@ -534,19 +657,11 @@ function PlanBridgeBody({ size: _size }: { size: 'desktop' | 'mobile' }) {
   );
 }
 
-function ModeChip({ children }: { children: React.ReactNode }) {
-  return (
-    <span className="inline-flex items-center border border-foreground px-2 py-2 font-mono text-base uppercase tracking-[0.16em] text-foreground">
-      {children}
-    </span>
-  );
-}
-
-function PlanPill() {
+function InputPill({ icon: Icon, label }: { icon: LucideIcon; label: string }) {
   return (
     <div className="bg-background px-4 py-2 border border-foreground flex items-center gap-2 text-foreground text-base font-mono font-bold uppercase tracking-tight">
-      <FileText className="w-4 h-4" />
-      Plan
+      <Icon className="w-4 h-4" />
+      {label}
     </div>
   );
 }
@@ -561,18 +676,14 @@ function ApprovePill() {
 }
 
 function RevisePill({ compact }: { compact?: boolean }) {
-  if (compact) {
-    return (
-      <div className="bg-background px-4 py-2 border border-foreground flex items-center gap-2 text-foreground text-base font-mono font-bold uppercase tracking-tight whitespace-nowrap">
-        <MessageSquare className="w-4 h-4" />
-        Revise
-      </div>
-    );
-  }
   return (
-    <div className="bg-background px-6 py-2 border border-foreground flex items-center gap-2 text-foreground text-base font-mono font-bold uppercase tracking-tight">
+    <div
+      className={`bg-background py-2 border border-foreground flex items-center gap-2 text-foreground text-base font-mono font-bold uppercase tracking-tight ${
+        compact ? 'px-4 whitespace-nowrap' : 'px-6'
+      }`}
+    >
       <MessageSquare className="w-4 h-4" />
-      Revise Plan
+      Revise
     </div>
   );
 }

--- a/packages/website/src/components/UseCases.astro
+++ b/packages/website/src/components/UseCases.astro
@@ -1,0 +1,115 @@
+---
+import { Icon } from 'astro-icon/components';
+import { Image } from 'astro:assets';
+import claudeCodeBadge from '../assets/brands/claude-code.svg';
+import codexCliBadge from '../assets/brands/codex-cli.png';
+
+const useCases = [
+  {
+    icon: 'lucide:clipboard-check',
+    title: 'Plan-mode collaboration',
+    body: 'PlanBridge opens automatically when your agent finishes a plan in Claude Code or Codex. Comment, then approve or send it back.',
+    badge: 'Plan mode · Automatic',
+    badgeNote: 'Using standard hooks',
+    commands: null,
+    href: '/usage/plan-mode/',
+  },
+  {
+    icon: 'lucide:file-text',
+    title: 'Precision feedback on a file',
+    body: 'Annotate any existing plan, spec, or doc on demand. Your comments come back to the agent.',
+    badge: null,
+    badgeNote: null,
+    commands: [
+      { agent: 'Claude Code', command: '/planbridge-open' },
+      { agent: 'Codex', command: '$planbridge-open' },
+    ],
+    href: '/usage/open/',
+  },
+  {
+    icon: 'lucide:message-square',
+    title: 'Annotate the last message',
+    body: 'Mark up the long answer your agent just wrote, then send your notes back inline.',
+    badge: null,
+    badgeNote: null,
+    commands: [
+      { agent: 'Claude Code', command: '/planbridge-last' },
+      { agent: 'Codex', command: '$planbridge-last' },
+    ],
+    href: '/usage/last/',
+  },
+];
+---
+
+<section class="border-t border-foreground bg-background px-8 py-24 sm:py-32">
+  <div class="mx-auto max-w-7xl">
+    <p class="font-mono text-base font-bold uppercase tracking-[0.16em] text-foreground">Use cases</p>
+    <h2 class="mt-8 font-medium leading-[1.0] tracking-tight text-foreground text-[40px] sm:text-[64px] lg:text-[80px]">
+      Three ways to use PlanBridge.
+    </h2>
+
+    <ol class="mt-16 grid list-none grid-cols-1 gap-px bg-foreground pl-0 md:grid-cols-3">
+      {
+        useCases.map((useCase, index) => (
+          <li class="flex list-none flex-col bg-background p-8">
+            <span class="font-mono text-2xl font-bold text-foreground">{String(index + 1).padStart(2, '0')}</span>
+            <div class="mt-6 flex items-center gap-4">
+              <Icon name={useCase.icon} class="h-8 w-8 flex-shrink-0 text-foreground" aria-hidden="true" />
+              <h3 class="font-mono text-2xl font-bold leading-tight text-foreground">{useCase.title}</h3>
+            </div>
+            <p class="mt-4 font-sans text-base leading-relaxed text-foreground">{useCase.body}</p>
+
+            <div class="mt-auto pt-8">
+              {useCase.commands ? (
+                <dl class="grid grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-2 border border-foreground p-4">
+                  {useCase.commands.map((entry) => (
+                    <>
+                      <dt class="flex items-center gap-2 self-center font-mono text-xs font-bold uppercase tracking-[0.12em] text-foreground">
+                        {entry.agent === 'Claude Code' ? (
+                          <Image
+                            src={claudeCodeBadge}
+                            alt=""
+                            aria-hidden="true"
+                            width={16}
+                            height={16}
+                            layout="none"
+                            class="h-4 w-4 flex-shrink-0"
+                          />
+                        ) : (
+                          <Image
+                            src={codexCliBadge}
+                            alt=""
+                            aria-hidden="true"
+                            width={16}
+                            height={16}
+                            class="h-4 w-4 flex-shrink-0 object-contain"
+                          />
+                        )}
+                        {entry.agent}
+                      </dt>
+                      <dd class="m-0 self-center font-mono text-sm font-bold text-foreground">
+                        <code class="font-mono">{entry.command}</code>
+                      </dd>
+                    </>
+                  ))}
+                </dl>
+              ) : (
+                <div class="inline-flex flex-col gap-1 border border-foreground px-4 py-3 font-mono text-foreground">
+                  <span class="text-sm font-bold uppercase tracking-[0.12em]">{useCase.badge}</span>
+                  <span class="text-xs">{useCase.badgeNote}</span>
+                </div>
+              )}
+
+              <a
+                href={useCase.href}
+                class="mt-6 inline-block font-sans text-base text-foreground underline underline-offset-4 hover:no-underline"
+              >
+                Read the docs &rarr;
+              </a>
+            </div>
+          </li>
+        ))
+      }
+    </ol>
+  </div>
+</section>

--- a/packages/website/src/components/ValueProps.astro
+++ b/packages/website/src/components/ValueProps.astro
@@ -2,19 +2,19 @@
 const valueProps = [
   {
     title: 'Agent UX is optimized for chat, not review',
-    body: 'Plans run hundreds of lines. Scrolling up and down to read and comment is tedious. The terminal does not anchor feedback to specific lines.',
+    body: 'A plan, a spec, or an agent message can run hundreds of lines. Scrolling up and down to read it is tedious, and the terminal gives you no way to comment on a specific line.',
   },
   {
-    title: 'One text box for all your feedback',
-    body: 'Coding agents give you a single input for every revision. PlanBridge lets you attach comments to the exact lines that need work.',
+    title: 'One text box cannot give precise feedback',
+    body: 'A single input box is a blunt way to respond to a spec, plan, or long message. PlanBridge lets you add inline comments, the most precise direction you can give.',
   },
   {
-    title: 'Less refined plans get accepted because of friction',
-    body: 'When iterating hurts, you stop early. The plan that ships is the one you tolerated, not the one you actually wanted.',
+    title: 'Less refined work gets accepted because of friction',
+    body: 'When iterating is tedious and hard, you stop early. What gets generated reflects the specificity of your feedback or the lack of it: great code, or slop that needs rework.',
   },
   {
-    title: 'Settling for a plan costs you rework and tokens',
-    body: 'Every problem missed at plan time pays twice. Once on the wrong implementation, again on the code-review thrash to fix it.',
+    title: 'Imprecision upstream costs more to fix downstream',
+    body: 'Refining hundreds of lines of markdown is a great investment compared to cleaning up thousands of lines of code slop.',
   },
 ];
 ---
@@ -23,7 +23,7 @@ const valueProps = [
   <div class="mx-auto max-w-7xl">
     <p class="font-mono text-base font-bold uppercase tracking-[0.16em] text-foreground">Why it matters</p>
     <h2 class="mt-8 font-medium leading-[1.0] tracking-tight text-foreground text-[40px] sm:text-[64px] lg:text-[80px]">
-      The most expensive bugs are the ones you didn't catch at plan time.
+      Precision steering saves you from slop.
     </h2>
 
     <div class="mt-16 h-px w-full bg-foreground"></div>

--- a/packages/website/src/content/docs/how-it-works.mdx
+++ b/packages/website/src/content/docs/how-it-works.mdx
@@ -3,7 +3,7 @@ title: How it works
 description: What you do, what you see, and what runs on your machine when PlanBridge is in the loop.
 ---
 
-You install PlanBridge once. After that, you keep using your coding agent the way you always have. The only difference: when your agent reaches a standard plan-review hook, your browser opens with the plan and you mark it up before any code is written.
+You install PlanBridge once. After that, you keep using your coding agent the way you always have. When you want to weigh in on a plan, a file, or the agent's last message, PlanBridge opens that markdown in a local browser. You select text, comment, and your agent acts on your feedback before writing code.
 
 ## Your workflow
 
@@ -11,17 +11,21 @@ You install PlanBridge once. After that, you keep using your coding agent the wa
 
 Run the install script and PlanBridge picks up any supported coding agent already on your machine. It adds standard plugin or hook entries, not a custom runtime. No API keys. Re-run it later if you add a new agent.
 
-### You review every plan
+### You open what you want to review
 
-Use your coding agent the way you always have. When it produces a plan, the harness's normal review hook can call PlanBridge before any code is written. Your default browser opens to a review page on `localhost`.
+Three entry points, all landing on the same local review page on `localhost`:
+
+- **Automatic on plan mode.** When your agent finishes a plan, the harness's normal review hook calls PlanBridge before any code is written. This is the default.
+- **A file, on demand.** Run `/planbridge-open <file>` in Claude Code or `$planbridge-open <file>` in Codex to mark up an existing plan, spec, or doc.
+- **The last message, on demand.** Run `/planbridge-last` or `$planbridge-last` to mark up the answer your agent just wrote.
 
 ### You shape the work
 
-Highlight any line of the plan, leave a comment. When you're happy, click **Approve Plan**. If something needs to change, click **Request Changes** and your agent picks the work back up with your feedback in hand.
+Select any line, leave a comment. When you're happy, click **Approve**. If something needs to change, click **Request Changes** and your agent picks the work back up with your feedback in hand.
 
 ## What runs where
 
-Your plan never leaves your machine. There's no remote backend, no account, no API keys, and no background daemon. The only network traffic is your browser talking to a CLI process on `localhost`.
+Your content never leaves your machine. There's no remote backend, no account, no API keys, and no background daemon. The only network traffic is your browser talking to a CLI process on `localhost`.
 
 The CLI launches the local server only when your agent needs review, then shuts it down as soon as you submit. Nothing persists.
 
@@ -48,6 +52,8 @@ stdin / [path]  ─▶  contextbridge plan
 - **CLI → stderr**: pino logs (JSON, or pretty when stderr is a TTY).
 
 The stdout/stderr split exists so piped consumers see only the markdown result while humans get readable diagnostics. The hook adapters (`contextbridge hook claude` for [Claude Code's `ExitPlanMode`](/usage/claude-code/), `contextbridge hook codex` for [Codex's `Stop` hook](/usage/codex/)) consume that markdown and wrap it in the harness-specific JSON response their hook contract expects.
+
+The on-demand skills follow the same loop through `contextbridge open` instead of `contextbridge plan`: `/planbridge-open` pipes in a file, `/planbridge-last` pipes in the agent's last message, and the markdown result comes back on stdout the same way.
 
 ## Fixed local ports
 

--- a/packages/website/src/content/docs/quickstart.mdx
+++ b/packages/website/src/content/docs/quickstart.mdx
@@ -3,10 +3,11 @@ title: Quickstart
 description: Install PlanBridge with standard harness plugins and hooks.
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
 import { Code } from 'astro-expressive-code/components';
 import DemoVideo from '../../components/DemoVideo.astro';
 
-One command installs the binary and offers to add standard plugin or hook entries for the AI coding harnesses on your machine. After that, you use your harness as you always do; PlanBridge opens when the harness reaches its normal review point.
+One command installs the binary and wires PlanBridge into the AI coding harnesses on your machine. From there you can open any file or your agent's last message on demand, or let PlanBridge open automatically when your agent finishes a plan.
 
 ## 1. Install
 
@@ -20,13 +21,39 @@ The script uses [Homebrew](https://brew.sh/) if installed, otherwise places the 
 
 Prefer to step through the install yourself? See [Install](/install/) for manual installation details.
 
-## 2. Use your harness normally
+## 2. Try PlanBridge Now
 
-That's the whole setup. The next time your harness reaches a review point, PlanBridge opens for review:
+The quickest way to see PlanBridge: pull an existing markdown file into the review UI. No plan mode required.
 
-1. Your browser opens to a review UI.
-2. You annotate what you'd like to change or approve.
-3. Your decision flows back to the harness, which iterates on the plan or proceeds once the approved plan is accepted.
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code code="/planbridge-open path/to/file.md" lang="text" />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code code="$planbridge-open path/to/file.md" lang="text" />
+  </TabItem>
+</Tabs>
+
+Once your agent has written something, you can also open its last message for markup:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code code="/planbridge-last" lang="text" />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code code="$planbridge-last" lang="text" />
+  </TabItem>
+</Tabs>
+
+That's two of the [three ways to use PlanBridge](/usage/). The third is the automatic plan-mode flow below.
+
+## 3. Use plan mode
+
+Put your agent in plan mode and PlanBridge runs automatically. When your agent finishes a plan, it opens on its own, no command needed:
+
+1. Your browser opens to the review UI.
+2. You select text and comment, or approve as-is.
+3. Your decision flows back to the harness, which revises the plan or starts implementing once you approve.
 
 <DemoVideo />
 

--- a/packages/website/src/content/docs/recipes/agent-os.mdx
+++ b/packages/website/src/content/docs/recipes/agent-os.mdx
@@ -1,0 +1,80 @@
+---
+title: Agent OS
+description: Pair PlanBridge with Agent OS to review the product plan and shaped specs before coding.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Code } from 'astro-expressive-code/components';
+
+[Agent OS](https://github.com/buildermethods/agent-os) (by Builder Methods) is a system for injecting codebase standards and writing better specs for spec-driven development. You drive it with slash commands: `/plan-product` lays out the product, `/shape-spec` turns a feature into a spec.
+
+`/plan-product` writes committed markdown under `agent-os/product/`:
+
+- `agent-os/product/mission.md`
+- `agent-os/product/roadmap.md`
+- `agent-os/product/tech-stack.md`
+
+`/shape-spec` (run in plan mode) gathers requirements into a spec doc. Both phases are pause points for PlanBridge.
+
+## Manual
+
+After `/plan-product`, review the product docs:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code
+      code={`/planbridge-open agent-os/product/mission.md
+/planbridge-open agent-os/product/roadmap.md`}
+      lang="text"
+    />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code
+      code={`$planbridge-open agent-os/product/mission.md
+$planbridge-open agent-os/product/roadmap.md`}
+      lang="text"
+    />
+  </TabItem>
+</Tabs>
+
+After `/shape-spec`, review the spec it just wrote:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code code="/planbridge-open the spec you just wrote" lang="text" />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code code="$planbridge-open the spec you just wrote" lang="text" />
+  </TabItem>
+</Tabs>
+
+The agent revises the spec from your inline comments before any code is written.
+
+## Automatic
+
+To review each artifact without asking, append a snippet to your global agent instructions:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code
+      lang="bash"
+      code={`echo '
+## Agent OS + PlanBridge
+
+After \`/plan-product\` writes the product docs under \`agent-os/product/\`, or \`/shape-spec\` writes a spec, run \`/planbridge-open\` on the file instead of asking me to review it as text. Treat the returned annotations as my review feedback and revise before coding.
+' >> ~/.claude/CLAUDE.md`}
+/>
+
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code
+      lang="bash"
+      code={`echo '
+## Agent OS + PlanBridge
+
+After \`/plan-product\` writes the product docs under \`agent-os/product/\`, or \`/shape-spec\` writes a spec, run \`$planbridge-open\` on the file instead of asking me to review it as text. Treat the returned annotations as my review feedback and revise before coding.
+' >> ~/.codex/AGENTS.md`}
+/>
+
+  </TabItem>
+</Tabs>

--- a/packages/website/src/content/docs/recipes/bmad.mdx
+++ b/packages/website/src/content/docs/recipes/bmad.mdx
@@ -1,0 +1,82 @@
+---
+title: BMAD Method
+description: Pair PlanBridge with BMAD-METHOD to review the PRD, architecture, and stories before implementation.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Code } from 'astro-expressive-code/components';
+
+[BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD) ("Breakthrough Method for Agile AI-Driven Development") is a multi-agent framework with Analyst, PM, Architect, and Dev personas that take you from idea to implementation. Install it with `npx bmad-method install`.
+
+Its planning agents write markdown to `docs/` at your repo root, with a clean handoff at each phase:
+
+- `docs/prd.md` after the PM agent drafts the product requirements
+- `docs/architecture.md` after the Architect agent designs the system
+- `docs/stories/*.story.md` for the sharded implementation stories
+
+Each of those is a pause point: review it before the next agent picks up the work.
+
+## Manual
+
+After the PM agent writes the PRD, open it for review:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code code="/planbridge-open docs/prd.md" lang="text" />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code code="$planbridge-open docs/prd.md" lang="text" />
+  </TabItem>
+</Tabs>
+
+Comment inline, and BMAD revises the PRD before the Architect agent starts. Do the same for the architecture doc and each story:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code
+      code={`/planbridge-open docs/architecture.md
+/planbridge-open docs/stories/0.1.story.md`}
+      lang="text"
+    />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code
+      code={`$planbridge-open docs/architecture.md
+$planbridge-open docs/stories/0.1.story.md`}
+      lang="text"
+    />
+  </TabItem>
+</Tabs>
+
+## Automatic
+
+To review each planning doc without asking, append a snippet to your global agent instructions:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code
+      lang="bash"
+      code={`echo '
+## BMAD + PlanBridge
+
+When a BMAD agent writes a planning doc under \`docs/\` (\`prd.md\`, \`architecture.md\`, a file in \`docs/stories/\`), run \`/planbridge-open\` on it instead of asking me to review it as text. Treat the returned annotations as my review feedback and revise before the next agent or phase begins.
+' >> ~/.claude/CLAUDE.md`}
+/>
+
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code
+      lang="bash"
+      code={`echo '
+## BMAD + PlanBridge
+
+When a BMAD agent writes a planning doc under \`docs/\` (\`prd.md\`, \`architecture.md\`, a file in \`docs/stories/\`), run \`$planbridge-open\` on it instead of asking me to review it as text. Treat the returned annotations as my review feedback and revise before the next agent or phase begins.
+' >> ~/.codex/AGENTS.md`}
+/>
+
+  </TabItem>
+</Tabs>
+
+## Notes
+
+Activate BMAD's agents and workflows the way its [docs](https://docs.bmad-method.org/) describe; the exact agent and command names depend on your install and version. PlanBridge plugs in wherever a phase writes a markdown doc under `docs/`.

--- a/packages/website/src/content/docs/recipes/openspec.mdx
+++ b/packages/website/src/content/docs/recipes/openspec.mdx
@@ -1,0 +1,88 @@
+---
+title: OpenSpec
+description: Pair PlanBridge with OpenSpec to review a change proposal before the agent implements it.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Code } from 'astro-expressive-code/components';
+
+[OpenSpec](https://github.com/Fission-AI/OpenSpec) is a spec-driven framework where each proposed change gets its own folder so you and the agent agree on the spec before any code is written. After `openspec init`, you drive it with `/opsx:*` slash commands: `/opsx:propose` creates the change, `/opsx:apply` implements it, `/opsx:archive` merges the spec deltas.
+
+`/opsx:propose <idea>` writes a change folder under `openspec/changes/<change-name>/`:
+
+```
+openspec/changes/<change-name>/
+├── proposal.md   # why and what is changing
+├── design.md     # technical approach
+├── tasks.md      # implementation checklist
+└── specs/        # delta specs
+```
+
+OpenSpec designed that folder to be reviewed before you implement. That is the pause point for PlanBridge.
+
+## Manual
+
+After `/opsx:propose`, open the proposal for inline review:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code code="/planbridge-open openspec/changes/add-dark-mode/proposal.md" lang="text" />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code code="$planbridge-open openspec/changes/add-dark-mode/proposal.md" lang="text" />
+  </TabItem>
+</Tabs>
+
+PlanBridge opens one markdown file at a time, so review the design and tasks the same way before you run `/opsx:apply`:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code
+      code={`/planbridge-open openspec/changes/add-dark-mode/design.md
+/planbridge-open openspec/changes/add-dark-mode/tasks.md`}
+      lang="text"
+    />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code
+      code={`$planbridge-open openspec/changes/add-dark-mode/design.md
+$planbridge-open openspec/changes/add-dark-mode/tasks.md`}
+      lang="text"
+    />
+  </TabItem>
+</Tabs>
+
+The agent revises the change from your inline comments before it applies it.
+
+## Automatic
+
+To review every proposal without asking, append a snippet to your global agent instructions:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code
+      lang="bash"
+      code={`echo '
+## OpenSpec + PlanBridge
+
+After \`/opsx:propose\` writes a change under \`openspec/changes/<name>/\`, run \`/planbridge-open\` on its \`proposal.md\` (then \`design.md\` and \`tasks.md\`) before \`/opsx:apply\`. Treat the returned annotations as my review feedback and revise the change before implementing.
+' >> ~/.claude/CLAUDE.md`}
+/>
+
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code
+      lang="bash"
+      code={`echo '
+## OpenSpec + PlanBridge
+
+After \`/opsx:propose\` writes a change under \`openspec/changes/<name>/\`, run \`$planbridge-open\` on its \`proposal.md\` (then \`design.md\` and \`tasks.md\`) before \`/opsx:apply\`. Treat the returned annotations as my review feedback and revise the change before implementing.
+' >> ~/.codex/AGENTS.md`}
+/>
+
+  </TabItem>
+</Tabs>
+
+## Notes
+
+The `/opsx:*` commands are OpenSpec's current default workflow. If you upgraded from an older install, run `openspec update` to refresh the agent instructions and confirm the command set with your `/` autocomplete.

--- a/packages/website/src/content/docs/recipes/spec-kit.mdx
+++ b/packages/website/src/content/docs/recipes/spec-kit.mdx
@@ -1,0 +1,84 @@
+---
+title: Spec Kit
+description: Pair PlanBridge with GitHub's Spec Kit to review specs, plans, and tasks before any code is generated.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Code } from 'astro-expressive-code/components';
+
+[Spec Kit](https://github.com/github/spec-kit) is GitHub's spec-driven development toolkit. You drive it with `/speckit.*` slash commands inside your agent: `/speckit.specify` writes a spec, `/speckit.plan` a technical plan, `/speckit.tasks` a task list, and `/speckit.implement` builds it.
+
+Each phase writes a markdown artifact you should read before the agent moves to the next one. That is where PlanBridge fits: open the file, comment inline, and the agent revises before generating the next artifact.
+
+Spec Kit writes feature artifacts to `specs/<NNN-feature>/` at your repo root:
+
+- `specs/<NNN-feature>/spec.md` after `/speckit.specify`
+- `specs/<NNN-feature>/plan.md` after `/speckit.plan`
+- `specs/<NNN-feature>/tasks.md` after `/speckit.tasks`
+
+The `.specify/` directory holds templates and scripts, not the generated specs.
+
+## Manual
+
+The strongest pause point is right after `/speckit.specify`. Open the new spec for review:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code code="/planbridge-open the spec you just wrote" lang="text" />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code code="$planbridge-open the spec you just wrote" lang="text" />
+  </TabItem>
+</Tabs>
+
+Your agent resolves the path, opens it in PlanBridge, and revises the spec from your inline comments. Do the same after `/speckit.plan` and `/speckit.tasks`:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code
+      code={`/planbridge-open specs/001-my-feature/plan.md
+/planbridge-open specs/001-my-feature/tasks.md`}
+      lang="text"
+    />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code
+      code={`$planbridge-open specs/001-my-feature/plan.md
+$planbridge-open specs/001-my-feature/tasks.md`}
+      lang="text"
+    />
+  </TabItem>
+</Tabs>
+
+## Automatic
+
+To review each artifact without asking, append a snippet to your global agent instructions:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code
+      lang="bash"
+      code={`echo '
+## Spec Kit + PlanBridge
+
+After running \`/speckit.specify\`, \`/speckit.plan\`, or \`/speckit.tasks\`, run \`/planbridge-open\` on the file it just wrote (under \`specs/<feature>/\`) instead of asking me to review it as text. Treat the returned annotations as my review feedback and revise before moving to the next phase.
+' >> ~/.claude/CLAUDE.md`}
+/>
+
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code
+      lang="bash"
+      code={`echo '
+## Spec Kit + PlanBridge
+
+After running \`$speckit-specify\`, \`$speckit-plan\`, or \`$speckit-tasks\`, run \`$planbridge-open\` on the file it just wrote (under \`specs/<feature>/\`) instead of asking me to review it as text. Treat the returned annotations as my review feedback and revise before moving to the next phase.
+' >> ~/.codex/AGENTS.md`}
+/>
+
+  </TabItem>
+</Tabs>
+
+## Notes
+
+Spec Kit's command names have shifted across releases, and Codex skills mode uses `$speckit-*` rather than `/speckit.*`. Run `specify integration list` or check your `/` autocomplete to confirm the exact names for your install.

--- a/packages/website/src/content/docs/recipes/spec-kitty.mdx
+++ b/packages/website/src/content/docs/recipes/spec-kitty.mdx
@@ -1,0 +1,78 @@
+---
+title: Spec Kitty
+description: Pair PlanBridge with Spec Kitty to review the spec, plan, and tasks before implementation.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Code } from 'astro-expressive-code/components';
+
+[Spec Kitty](https://github.com/Priivacy-ai/spec-kitty) is a spec-driven CLI that adds a Kanban dashboard, git worktrees, and lifecycle lanes on top of a spec → plan → tasks → review → merge loop. After `spec-kitty init`, you drive it with `/spec-kitty.*` slash commands: `/spec-kitty.specify` writes a mission spec, `/spec-kitty.plan` a plan, `/spec-kitty.tasks` the work packages.
+
+Spec Kitty writes mission artifacts under `kitty-specs/<feature>/`:
+
+- `kitty-specs/<feature>/spec.md` after `/spec-kitty.specify`
+- `kitty-specs/<feature>/plan.md` after `/spec-kitty.plan`
+- `kitty-specs/<feature>/tasks.md` after `/spec-kitty.tasks`
+
+Spec Kitty already has a `/spec-kitty.review` lane for completed code. PlanBridge complements it upstream, on the spec, plan, and task markdown before any code is written.
+
+## Manual
+
+After `/spec-kitty.specify`, open the new spec for review:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code code="/planbridge-open the spec you just wrote" lang="text" />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code code="$planbridge-open the spec you just wrote" lang="text" />
+  </TabItem>
+</Tabs>
+
+The agent resolves the path under `kitty-specs/<feature>/` and revises from your inline comments. Do the same after `/spec-kitty.plan` and `/spec-kitty.tasks`:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code
+      code={`/planbridge-open kitty-specs/my-feature/plan.md
+/planbridge-open kitty-specs/my-feature/tasks.md`}
+      lang="text"
+    />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code
+      code={`$planbridge-open kitty-specs/my-feature/plan.md
+$planbridge-open kitty-specs/my-feature/tasks.md`}
+      lang="text"
+    />
+  </TabItem>
+</Tabs>
+
+## Automatic
+
+To review each artifact without asking, append a snippet to your global agent instructions:
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code
+      lang="bash"
+      code={`echo '
+## Spec Kitty + PlanBridge
+
+After running \`/spec-kitty.specify\`, \`/spec-kitty.plan\`, or \`/spec-kitty.tasks\`, run \`/planbridge-open\` on the file it just wrote (under \`kitty-specs/<feature>/\`) instead of asking me to review it as text. Treat the returned annotations as my review feedback and revise before moving to the next phase.
+' >> ~/.claude/CLAUDE.md`}
+/>
+
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code
+      lang="bash"
+      code={`echo '
+## Spec Kitty + PlanBridge
+
+After running \`/spec-kitty.specify\`, \`/spec-kitty.plan\`, or \`/spec-kitty.tasks\`, run \`$planbridge-open\` on the file it just wrote (under \`kitty-specs/<feature>/\`) instead of asking me to review it as text. Treat the returned annotations as my review feedback and revise before moving to the next phase.
+' >> ~/.codex/AGENTS.md`}
+/>
+
+  </TabItem>
+</Tabs>

--- a/packages/website/src/content/docs/usage/claude-code.mdx
+++ b/packages/website/src/content/docs/usage/claude-code.mdx
@@ -62,8 +62,8 @@ Or `contextbridge uninstall` to remove PlanBridge plugin and hook entries from e
 
 The plan-mode hook fires automatically.
 
-- To pull an arbitrary markdown file into the PlanBridge UI on demand, use `/planbridge-open`.
-- To annotate the agent's last message, use `/planbridge-last`. See [Open arbitrary content](/usage/open/).
+- To pull an arbitrary markdown file into the PlanBridge UI on demand, use `/planbridge-open`. See [Precision feedback on a file](/usage/open/).
+- To annotate the agent's last message, use `/planbridge-last`. See [Annotate the last message](/usage/last/).
 
 ## Reference
 

--- a/packages/website/src/content/docs/usage/codex.mdx
+++ b/packages/website/src/content/docs/usage/codex.mdx
@@ -136,10 +136,10 @@ Or `contextbridge uninstall` to remove PlanBridge plugin and hook entries from e
 
 The `Stop` hook fires automatically and opens plans for review (if you're in Codex's plan mode).
 
-- To pull an arbitrary markdown file into the PlanBridge UI on demand, use `$planbridge-open`.
-- To annotate the agent's previous message, use `$planbridge-last`.
+- To pull an arbitrary markdown file into the PlanBridge UI on demand, use `$planbridge-open`. See [Precision feedback on a file](/usage/open/).
+- To annotate the agent's previous message, use `$planbridge-last`. See [Annotate the last message](/usage/last/).
 
-`contextbridge install codex` writes both skills to `~/.agents/skills/`. See [Open arbitrary content](/usage/open/).
+`contextbridge install codex` writes both skills to `~/.agents/skills/`.
 
 ## Troubleshooting
 

--- a/packages/website/src/content/docs/usage/index.mdx
+++ b/packages/website/src/content/docs/usage/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Usage
-description: 'The three ways to use PlanBridge: automatic plan-mode collaboration, precision feedback on a file, and annotating the agent''s last message.'
+description: "The three ways to use PlanBridge: automatic plan-mode collaboration, precision feedback on a file, and annotating the agent's last message."
 ---
 
 PlanBridge opens a local browser UI where you annotate markdown and the result flows back to your agent. There are three ways to get content into that UI.

--- a/packages/website/src/content/docs/usage/index.mdx
+++ b/packages/website/src/content/docs/usage/index.mdx
@@ -1,18 +1,27 @@
 ---
 title: Usage
-description: Use PlanBridge through standard harness hooks, or ask any other agent to call it directly.
+description: 'The three ways to use PlanBridge: automatic plan-mode collaboration, precision feedback on a file, and annotating the agent''s last message.'
 ---
 
-PlanBridge has two paths into the browser review UI.
+PlanBridge opens a local browser UI where you annotate markdown and the result flows back to your agent. There are three ways to get content into that UI.
 
-**As a harness hook.** Your AI coding agent calls `contextbridge` through its standard plugin or hook system at decision points, a human annotates in the browser, and the decision flows back to the agent. The [install script](/install/) adds those entries for any supported harness it detects.
+## Plan-mode collaboration
 
-**As a manual skill.** You ask your agent to open content in the browser outside the automatic hook flow:
+Your agent calls `contextbridge` through its standard plugin or hook system when it finishes a plan, and PlanBridge opens automatically. You annotate, then approve or send it back. The [install script](/install/) adds those entries for any supported harness it detects.
 
-- Use `/planbridge-open <path>` in Claude Code or `$planbridge-open <path>` in Codex CLI for markdown files.
-- Use `/planbridge-last` in Claude Code or `$planbridge-last` in Codex CLI for the agent's last message.
+See [Plan-mode collaboration](/usage/plan-mode/).
 
-See [Open arbitrary content](/usage/open/).
+## Precision feedback on a file
+
+Ask your agent to open an existing markdown file on demand: `/planbridge-open <path>` in Claude Code or `$planbridge-open <path>` in Codex CLI. Good for a design doc, RFC, or spec that never went through plan mode.
+
+See [Precision feedback on a file](/usage/open/).
+
+## Annotate the last message
+
+Mark up the long answer your agent just wrote: `/planbridge-last` in Claude Code or `$planbridge-last` in Codex CLI.
+
+See [Annotate the last message](/usage/last/).
 
 ## Supported harnesses
 

--- a/packages/website/src/content/docs/usage/last.mdx
+++ b/packages/website/src/content/docs/usage/last.mdx
@@ -1,0 +1,61 @@
+---
+title: Annotate the last message
+description: Open the agent's most recent message in the PlanBridge browser UI to mark it up inline.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Code } from 'astro-expressive-code/components';
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    <Code code="/planbridge-last" lang="text" />
+  </TabItem>
+  <TabItem label="Codex CLI">
+    <Code code="$planbridge-last" lang="text" />
+  </TabItem>
+</Tabs>
+
+The agent pipes its previous message verbatim into PlanBridge, which opens it in your browser for inline annotation. Your comments come back to the agent on stdout.
+
+Reach for this when the thing you want to mark up is the answer your agent just wrote, not a file on disk. To annotate a saved file instead, use [Precision feedback on a file](/usage/open/).
+
+## When to use it
+
+- Your agent wrote a long spec, architecture explanation, migration plan, or brainstorming section in chat and you want targeted line-level feedback.
+- You are in a workflow that presents work in the terminal rather than in plan mode. The [obra/superpowers](https://github.com/obra/superpowers) brainstorming skill is one example. See the [Superpowers recipe](/recipes/superpowers/).
+
+## Run it before you say anything
+
+`planbridge-last` targets your agent's most recent message. A preamble like "Sure, opening that now" becomes the new last message and gets annotated instead. So trigger it as the first thing in your turn, before the agent replies with anything else.
+
+## Agent skill
+
+<Tabs syncKey="harness">
+  <TabItem label="Claude Code">
+    The `planbridge-last` skill ships with the `planbridge@contextbridge` Claude plugin.
+
+    Claude Code may display plugin skills as `/planbridge:planbridge-last`. Use that form if it appears in your slash-command picker.
+
+  </TabItem>
+  <TabItem label="Codex CLI">
+    `contextbridge install codex` writes the skill to `~/.agents/skills/`.
+  </TabItem>
+</Tabs>
+
+## What you see
+
+1. Your agent copies its previous message and pipes it to `contextbridge open` via stdin.
+2. PlanBridge opens that text in your browser.
+3. You leave inline annotations and general comments, then submit or approve.
+4. PlanBridge writes a markdown summary of your feedback to stdout.
+5. Your agent reads the summary and responds conversationally.
+
+The output is feedback for discussion, not a directive. The agent treats your comments the way it would treat a colleague's review notes, not a checklist to silently execute.
+
+## Direct CLI use
+
+The skill is a thin wrapper around `contextbridge open` reading from stdin:
+
+<Code code='printf "%s" "$message" | contextbridge open' lang="sh" title="terminal" />
+
+Full flags and exit codes live in the [CLI reference](/cli/open/).

--- a/packages/website/src/content/docs/usage/open.mdx
+++ b/packages/website/src/content/docs/usage/open.mdx
@@ -1,6 +1,6 @@
 ---
-title: Open arbitrary content
-description: Ask your coding agent to open any markdown file in the PlanBridge browser UI for human annotation.
+title: Precision feedback on a file
+description: Ask your coding agent to open any markdown file in the PlanBridge browser UI for inline annotation.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -17,16 +17,17 @@ import { Code } from 'astro-expressive-code/components';
 
 The file opens in your browser for inline annotation. Your comments come back to the agent on stdout.
 
-This is the manual sibling to the automatic hook flow. Hooks fire when your agent finishes planning. The `open` and `last` skills fire whenever you ask for them.
+This is the on-demand sibling to the automatic [plan-mode hook](/usage/plan-mode/). The hook fires when your agent finishes planning. `planbridge-open` fires whenever you ask for it.
 
 ## When to use it
 
 - You want inline comments on a design doc, RFC, or spec.
-- You want to mark up the long answer your agent just wrote.
-- Your agent uses a workflow that bypasses plan mode. For example, the [obra/superpowers](https://github.com/obra/superpowers) plugin never enters Claude Code's plan mode. However, you can still use PlanBridge with it. See the [Superpowers recipe](/recipes/superpowers/) page for details.
+- Your agent uses a workflow that bypasses plan mode. For example, the [obra/superpowers](https://github.com/obra/superpowers) plugin never enters Claude Code's plan mode. You can still use PlanBridge with it. See the [Superpowers recipe](/recipes/superpowers/) for details.
 - You want to redirect the agent before it starts work, and the relevant context lives in a file rather than in plan mode.
 
-## Agent skills
+To mark up the answer your agent just wrote instead of a file on disk, use [Annotate the last message](/usage/last/).
+
+## Agent skill
 
 Use `planbridge-open` for files:
 
@@ -36,17 +37,6 @@ Use `planbridge-open` for files:
   </TabItem>
   <TabItem label="Codex CLI">
     <Code code="$planbridge-open path/to/file.md" lang="text" />
-  </TabItem>
-</Tabs>
-
-Use `planbridge-last` for the agent's previous message:
-
-<Tabs syncKey="harness">
-  <TabItem label="Claude Code">
-    <Code code="/planbridge-last" lang="text" />
-  </TabItem>
-  <TabItem label="Codex CLI">
-    <Code code="$planbridge-last" lang="text" />
   </TabItem>
 </Tabs>
 
@@ -63,13 +53,13 @@ You can also describe the file in plain language and your agent resolves it:
 
 <Tabs syncKey="harness">
   <TabItem label="Claude Code">
-    The `planbridge-open` and `planbridge-last` skills ship with the `planbridge@contextbridge` Claude plugin.
+    The `planbridge-open` skill ships with the `planbridge@contextbridge` Claude plugin.
 
-    Claude Code may display plugin skills as `/planbridge:planbridge-open` and `/planbridge:planbridge-last`. Use those forms if they appear in your slash-command picker.
+    Claude Code may display plugin skills as `/planbridge:planbridge-open`. Use that form if it appears in your slash-command picker.
 
   </TabItem>
   <TabItem label="Codex CLI">
-    `contextbridge install codex` writes both skills to `~/.agents/skills/`.
+    `contextbridge install codex` writes the skill to `~/.agents/skills/`.
   </TabItem>
 </Tabs>
 

--- a/packages/website/src/content/docs/usage/other-agents.mdx
+++ b/packages/website/src/content/docs/usage/other-agents.mdx
@@ -26,6 +26,18 @@ The agent runs something like:
 
 Your browser opens to the review UI. You annotate or approve. The markdown summary lands on stdout for the agent to read.
 
+## Open a file or arbitrary content
+
+PlanBridge is not limited to plans. The same binary opens any markdown for review through `contextbridge open`, so you can give precise feedback on a file or on your agent's last message, not just at plan time.
+
+<Code code="contextbridge open path/to/spec.md" lang="sh" title="agent shell" />
+
+Or pipe content the agent already has in hand (a draft, a generated doc, its previous reply):
+
+<Code code='printf "%s" "$content" | contextbridge open' lang="sh" title="agent shell" />
+
+The response shape and exit codes below are identical for `plan` and `open`.
+
 ## Response shape
 
 The agent receives markdown on stdout. It opens with one of two headers:

--- a/packages/website/src/content/docs/usage/plan-mode.mdx
+++ b/packages/website/src/content/docs/usage/plan-mode.mdx
@@ -1,0 +1,36 @@
+---
+title: Plan-mode collaboration
+description: PlanBridge opens automatically when your agent finishes a plan, so you can annotate before any code is written.
+---
+
+import { Code } from 'astro-expressive-code/components';
+
+Once the PlanBridge hook is installed, your agent opens PlanBridge in your browser the moment it finishes planning. You annotate the plan, then approve it or send it back. No code is written until you do.
+
+This is the default way to use PlanBridge. It fires on the harness's normal plan-approval point, so it fits the workflow you already have.
+
+## What you see
+
+1. Put your agent in plan mode and type your prompt.
+2. When the plan is ready, PlanBridge opens in your browser.
+3. Select the lines that need work and comment inline. This is the time to redirect the agent before it starts.
+4. Approve the plan, or request changes. On approval the agent begins implementing. On changes the agent reworks the plan and re-presents it.
+
+Keep iterating until the plan is one you want, not one you tolerated.
+
+## Per-harness setup
+
+The hook is wired in by `contextbridge install`, which detects the harnesses on your machine.
+
+<Code code="contextbridge install" lang="sh" title="terminal" />
+
+Each harness hooks a different point:
+
+- **Claude Code** runs on `PermissionRequest:ExitPlanMode`. See [Claude Code](/usage/claude-code/) for install, the terminal prompt to ignore, and uninstall.
+- **Codex CLI** runs on the `Stop` hook and needs a one-time trust step. See [Codex CLI](/usage/codex/) for install and the trust walkthrough.
+
+For agents without a plugin or hook system, see [Other agents](/usage/other-agents/).
+
+## When plan mode does not fire
+
+Some workflows never enter plan mode. The [obra/superpowers](https://github.com/obra/superpowers) plugin, for example, presents design sections and spec files outside Claude Code's plan mode. For those, trigger PlanBridge yourself with [Precision feedback on a file](/usage/open/) or [Annotate the last message](/usage/last/). See the [Superpowers recipe](/recipes/superpowers/).

--- a/packages/website/src/pages/index.mdx
+++ b/packages/website/src/pages/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../layouts/Landing.astro
 title: 'PlanBridge: Inline comments on your coding agent plans'
-description: 'PlanBridge uses standard agent plugins and hooks to open plans in a local browser window, so you can highlight text and leave comments exactly like you would in a document.'
+description: "PlanBridge opens markdown in a local browser so you can highlight text and leave comments like you would in a document. Use it three ways: collaborate on a plan, give feedback on a file, or annotate your agent's last message."
 ---
 
 import Hero from '../components/Hero.astro';
@@ -9,6 +9,7 @@ import UserQuotes from '../components/UserQuotes.astro';
 import DataPrivacy from '../components/DataPrivacy.astro';
 import ValueProps from '../components/ValueProps.astro';
 import ReviewLoop from '../components/ReviewLoop.astro';
+import UseCases from '../components/UseCases.astro';
 import IntegrationCards from '../components/IntegrationCards.astro';
 import Faq from '../components/Faq.astro';
 import CallToAction from '../components/CallToAction.astro';
@@ -16,6 +17,8 @@ import CallToAction from '../components/CallToAction.astro';
 <Hero />
 
 <ValueProps />
+
+<UseCases />
 
 <ReviewLoop />
 
@@ -27,4 +30,4 @@ import CallToAction from '../components/CallToAction.astro';
 
 <Faq />
 
-<CallToAction title="Better plans, better code." description="Refine the plan first. Skip the rework." />
+<CallToAction title="Move faster with precision steering." description="Refine first.  Skip the rework." />


### PR DESCRIPTION
## Summary

The marketing site and docs previously led almost entirely with one use case (plan-mode review). This surfaces all three use cases consistently — plan-mode collaboration, precision feedback on a file (`/planbridge-open`), and annotating the agent's last message (`/planbridge-last`). It rebuilds the landing page (new use-cases section, a tabbed per-use-case "how it works" flow, broadened hero/FAQ/value-prop/data-privacy copy, reordered sections), reframes the usage and start-here docs, splits the old "open arbitrary content" page into "Precision feedback on a file" and "Annotate the last message", and adds spec-driven-development recipes for Spec Kit, Spec Kitty, OpenSpec, BMAD Method, and Agent OS. External links in docs now open in a new tab.

## Review focus

- **`ReviewLoopDiagram.tsx`** was refactored from a single hard-coded plan flow into a variant-driven, tabbed component (one tab per use case). Worth a look at the tab a11y (`role="tab"` / arrow-key nav) and the animation-replay-on-switch approach (`key={variant}` remount).
- **SDD recipe accuracy:** file paths and slash commands were gathered from each project's current docs, but these tools move fast, so each recipe hedges ("confirm via `/` autocomplete / `openspec update`") rather than hard-coding exact command names that may drift.

## Commits

- [`8352328`](https://github.com/contextbridge/planbridge/commit/8352328) — chore: add chrome-devtools and outline MCP servers to Codex config
- [`e0777be`](https://github.com/contextbridge/planbridge/commit/e0777be) — feat(website): rebuild the landing page around the three use cases
- [`7fdf2aa`](https://github.com/contextbridge/planbridge/commit/7fdf2aa) — docs(website): reframe docs around three use cases and add SDD recipes