### PR TITLE
fix: replace empty annotation draft when clicking another element

### DIFF
--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -290,6 +290,97 @@ describe('App', () => {
     expect(submission?.threads[0]?.messages[0]?.body).toBe('Why annotate the heading?');
   });
 
+  it('replaces an empty draft when clicking a different element', async () => {
+    const user = userEvent.setup();
+    const { submitAnnotation } = renderApp({
+      initialPayload: { contentKind: 'plan', content: '# Title\n\nFirst paragraph.\n\nSecond paragraph.' },
+    });
+
+    const heading = await waitForMarkdownElement('h1');
+    await waitFor(() => {
+      expect(heading).toHaveAttribute('data-target-id');
+    });
+    await user.click(heading);
+    await screen.findByTestId(annotationDraftCommentComposerTestIds.container);
+
+    const firstParagraph = getMarkdownParagraph(0);
+    await waitFor(() => {
+      expect(firstParagraph).toHaveAttribute('data-target-id');
+    });
+    await user.click(firstParagraph);
+
+    expect(screen.queryByTestId(appTestIds.discardDraftDialog)).not.toBeInTheDocument();
+
+    await user.type(screen.getByTestId(annotationDraftCommentComposerTestIds.textarea), 'Comment on the paragraph');
+    await user.click(screen.getByTestId(annotationDraftCommentComposerTestIds.saveButton));
+    await user.click(screen.getByTestId(submitBarTestIds.button));
+
+    await waitFor(() => {
+      expect(submitAnnotation).toHaveBeenCalledTimes(1);
+    });
+
+    const submission = submitAnnotation.mock.calls[0]?.[0];
+    expect(submission?.threads).toHaveLength(1);
+    const anchor = submission?.threads[0]?.subject.kind === 'annotation' ? submission.threads[0].subject.anchor : null;
+    expect(anchor?.quote.exact).toBe('First paragraph.');
+  });
+
+  it('prompts to discard a dirty draft when clicking a different element', async () => {
+    const user = userEvent.setup();
+    renderApp({
+      initialPayload: { contentKind: 'plan', content: '# Title\n\nFirst paragraph.\n\nSecond paragraph.' },
+    });
+
+    const heading = await waitForMarkdownElement('h1');
+    await waitFor(() => {
+      expect(heading).toHaveAttribute('data-target-id');
+    });
+    await user.click(heading);
+    await user.type(await screen.findByTestId(annotationDraftCommentComposerTestIds.textarea), 'Heading note');
+
+    const firstParagraph = getMarkdownParagraph(0);
+    await waitFor(() => {
+      expect(firstParagraph).toHaveAttribute('data-target-id');
+    });
+    await user.click(firstParagraph);
+
+    expect(await screen.findByTestId(appTestIds.discardDraftDialog)).toBeInTheDocument();
+
+    await user.click(screen.getByTestId(appTestIds.discardDraftDialogCancelButton));
+    expect(screen.getByTestId(annotationDraftCommentComposerTestIds.textarea)).toHaveValue('Heading note');
+
+    await user.click(firstParagraph);
+    await user.click(await screen.findByTestId(appTestIds.discardDraftDialogActionButton));
+    expect(screen.getByTestId(annotationDraftCommentComposerTestIds.textarea)).toHaveValue('');
+  });
+
+  it('edits an existing annotation when clicking it while a different empty draft is open', async () => {
+    const user = userEvent.setup();
+    renderApp({
+      initialPayload: { contentKind: 'plan', content: '# Title\n\nFirst paragraph.\n\nSecond paragraph.' },
+    });
+
+    await saveAnnotationOnElement(user, await waitForMarkdownElement('h1'), 'Heading comment');
+
+    const firstParagraph = getMarkdownParagraph(0);
+    await waitFor(() => {
+      expect(firstParagraph).toHaveAttribute('data-target-id');
+    });
+    await user.click(firstParagraph);
+    await screen.findByTestId(annotationDraftCommentComposerTestIds.container);
+
+    const heading = getMarkdownElement('h1');
+    const rect = heading.getBoundingClientRect();
+    fireEvent.click(heading, {
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + rect.height / 2,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId(annotationDraftCommentComposerTestIds.textarea)).toHaveValue('Heading comment');
+    });
+  });
+
   it('uses the generic discard workflow before submitting with an unsaved annotation draft', async () => {
     const user = userEvent.setup();
     const { submitAnnotation } = renderApp({

--- a/packages/annotation/src/useAnnotationInteractions.ts
+++ b/packages/annotation/src/useAnnotationInteractions.ts
@@ -99,7 +99,7 @@ export function useAnnotationInteractions({
   );
 
   useTargetActivation({
-    enabled: activeDraft === null && !submitted,
+    enabled: !submitted,
     container: planContainer,
     index: textIndex,
     suppressNextActivationRef: suppressNextTargetActivationRef,
@@ -155,7 +155,7 @@ export function useAnnotationInteractions({
   }, [draftRange, highlightedAnnotationId, resolvedThreads]);
 
   useEffect(() => {
-    if (!planContainer || submitted || activeDraft !== null) {
+    if (!planContainer || submitted) {
       return;
     }
 
@@ -184,7 +184,7 @@ export function useAnnotationInteractions({
     return () => {
       planContainer.removeEventListener('click', handleClickCapture, true);
     };
-  }, [activeDraft, editAnnotationComment, planContainer, submitted]);
+  }, [editAnnotationComment, planContainer, submitted]);
 
   useHotkeys(
     'escape',


### PR DESCRIPTION
## Summary

I noticed this inconsistency while adding Mermaid support.

In the plan annotation UI, clicking an annotatable element to start an annotation was hard-gated on `activeDraft === null`, so an already-open *empty* comment draft could not be replaced by a click — but drag-selecting different text already replaced it. The two gestures were inconsistent and the empty draft felt "stuck" (dismissible only via Escape/Cancel). This routes both click entry points through the same replace/discard arbiter the drag path already uses, so clicking a different element replaces an empty draft (or prompts the discard dialog for a dirty one).

Closes #213 (PLAN-26 sibling: PLAN-78).

## Review focus

Scope decision: I ungated **both** click entry points, not just the one in the repro. The second gate governs "click an existing saved annotation → edit it"; ungating it means clicking a saved annotation while a draft is open now *edits* it rather than being ignored (or creating an overlapping new thread, as drag would). This makes draft-open click behavior identical to draft-closed, and matches the already-ungated drag path. The capture-phase `stopImmediatePropagation` + shared `suppressNextTargetActivationRef` still make the edit path win over new-annotation when a click lands on an existing annotation — unchanged from how it works with no draft open.

## Commits

- [`72d6322`](https://github.com/contextbridge/planbridge/commit/72d6322) — Drop the `activeDraft` clause from both click gates in `useAnnotationInteractions.ts` (routing clicks through `requestDraftAction`), and add three `App.test.tsx` cases (empty-draft replace, dirty-draft discard prompt, edit-existing-on-click) written TDD-style.