### PR TITLE
fix: publish verifiable build provenance for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
       contents: write
       id-token: write
       packages: read
+      attestations: write # publish Sigstore build-provenance attestations for release artifacts
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -85,6 +86,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap-token.outputs.token }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+
+      # Build provenance: a Sigstore-signed attestation binding every release
+      # archive (each file in checksums.txt) to this repo, commit, and workflow
+      # run, recorded in a public transparency log. Attestations are keyed by
+      # artifact digest, so they also cover the byte-identical copies served from
+      # downloads.contextbridge.ai and the Homebrew cask. Verify a download with:
+      #   gh attestation verify <archive> --repo contextbridge/planbridge
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-checksums: dist/checksums.txt
 
       - name: Mirror release to channel alias
         shell: bash

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Using something else (Cursor, Aider, opencode, Gemini CLI, Aether)? Any agent th
 
 Your plan content stays on your machine. No remote backend, no account, no API keys. The CLI sends anonymous product analytics and crash reports unless you opt out with `DO_NOT_TRACK=1` or `CONTEXTBRIDGE_TELEMETRY_DISABLED=1`. Details: [Privacy & Telemetry](https://plan.contextbridge.ai/privacy/).
 
+## Verify what you're running
+
+PlanBridge is open source (this repo, MIT), and GitHub Actions builds the released binaries straight from it. Every release archive comes with [GitHub build provenance](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds): a Sigstore-signed attestation that ties the archive back to the commit and CI workflow that built it, recorded in a public transparency log. Verify a download with:
+
+```sh
+gh attestation verify contextbridge_<version>_darwin_arm64.tar.gz --repo contextbridge/planbridge
+```
+
+macOS binaries are signed and Apple-notarized on top of that.
+
 ## Documentation
 
 - [Quickstart](https://plan.contextbridge.ai/quickstart/)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,9 @@
 #
 # install.sh — ContextBridge CLI installer
 #
+# Source Code:
+#   https://github.com/contextbridge/planbridge
+#
 # Usage:
 #   /bin/sh -c "$(curl -fsSL https://downloads.contextbridge.ai/cli/install.sh)"
 #   /bin/sh -c "$(curl -fsSL https://downloads.contextbridge.ai/cli/install.sh)" -- --channel alpha
@@ -14,6 +17,16 @@
 # detected AI coding harnesses. The documented /bin/sh -c "$(curl ...)" form
 # preserves terminal stdin for prompts. Skip with --no-configure /
 # CB_SKIP_CONFIGURE=1.
+#
+# Privacy: PlanBridge runs locally. Your plan content stays on your machine,
+# with no remote backend, account, or API keys. It sends anonymous product
+# analytics and crash reports only; turn that off with DO_NOT_TRACK=1 or
+# CONTEXTBRIDGE_TELEMETRY_DISABLED=1. See https://plan.contextbridge.ai/privacy/.
+#
+# To verify the binary: macOS release builds are signed and Apple-notarized, and
+# every release archive carries GitHub build provenance. Check it with
+# `gh attestation verify` (the README's "Verify what you're running" section has
+# the command).
 #
 # Env vars (CLI flags take precedence):
 #   CB_CHANNEL          stable (default) | alpha


### PR DESCRIPTION
## Summary

A friend ran the patchwave-analysis installer past a due-diligence agent, and the gaps it found apply here too. The `checksums.txt` sitting next to a download proves nothing if the release itself is bad, since whoever publishes the release publishes the checksums. And someone reading just `install.sh` can't tell where the source or the telemetry policy live.

This ports the same hardening to PlanBridge:

- The release workflow signs every artifact with GitHub build provenance: a Sigstore attestation, logged in a public transparency log, that pins each archive to this repo, commit, and CI run. Check a download with `gh attestation verify <archive> --repo contextbridge/planbridge`. Unlike `checksums.txt`, it holds up even if the publisher is compromised.
- `install.sh` points at the source and spells out the privacy posture and how to verify a download.
- README picks up a short verification section.

Worth knowing: attestations match on file digest, not URL. We serve binaries from downloads.contextbridge.ai and Homebrew rather than GitHub releases, but those are byte-identical copies, so they verify against the same attestation.

## Review focus

- The attest step fires on alpha tags too, so prereleases get provenance. Felt right to me (no reason to leave alpha unverifiable), but say the word if you'd rather scope it to stable.
- Both install paths leave you with the extracted binary, not the archive, and only the archive is attested. So provenance is something you check when you deliberately download an archive; it doesn't cover an already-installed binary. patchwave-analysis has the same limitation and I didn't try to solve it here.
- Went with `fix:` to match the patchwave PR and keep it in the changelog. It's arguably more of a hardening than a bug, so happy to switch to `feat:`.

## Commits

- [`2d26524`](https://github.com/contextbridge/planbridge/commit/2d265248435392d7d98f28e59e2cb3df2849c4ec) — fix: publish verifiable build provenance for releases