### PR TITLE
feat: add element annotations with a Mermaid diagram adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "@contextbridge/ui": "workspace:*",
         "highlight.js": "^11.11.1",
         "lucide-react": "catalog:",
+        "mermaid": "11.15.0",
         "neverthrow": "catalog:",
         "react": "catalog:",
         "react-dom": "catalog:",
@@ -399,7 +400,11 @@
 
     "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
     "@clack/core": ["@clack/core@1.3.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA=="],
 
@@ -571,7 +576,7 @@
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
-    "@iconify/utils": ["@iconify/utils@2.3.0", "", { "dependencies": { "@antfu/install-pkg": "^1.0.0", "@antfu/utils": "^8.1.0", "@iconify/types": "^2.0.0", "debug": "^4.4.0", "globals": "^15.14.0", "kolorist": "^1.8.0", "local-pkg": "^1.0.0", "mlly": "^1.7.4" } }, "sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA=="],
+    "@iconify/utils": ["@iconify/utils@3.1.3", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -640,6 +645,8 @@
     "@js-temporal/polyfill": ["@js-temporal/polyfill@0.5.1", "", { "dependencies": { "jsbi": "^4.3.0" } }, "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -1085,6 +1092,68 @@
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -1096,6 +1165,8 @@
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -1198,6 +1269,8 @@
     "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@vercel/og": ["@vercel/og@0.11.1", "", { "dependencies": { "@resvg/resvg-wasm": "2.4.0", "satori": "0.25.0" }, "optionalDependencies": { "sharp": "^0.34.5" } }, "sha512-02rXXRABFq1B03w3aNhcVfxkY+8Ba5QFi4ax0zS0oOiD/LL9WUd/LA7BjVPakrQmVhIBjuo2oBM5U25R9IuXMg=="],
 
@@ -1423,6 +1496,8 @@
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
@@ -1453,6 +1528,78 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
 
     "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
@@ -1460,6 +1607,8 @@
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
 
     "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -1480,6 +1629,8 @@
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -1560,6 +1711,8 @@
     "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "es-toolkit": ["es-toolkit@1.47.0", "", {}, "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -1743,6 +1896,8 @@
 
     "h3": ["h3@1.15.11", "", { "dependencies": { "cookie-es": "^1.2.3", "crossws": "^0.3.5", "defu": "^6.1.6", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
     "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
@@ -1827,11 +1982,13 @@
 
     "i18next": ["i18next@23.16.8", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg=="],
 
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-in-the-middle": ["import-in-the-middle@3.0.1", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
@@ -1842,6 +1999,8 @@
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -1959,13 +2118,19 @@
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "klona": ["klona@2.0.6", "", {}, "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="],
 
     "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -1999,6 +2164,8 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "lodash.mergewith": ["lodash.mergewith@4.6.2", "", {}, "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
@@ -2024,6 +2191,8 @@
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -2070,6 +2239,8 @@
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "mermaid": ["mermaid@11.15.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.1", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "es-toolkit": "^1.45.1", "katex": "^0.16.25", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -2269,6 +2440,8 @@
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -2314,6 +2487,10 @@
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -2489,13 +2666,19 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "s.color": ["s.color@0.0.15", "", {}, "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA=="],
 
@@ -2614,6 +2797,8 @@
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
     "suf-log": ["suf-log@2.5.3", "", { "dependencies": { "s.color": "0.0.15" } }, "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow=="],
 
@@ -2754,6 +2939,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -2897,9 +3084,9 @@
 
     "@fastify/otel/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.212.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.212.0", "import-in-the-middle": "^2.0.6", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg=="],
 
-    "@iconify/tools/svgo": ["svgo@3.3.3", "", { "dependencies": { "commander": "^7.2.0", "css-select": "^5.1.0", "css-tree": "^2.3.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.0.0", "sax": "^1.5.0" }, "bin": "./bin/svgo" }, "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng=="],
+    "@iconify/tools/@iconify/utils": ["@iconify/utils@2.3.0", "", { "dependencies": { "@antfu/install-pkg": "^1.0.0", "@antfu/utils": "^8.1.0", "@iconify/types": "^2.0.0", "debug": "^4.4.0", "globals": "^15.14.0", "kolorist": "^1.8.0", "local-pkg": "^1.0.0", "mlly": "^1.7.4" } }, "sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA=="],
 
-    "@iconify/utils/globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
+    "@iconify/tools/svgo": ["svgo@3.3.3", "", { "dependencies": { "commander": "^7.2.0", "css-select": "^5.1.0", "css-tree": "^2.3.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.0.0", "sax": "^1.5.0" }, "bin": "./bin/svgo" }, "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng=="],
 
     "@mdx-js/mdx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -2977,11 +3164,21 @@
 
     "astro-eslint-parser/@typescript-eslint/types": ["@typescript-eslint/types@8.59.1", "", {}, "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A=="],
 
+    "astro-icon/@iconify/utils": ["@iconify/utils@2.3.0", "", { "dependencies": { "@antfu/install-pkg": "^1.0.0", "@antfu/utils": "^8.1.0", "@iconify/types": "^2.0.0", "debug": "^4.4.0", "globals": "^15.14.0", "kolorist": "^1.8.0", "local-pkg": "^1.0.0", "mlly": "^1.7.4" } }, "sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA=="],
+
+    "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
-    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
-    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "eslint/eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 
@@ -3007,6 +3204,8 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
     "magicast/@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -3026,6 +3225,8 @@
     "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "react-docgen/doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
@@ -3048,8 +3249,6 @@
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -3097,6 +3296,8 @@
 
     "@fastify/otel/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
+    "@iconify/tools/@iconify/utils/globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
+
     "@iconify/tools/svgo/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
     "@iconify/tools/svgo/css-tree": ["css-tree@2.3.1", "", { "dependencies": { "mdn-data": "2.0.30", "source-map-js": "^1.0.1" } }, "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw=="],
@@ -3110,6 +3311,8 @@
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "astro-eslint-parser/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg=="],
+
+    "astro-icon/@iconify/utils/globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
 
     "astro/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -3168,6 +3371,12 @@
     "astro/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "eslint-plugin-react/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
+        "unist-util-visit": "^5.1.0",
       },
       "devDependencies": {
         "@storybook/react-vite": "catalog:",
@@ -48,6 +49,7 @@
         "@testing-library/jest-dom": "catalog:",
         "@testing-library/react": "catalog:",
         "@testing-library/user-event": "^14.6.1",
+        "@types/hast": "^3.0.4",
         "@types/react": "catalog:",
         "@types/react-dom": "catalog:",
         "@vitejs/plugin-react": "catalog:",

--- a/packages/annotation/package.json
+++ b/packages/annotation/package.json
@@ -24,10 +24,12 @@
     "react-hotkeys-hook": "^5.3.2",
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@storybook/react-vite": "catalog:",
+    "@types/hast": "^3.0.4",
     "@tailwindcss/vite": "catalog:",
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",

--- a/packages/annotation/package.json
+++ b/packages/annotation/package.json
@@ -17,6 +17,7 @@
     "@contextbridge/ui": "workspace:*",
     "highlight.js": "^11.11.1",
     "lucide-react": "catalog:",
+    "mermaid": "11.15.0",
     "neverthrow": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/packages/annotation/src/AnnotatedMarkdown.tsx
+++ b/packages/annotation/src/AnnotatedMarkdown.tsx
@@ -1,10 +1,17 @@
 import type { AnnotationTargetKind, Asset } from '@contextbridge/shared/annotationSchema';
 import { cn } from '@contextbridge/ui/lib/utils';
+import type { Element } from 'hast';
 import { createElement } from 'react';
 import type { ComponentPropsWithoutRef, ComponentType, JSX, Ref } from 'react';
 import ReactMarkdown, { type ExtraProps } from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
+import { adapterForLang } from './element/ElementAdapter.ts';
+import {
+  ELEMENT_LANG_PROPERTY,
+  ELEMENT_SOURCE_PROPERTY,
+  rehypeElementSources,
+} from './element/rehypeElementSources.ts';
 
 export const annotatedMarkdownTestIds = {
   container: 'plan-review-markdown-plan',
@@ -40,7 +47,9 @@ export function AnnotatedMarkdown({ content, containerRef, onMouseUp, assets }: 
     >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[[rehypeHighlight, { detect: false, ignoreMissing: true }]]}
+        // rehypeElementSources must run before rehypeHighlight so a claimed block keeps its raw
+        // source instead of being tokenized into highlight spans.
+        rehypePlugins={[rehypeElementSources, [rehypeHighlight, { detect: false, ignoreMissing: true }]]}
         components={components}
       >
         {content}
@@ -146,7 +155,28 @@ const markdownComponents = {
     targetKind: 'block',
     className: 'border-l-4 border-chart-3/60 bg-chart-3/10 px-5 py-3 text-foreground/85 italic',
   }),
-  pre: AnnotatablePre,
+  pre: ({ node, children, ...props }: AnnotatableProps<'pre'>) => {
+    const fallback = (
+      <AnnotatablePre node={node} {...props}>
+        {children}
+      </AnnotatablePre>
+    );
+    const block = elementBlockFromPre(node);
+    const adapter = block ? adapterForLang(block.lang) : undefined;
+    if (!block || !adapter) {
+      return fallback;
+    }
+    const Block = adapter.Block;
+    return (
+      <Block
+        source={block.source}
+        contentType={adapter.contentType}
+        startLine={node?.position?.start.line}
+        endLine={node?.position?.end.line}
+        fallback={fallback}
+      />
+    );
+  },
   tr: annotatable('tr', {
     targetKey: 'tr',
     targetKind: 'table-row',
@@ -181,3 +211,12 @@ const markdownComponents = {
     <AnnotatableAnchor {...rest} rel={rel ?? 'noreferrer'} target={target ?? '_blank'} />
   ),
 };
+
+// Reads the source + language an element adapter stashed on a fenced code block (see
+// rehypeElementSources). Returns undefined for ordinary code blocks, which render normally.
+function elementBlockFromPre(node: Element | undefined): { lang: string; source: string } | undefined {
+  const code = node?.children.find((child): child is Element => child.type === 'element' && child.tagName === 'code');
+  const source = code?.properties[ELEMENT_SOURCE_PROPERTY];
+  const lang = code?.properties[ELEMENT_LANG_PROPERTY];
+  return typeof source === 'string' && typeof lang === 'string' ? { lang, source } : undefined;
+}

--- a/packages/annotation/src/App.mermaid.test.tsx
+++ b/packages/annotation/src/App.mermaid.test.tsx
@@ -1,0 +1,235 @@
+import type { AnnotationSubmission, ElementAnnotationAnchor } from '@contextbridge/shared/annotationSchema';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import { annotatedMarkdownTestIds } from './AnnotatedMarkdown.tsx';
+import { annotationDraftCommentComposerTestIds } from './AnnotationDraftCommentComposer.tsx';
+import { appTestIds } from './App.tsx';
+import { elementBlockAttrs } from './element/elementBlock.ts';
+import { mermaidAttrs } from './element/mermaid/MermaidBlock.tsx';
+import { annotateAndSubmit, renderApp, saveAnnotation } from './testHelpers/index.tsx';
+
+// End-to-end through the real `mermaid` dependency: a plan with a fenced mermaid block flows through
+// rehypeElementSources → AnnotatedMarkdown → MermaidBlock (renders the SVG and tags its nodes/edges)
+// → useElementTargets → the mermaid adapter's buildAnchor → the submitted payload. Rendering with
+// the actual library — not a hand-built SVG — is the point: a mermaid upgrade that changes the
+// rendered structure the adapter keys off (node element ids, edge-label markup) breaks these tests.
+describe('App — Mermaid diagram annotation', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('reports a node annotation to the agent as a "diagram node"', async () => {
+    const user = userEvent.setup();
+    const { submitAnnotation } = renderApp({ initialPayload: { contentKind: 'plan', content: MERMAID_PLAN.content } });
+
+    const node = await waitForDiagramElement(`[${mermaidAttrs.nodeId}="Login"]`);
+    const submission = await annotateAndSubmit({
+      user,
+      submitAnnotation,
+      target: node,
+      body: 'Should the login form support SSO?',
+    });
+
+    expect(submission).toMatchObject({
+      status: 'changes_requested',
+      threads: [
+        {
+          subject: { kind: 'annotation' },
+          messages: [{ body: 'Should the login form support SSO?' }],
+        },
+      ],
+    });
+    expect(expectElementAnchor(submission)).toMatchObject({
+      contentType: 'mermaid',
+      blockTargetId: `mermaid:${MERMAID_PLAN.fence.start}`,
+      sourceLines: MERMAID_PLAN.fence,
+      element: { id: 'Login', label: 'Login form', descriptor: 'diagram node' },
+    });
+  });
+
+  it('reports a labeled-edge annotation as a "diagram edge"', async () => {
+    const user = userEvent.setup();
+    const { submitAnnotation } = renderApp({ initialPayload: { contentKind: 'plan', content: MERMAID_PLAN.content } });
+
+    const edge = await waitForDiagramElement(`[${mermaidAttrs.edgeId}][${mermaidAttrs.label}="valid"]`);
+    const submission = await annotateAndSubmit({
+      user,
+      submitAnnotation,
+      target: edge,
+      body: 'Where does a valid token go next?',
+    });
+
+    const anchor = expectElementAnchor(submission);
+    expect(anchor).toMatchObject({
+      contentType: 'mermaid',
+      element: { label: 'valid', descriptor: 'diagram edge' },
+    });
+    // The edge id is mermaid's own opaque identifier; assert it was captured, not its exact value.
+    expect(anchor.element.id).toBeTruthy();
+  });
+
+  it('reports a click on empty diagram space as the whole "diagram"', async () => {
+    const user = userEvent.setup();
+    const { submitAnnotation } = renderApp({ initialPayload: { contentKind: 'plan', content: MERMAID_PLAN.content } });
+
+    const block = await waitForDiagramElement(`[${elementBlockAttrs.blockId}]`);
+    const submission = await annotateAndSubmit({
+      user,
+      submitAnnotation,
+      target: block,
+      body: 'Add a logout path to this flow.',
+    });
+
+    const anchor = expectElementAnchor(submission);
+    expect(anchor).toMatchObject({
+      contentType: 'mermaid',
+      element: { label: 'diagram', descriptor: 'diagram' },
+    });
+    expect(anchor.element.id).toBeUndefined();
+  });
+
+  it('anchors each comment to its own diagram when the plan has several', async () => {
+    const user = userEvent.setup();
+    const { submitAnnotation } = renderApp({
+      initialPayload: { contentKind: 'plan', content: MULTI_DIAGRAM_PLAN.content },
+    });
+
+    // Two diagrams are only distinguishable to the agent by source span, so comment on both and
+    // confirm each anchor carries the line range of the diagram it was placed on.
+    await saveAnnotation({
+      user,
+      target: await waitForDiagramElement(`[${mermaidAttrs.nodeId}="Login"]`),
+      body: 'Login-diagram comment',
+    });
+    const submission = await annotateAndSubmit({
+      user,
+      submitAnnotation,
+      target: await waitForDiagramElement(`[${mermaidAttrs.nodeId}="Logout"]`),
+      body: 'Logout-diagram comment',
+    });
+
+    const anchors = elementAnchorsByBody(submission);
+    expect(anchors['Login-diagram comment']).toMatchObject({
+      blockTargetId: `mermaid:${MULTI_DIAGRAM_PLAN.loginFence.start}`,
+      sourceLines: MULTI_DIAGRAM_PLAN.loginFence,
+      element: { id: 'Login', descriptor: 'diagram node' },
+    });
+    expect(anchors['Logout-diagram comment']).toMatchObject({
+      blockTargetId: `mermaid:${MULTI_DIAGRAM_PLAN.logoutFence.start}`,
+      sourceLines: MULTI_DIAGRAM_PLAN.logoutFence,
+      element: { id: 'Logout', descriptor: 'diagram node' },
+    });
+  });
+
+  it('replaces an empty diagram draft when clicking a different element', async () => {
+    const user = userEvent.setup();
+    const { submitAnnotation } = renderApp({ initialPayload: { contentKind: 'plan', content: MERMAID_PLAN.content } });
+
+    // Open an empty draft on one node, then comment on a different one without typing first. The
+    // empty draft is replaced (no discard prompt), so the submitted thread anchors to the second
+    // node — matching the text-selection path.
+    fireEvent.click(await waitForDiagramElement(`[${mermaidAttrs.nodeId}="Login"]`));
+    await screen.findByTestId(annotationDraftCommentComposerTestIds.container);
+
+    const submission = await annotateAndSubmit({
+      user,
+      submitAnnotation,
+      target: await waitForDiagramElement(`[${mermaidAttrs.nodeId}="Dashboard"]`),
+      body: 'Comment on the dashboard node',
+    });
+
+    expect(submission?.threads).toHaveLength(1);
+    expect(expectElementAnchor(submission).element).toMatchObject({ id: 'Dashboard', descriptor: 'diagram node' });
+  });
+
+  it('prompts to discard a dirty diagram draft when clicking a different element', async () => {
+    const user = userEvent.setup();
+    renderApp({ initialPayload: { contentKind: 'plan', content: MERMAID_PLAN.content } });
+
+    // A draft with typed-but-unsaved text must not be silently dropped on the next click.
+    fireEvent.click(await waitForDiagramElement(`[${mermaidAttrs.nodeId}="Login"]`));
+    await user.type(await screen.findByTestId(annotationDraftCommentComposerTestIds.textarea), 'Unsaved note');
+
+    fireEvent.click(await waitForDiagramElement(`[${mermaidAttrs.nodeId}="Dashboard"]`));
+
+    expect(await screen.findByTestId(appTestIds.discardDraftDialog)).toBeInTheDocument();
+  });
+});
+
+// Plan fixtures pair the markdown with the 1-indexed source line span of each ```mermaid fence (the
+// span the mermaid block stamps onto its anchors). Hardcoded rather than derived so the expected
+// anchor lines are obvious; keep them in sync with the content if you edit it.
+const MERMAID_PLAN = {
+  content: [
+    '# Auth flow',
+    '',
+    'The login sequence the middleware enforces:',
+    '',
+    '```mermaid', // line 5
+    'flowchart TD',
+    '  Login[Login form] --> Verify{Verify token}',
+    '  Verify -->|valid| Dashboard[Dashboard]',
+    '  Verify -->|invalid| Login',
+    '```', // line 10
+    '',
+    'Annotate a node or edge above.',
+  ].join('\n'),
+  fence: { start: 5, end: 10 },
+};
+
+const MULTI_DIAGRAM_PLAN = {
+  content: [
+    '# Auth flows',
+    '',
+    'Login sequence:',
+    '',
+    '```mermaid', // line 5
+    'flowchart TD',
+    '  Login[Login form] --> Dashboard[Dashboard]',
+    '```', // line 8
+    '',
+    'Logout sequence:',
+    '',
+    '```mermaid', // line 12
+    'flowchart TD',
+    '  Logout[Logout button] --> Goodbye[Goodbye]',
+    '```', // line 15
+  ].join('\n'),
+  loginFence: { start: 5, end: 8 },
+  logoutFence: { start: 12, end: 15 },
+};
+
+async function waitForDiagramElement(selector: string): Promise<Element> {
+  return await waitFor(
+    () => {
+      const element = screen.getByTestId(annotatedMarkdownTestIds.container).querySelector(selector);
+      if (!element) {
+        throw new Error(`Diagram element not rendered yet: ${selector}`);
+      }
+      return element;
+    },
+    { timeout: 5000 },
+  );
+}
+
+function expectElementAnchor(submission: AnnotationSubmission | undefined): ElementAnnotationAnchor {
+  const subject = submission?.threads[0]?.subject;
+  const anchor = subject?.kind === 'annotation' ? subject.anchor : null;
+  if (anchor?.kind !== 'element') {
+    throw new Error(`Expected an element anchor, got ${anchor?.kind ?? 'none'}`);
+  }
+  return anchor;
+}
+
+function elementAnchorsByBody(submission: AnnotationSubmission | undefined): Record<string, ElementAnnotationAnchor> {
+  const byBody: Record<string, ElementAnnotationAnchor> = {};
+  for (const thread of submission?.threads ?? []) {
+    const { subject } = thread;
+    const body = thread.messages[0]?.body;
+    if (subject.kind === 'annotation' && subject.anchor.kind === 'element' && body) {
+      byBody[body] = subject.anchor;
+    }
+  }
+  return byBody;
+}

--- a/packages/annotation/src/App.stories.tsx
+++ b/packages/annotation/src/App.stories.tsx
@@ -84,6 +84,21 @@ const seededThreads = [
 
 const seededGlobalComment = 'The plan never says how rollback works if the verifier swap causes issues.';
 
+const mermaidPlan = [
+  '# Auth flow',
+  '',
+  'The login sequence the middleware should enforce:',
+  '',
+  '```mermaid',
+  'flowchart TD',
+  '  Login[Login form] --> Verify{Verify token}',
+  '  Verify -->|valid| Dashboard[Dashboard]',
+  '  Verify -->|invalid| Login',
+  '```',
+  '',
+  'Click a node or edge above to annotate it, or click empty diagram space to comment on the whole diagram.',
+].join('\n');
+
 const overflowingCommentBodies = [
   'Why does the doc step happen after the verifier swap instead of before it?',
   'How long do we keep the legacy verifier around once the flag flips in production?',
@@ -161,6 +176,26 @@ export const SeededReview: Story = {
     initialGlobalComment: seededGlobalComment,
   },
   decorators: [withAppContext({ submitAnnotation: delayedSubmit })],
+};
+
+export const MermaidDiagram: Story = {
+  args: {
+    initialPayload: {
+      contentKind: 'plan',
+      content: mermaidPlan,
+      title: 'Auth flow',
+      metadata: { entrypoint: 'plan_command' },
+    },
+  },
+  decorators: [withAppContext({ submitAnnotation: delayedSubmit })],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a Mermaid flowchart through the mermaid ElementAdapter. Click a node, edge, or empty diagram area to annotate it; saved annotations show the amber marker and hover shows the royal preview.',
+      },
+    },
+  },
 };
 
 export const OverflowingComments: Story = {

--- a/packages/annotation/src/App.stories.tsx
+++ b/packages/annotation/src/App.stories.tsx
@@ -33,6 +33,7 @@ const seededThreads = [
     subject: {
       kind: 'annotation' as const,
       anchor: {
+        kind: 'text' as const,
         createdFrom: 'element' as const,
         sourceLines: { start: 14, end: 14 },
         quote: {

--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -322,7 +322,7 @@ describe('App', () => {
     const submission = submitAnnotation.mock.calls[0]?.[0];
     expect(submission?.threads).toHaveLength(1);
     const anchor = submission?.threads[0]?.subject.kind === 'annotation' ? submission.threads[0].subject.anchor : null;
-    expect(anchor?.quote.exact).toBe('First paragraph.');
+    expect(anchor?.kind === 'text' ? anchor.quote.exact : null).toBe('First paragraph.');
   });
 
   it('prompts to discard a dirty draft when clicking a different element', async () => {
@@ -535,7 +535,7 @@ describe('App', () => {
     const submission = submitAnnotation.mock.calls[0]?.[0];
     expect(submission?.threads).toHaveLength(1);
     const anchor = submission?.threads[0]?.subject.kind === 'annotation' ? submission.threads[0].subject.anchor : null;
-    expect(anchor?.quote.exact).toBe('"helloWorld"');
+    expect(anchor?.kind === 'text' ? anchor.quote.exact : null).toBe('"helloWorld"');
   });
 
   it('scopes a code-token click to just the token, not the whole block', async () => {
@@ -562,7 +562,7 @@ describe('App', () => {
 
     const submission = submitAnnotation.mock.calls[0]?.[0];
     const anchor = submission?.threads[0]?.subject.kind === 'annotation' ? submission.threads[0].subject.anchor : null;
-    expect(anchor?.quote.exact).toBe('"hello"');
+    expect(anchor?.kind === 'text' ? anchor.quote.exact : null).toBe('"hello"');
   });
 
   it('renders markdown links with target="_blank" and rel="noreferrer"', async () => {

--- a/packages/annotation/src/annotationResolvers.ts
+++ b/packages/annotation/src/annotationResolvers.ts
@@ -1,7 +1,23 @@
-import type { CommentThread, StoredAnnotationAnchor } from '@contextbridge/shared/annotationSchema';
+import type {
+  CommentThread,
+  ElementAnnotationAnchor,
+  StoredAnnotationAnchor,
+} from '@contextbridge/shared/annotationSchema';
 import type { ActiveCommentDraft, ResolvedAnnotationThread, SelectableTextIndex } from './annotationTypes.ts';
 import { isAnnotationCommentThread } from './annotationTypes.ts';
 import { getPrimaryMessage } from './commentModel.ts';
+import { adapterForContentType } from './element/ElementAdapter.ts';
+
+export function isElementAnchor(anchor: StoredAnnotationAnchor): anchor is ElementAnnotationAnchor {
+  return anchor.kind === 'element';
+}
+
+export function findElementAnchorTarget(container: HTMLElement, anchor: StoredAnnotationAnchor): Element | null {
+  if (!isElementAnchor(anchor)) {
+    return null;
+  }
+  return adapterForContentType(anchor.contentType)?.resolveTarget(container, anchor) ?? null;
+}
 
 export function resolveAnnotationThreads(
   textIndex: SelectableTextIndex | null,
@@ -18,21 +34,12 @@ export function resolveAnnotationThreads(
     }
 
     const anchor = thread.subject.anchor;
-    const range = textIndex.restoreAnchor(anchor);
-    const targetId = anchor.target?.id ?? anchor.endpoints.start.targetId;
     const primaryMessage = getPrimaryMessage(thread);
-
-    return [
-      {
-        id: thread.id,
-        anchor,
-        range,
-        target: textIndex.resolveTarget(targetId),
-        unresolved: range === null,
-        quote: anchor.quote.exact,
-        comments: [{ kind: 'saved', threadId: thread.id, message: primaryMessage, isPrimary: true }],
-      },
+    const comments = [
+      { kind: 'saved' as const, threadId: thread.id, message: primaryMessage, isPrimary: true as const },
     ];
+
+    return [resolveThread({ id: thread.id, anchor, comments, textIndex })];
   });
 
   return withActiveDraftThread(textIndex, items, activeDraft).sort(compareResolvedThreads);
@@ -47,7 +54,47 @@ export function getDraftThreadId(draft: ActiveCommentDraft): string {
 }
 
 export function getNewThreadDraftId(anchor: StoredAnnotationAnchor): string {
-  return `draft-annotation-${anchor.position.start}-${anchor.position.end}`;
+  if (anchor.kind === 'text') {
+    return `draft-annotation-${anchor.position.start}-${anchor.position.end}`;
+  }
+
+  return `draft-annotation-element-${anchor.blockTargetId}-${anchor.element.id ?? anchor.element.descriptor}`;
+}
+
+// Resolves one stored anchor into the runtime thread shape the UI renders. The two arms are the
+// two annotation mechanisms (text-range vs element); the element arm is content-type-agnostic —
+// the only adapter-specific work (finding the DOM element) is deferred to focus/marker time.
+function resolveThread(args: {
+  id: string;
+  anchor: StoredAnnotationAnchor;
+  comments: ResolvedAnnotationThread['comments'];
+  textIndex: SelectableTextIndex;
+}): ResolvedAnnotationThread {
+  const { id, anchor, comments, textIndex } = args;
+
+  if (anchor.kind === 'text') {
+    const range = textIndex.restoreAnchor(anchor);
+    const targetId = anchor.target?.id ?? anchor.endpoints.start.targetId;
+    return {
+      id,
+      anchor,
+      range,
+      target: textIndex.resolveTarget(targetId),
+      unresolved: range === null,
+      quote: anchor.quote.exact,
+      comments,
+    };
+  }
+
+  return {
+    id,
+    anchor,
+    range: null,
+    target: null,
+    unresolved: false,
+    quote: anchor.element.label,
+    comments,
+  };
 }
 
 function withActiveDraftThread(
@@ -66,19 +113,14 @@ function withActiveDraftThread(
     );
   }
 
-  const draftRange = textIndex.restoreAnchor(activeDraft.anchor);
-  const draftTargetId = activeDraft.anchor.target?.id ?? activeDraft.anchor.endpoints.start.targetId;
   return [
     ...items,
-    {
+    resolveThread({
       id: getNewThreadDraftId(activeDraft.anchor),
       anchor: activeDraft.anchor,
-      range: draftRange,
-      target: textIndex.resolveTarget(draftTargetId),
-      unresolved: draftRange === null,
-      quote: activeDraft.anchor.quote.exact,
       comments: [draftComment],
-    },
+      textIndex,
+    }),
   ];
 }
 
@@ -98,5 +140,32 @@ function compareResolvedThreads(left: ResolvedAnnotationThread, right: ResolvedA
     return 1;
   }
 
-  return left.anchor.position.start - right.anchor.position.start;
+  // Range-less threads (element anchors) order by source line, which tracks document order,
+  // before falling back to a per-anchor secondary key.
+  const lineOrder = left.anchor.sourceLines.start - right.anchor.sourceLines.start;
+  if (lineOrder !== 0) {
+    return lineOrder;
+  }
+
+  return secondaryOrderKey(left.anchor) - secondaryOrderKey(right.anchor);
+}
+
+/**
+ * Stable tiebreaker for two threads that share a start line (e.g. comments on different nodes of the
+ * same diagram). Text anchors order by character offset; element anchors have none, so hash their id.
+ */
+function secondaryOrderKey(anchor: StoredAnnotationAnchor): number {
+  if (anchor.kind === 'text') {
+    return anchor.position.start;
+  }
+  return stableOffset(`${anchor.blockTargetId}:${anchor.element.id ?? anchor.element.descriptor}`);
+}
+
+/** Hashes a string to a small, stable number — used only to keep equal-line anchors in a fixed order. */
+function stableOffset(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) % 1_000_000;
+  }
+  return hash;
 }

--- a/packages/annotation/src/annotationTypes.ts
+++ b/packages/annotation/src/annotationTypes.ts
@@ -3,6 +3,7 @@ import type {
   CommentMessage,
   CommentThread,
   StoredAnnotationAnchor,
+  TextAnnotationAnchor,
 } from '@contextbridge/shared/annotationSchema';
 
 export type AnnotationCommentThread = CommentThread & {
@@ -31,11 +32,11 @@ export interface SelectableTextIndex {
   targets: Map<string, AnnotatableTarget>;
   rangeToAnchor(
     range: Range,
-    createdFrom: StoredAnnotationAnchor['createdFrom'],
+    createdFrom: TextAnnotationAnchor['createdFrom'],
     explicitTarget?: HTMLElement,
-  ): StoredAnnotationAnchor;
+  ): TextAnnotationAnchor;
   targetToRange(targetId: string): Range | null;
-  restoreAnchor(anchor: StoredAnnotationAnchor): Range | null;
+  restoreAnchor(anchor: TextAnnotationAnchor): Range | null;
   resolveTarget(targetId: string): AnnotatableTarget | null;
 }
 

--- a/packages/annotation/src/element/ElementAdapter.ts
+++ b/packages/annotation/src/element/ElementAdapter.ts
@@ -1,0 +1,52 @@
+import type { ElementAnnotationAnchor } from '@contextbridge/shared/annotationSchema';
+import type { ComponentType } from 'react';
+import type { ResolvedAnnotationThread } from '../annotationTypes.ts';
+import type { ElementBlockProps } from './elementBlock.ts';
+
+/**
+ * Adapts a non-text content type (e.g. a Mermaid diagram) into the annotation engine. Implement
+ * this interface and register the instance in {@link elementAdapters} to make a kind of rendered
+ * content annotatable; the resolver, interaction hook, CLI serializer, and sidebar are generic
+ * over `element` anchors and need no per-type changes.
+ *
+ * An adapter is self-contained: it renders its own DOM, tags its own sub-elements (private
+ * data-attributes), builds and resolves anchors against those tags, and owns its marker and hover
+ * CSS. The only shared surface is the block-level contract in `elementBlock.ts`, which lets the
+ * interaction hook route events to the owning adapter.
+ */
+export interface ElementAdapter {
+  /** Stable id for this content type, stored verbatim on every anchor as `contentType` and used to route resolve/marker/hover calls back here. e.g. `'mermaid'`. */
+  readonly contentType: string;
+
+  /** True if this adapter renders the given fenced-code language (the info string of a ``` block). e.g. `(lang) => lang === 'mermaid'`. */
+  claims(lang: string): boolean;
+
+  /** React component that renders the source to DOM and tags its annotatable sub-elements. Spreads the shared block-level attrs from `elementBlock.ts` and dispatches `ELEMENT_RENDERED_EVENT` once tagged so markers re-apply. */
+  readonly Block: ComponentType<ElementBlockProps>;
+
+  /** Translate a click on a tagged sub-element (or the block itself) into a stored anchor; return null if the click isn't on something annotatable. Stamps the agent-facing `descriptor` + `label` here — this is where serialization wording is decided. */
+  buildAnchor(block: HTMLElement, clicked: Element): ElementAnnotationAnchor | null;
+
+  /** Find the live DOM element a stored anchor points at (for focus/scroll/marker placement). Returns null when the content changed and the element is gone. */
+  resolveTarget(container: HTMLElement, anchor: ElementAnnotationAnchor): Element | null;
+
+  /** Paint saved/active markers for this adapter's threads. Receives the element threads (the hook filters to this `contentType`); clears its own markers before re-applying. */
+  applyMarkers(args: {
+    container: HTMLElement;
+    threads: ResolvedAnnotationThread[];
+    activeAnnotationId: string | null;
+  }): void;
+}
+
+/** The registered element adapters. Add a new content type here — nothing else changes. */
+export const elementAdapters: ElementAdapter[] = [];
+
+/** The adapter that renders a given fenced-code language, if any. */
+export function adapterForLang(lang: string): ElementAdapter | undefined {
+  return elementAdapters.find((adapter) => adapter.claims(lang));
+}
+
+/** The adapter that owns a given `contentType` (an anchor's `contentType`), if any. */
+export function adapterForContentType(contentType: string): ElementAdapter | undefined {
+  return elementAdapters.find((adapter) => adapter.contentType === contentType);
+}

--- a/packages/annotation/src/element/ElementAdapter.ts
+++ b/packages/annotation/src/element/ElementAdapter.ts
@@ -2,6 +2,7 @@ import type { ElementAnnotationAnchor } from '@contextbridge/shared/annotationSc
 import type { ComponentType } from 'react';
 import type { ResolvedAnnotationThread } from '../annotationTypes.ts';
 import type { ElementBlockProps } from './elementBlock.ts';
+import { mermaidAdapter } from './mermaid/mermaidAdapter.ts';
 
 /**
  * Adapts a non-text content type (e.g. a Mermaid diagram) into the annotation engine. Implement
@@ -39,7 +40,7 @@ export interface ElementAdapter {
 }
 
 /** The registered element adapters. Add a new content type here — nothing else changes. */
-export const elementAdapters: ElementAdapter[] = [];
+export const elementAdapters: ElementAdapter[] = [mermaidAdapter];
 
 /** The adapter that renders a given fenced-code language, if any. */
 export function adapterForLang(lang: string): ElementAdapter | undefined {

--- a/packages/annotation/src/element/elementBlock.ts
+++ b/packages/annotation/src/element/elementBlock.ts
@@ -1,0 +1,79 @@
+import type { ReactNode } from 'react';
+
+/**
+ * The minimal contract shared between the generic element-annotation layer and every
+ * {@link ElementAdapter}. An adapter renders its own DOM and tags its own sub-elements with
+ * private attributes; the only thing it shares is this block-level vocabulary, which lets the
+ * interaction hook (`useElementTargets`) find a rendered block and route events to the adapter
+ * that owns it. There is deliberately no shared wrapper component — just these attrs, the id
+ * scheme, and the ready event.
+ */
+
+/** Props every adapter's `Block` component receives from `AnnotatedMarkdown`. */
+export interface ElementBlockProps {
+  /** The block's raw source text (for Mermaid, the diagram definition). */
+  source: string;
+  /** The owning adapter's content type, e.g. `'mermaid'`. */
+  contentType: string;
+  /** Document-absolute first line of the block's source. Absent ⇒ no position info, so annotation is disabled but the block still renders. */
+  startLine?: number;
+  /** Document-absolute last line of the block's source. */
+  endLine?: number;
+  /** Rendered verbatim when the source fails to parse — keeps malformed content visible as a plain code block. */
+  fallback: ReactNode;
+}
+
+/** Block-level data attributes. Sub-element tagging is each adapter's private business. */
+export const elementBlockAttrs = {
+  /** Marks a rendered, annotatable block. */
+  block: 'data-element-block',
+  /** Stable block id; the interaction hook keys off this to find blocks. */
+  blockId: 'data-element-block-id',
+  /** The owning adapter's content type; the hook reads it to pick the adapter. */
+  contentType: 'data-element-content-type',
+} as const;
+
+/** Custom event an adapter's `Block` dispatches once it has rendered and tagged its elements, so the hook re-applies markers for any existing annotations. */
+export const ELEMENT_RENDERED_EVENT = 'cb:element-rendered';
+
+/**
+ * Stable id for a rendered block: `${contentType}:${startLine}`. Keyed on the block's first
+ * source line so it survives a reload of the same content. Returns undefined when the block has
+ * no position info (annotation disabled).
+ */
+export function elementBlockId(contentType: string, startLine?: number): string | undefined {
+  return startLine === undefined ? undefined : `${contentType}:${startLine}`;
+}
+
+/**
+ * The block-level attributes an adapter spreads onto its container element. Returns an empty
+ * object (no annotatable attrs) when there's no position info, so the block renders but can't
+ * be annotated. Source-line attrs reuse the same `data-src-*` names as text targets.
+ */
+export function elementBlockContainerProps(args: {
+  contentType: string;
+  startLine?: number;
+  endLine?: number;
+}): Record<string, string> {
+  const { contentType, startLine, endLine } = args;
+  const blockId = elementBlockId(contentType, startLine);
+  if (blockId === undefined || startLine === undefined) {
+    return {};
+  }
+
+  const props: Record<string, string> = {
+    [elementBlockAttrs.block]: '',
+    [elementBlockAttrs.blockId]: blockId,
+    [elementBlockAttrs.contentType]: contentType,
+    'data-src-start-line': String(startLine),
+  };
+  if (endLine !== undefined) {
+    props['data-src-end-line'] = String(endLine);
+  }
+  return props;
+}
+
+/** Tell the annotation layer a block finished rendering and tagging, so markers re-apply. */
+export function dispatchElementRendered(host: HTMLElement): void {
+  host.dispatchEvent(new CustomEvent(ELEMENT_RENDERED_EVENT, { bubbles: true }));
+}

--- a/packages/annotation/src/element/mermaid/MermaidBlock.tsx
+++ b/packages/annotation/src/element/mermaid/MermaidBlock.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useId, useRef, useState } from 'react';
+import type { ElementBlockProps } from '../elementBlock.ts';
+import { dispatchElementRendered, elementBlockContainerProps } from '../elementBlock.ts';
+import './mermaidAdapter.css';
+import { currentMermaidTheme, renderMermaid } from './renderer.ts';
+
+const NODE_ID_PATTERN = /flowchart-(.+)-\d+$/;
+
+export const mermaidBlockTestIds = {
+  container: 'mermaid-block',
+  diagram: 'mermaid-block-diagram',
+  loading: 'mermaid-block-loading',
+};
+
+/**
+ * Mermaid's private sub-element tagging vocabulary. `MermaidBlock` writes these after render;
+ * `mermaidAdapter` reads them to build/resolve/mark anchors. Kept here (not in the shared
+ * `elementBlock` contract) because they are this adapter's business alone.
+ */
+export const mermaidAttrs = {
+  nodeId: 'data-mermaid-node-id',
+  edgeId: 'data-mermaid-edge-id',
+  label: 'data-mermaid-label',
+} as const;
+
+type RenderState = { status: 'loading' } | { status: 'ready'; svg: string } | { status: 'error' };
+
+export function MermaidBlock({ source, contentType, startLine, endLine, fallback }: ElementBlockProps) {
+  const reactId = useId();
+  const renderId = `mermaid-${reactId}`;
+  const diagramRef = useRef<HTMLDivElement>(null);
+  const [state, setState] = useState<RenderState>({ status: 'loading' });
+
+  useEffect(() => {
+    renderMermaid(renderId, source, currentMermaidTheme())
+      .then(({ svg }) => {
+        setState({ status: 'ready', svg });
+      })
+      .catch(() => {
+        // Mermaid appends an orphaned error node to <body> on parse failure — clean it up.
+        document.getElementById(`d${renderId}`)?.remove();
+        setState({ status: 'error' });
+      });
+  }, [renderId, source]);
+
+  useEffect(() => {
+    const host = diagramRef.current;
+    if (state.status !== 'ready' || !host || startLine === undefined) return;
+    tagMermaidElements(host);
+    // Signal that the diagram is in the DOM so markers re-apply for any comments anchored here.
+    dispatchElementRendered(host);
+  }, [state, startLine]);
+
+  if (state.status === 'error') {
+    return <>{fallback}</>;
+  }
+
+  if (state.status === 'loading') {
+    return (
+      <div
+        className="rounded-md border border-border px-4 py-3 text-sm text-muted-foreground"
+        data-testid={mermaidBlockTestIds.loading}
+      >
+        Rendering diagram…
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="overflow-x-auto rounded-md border border-border px-4 py-3 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-w-full"
+      {...elementBlockContainerProps({ contentType, startLine, endLine })}
+      data-testid={mermaidBlockTestIds.container}
+    >
+      <div ref={diagramRef} data-testid={mermaidBlockTestIds.diagram} dangerouslySetInnerHTML={{ __html: state.svg }} />
+    </div>
+  );
+}
+
+function tagMermaidElements(host: HTMLElement): void {
+  for (const node of host.querySelectorAll<SVGGElement>('g.node[id]')) {
+    const nodeId = NODE_ID_PATTERN.exec(node.id)?.[1];
+    if (nodeId === undefined) continue;
+    node.setAttribute(mermaidAttrs.nodeId, nodeId);
+    node.setAttribute(mermaidAttrs.label, labelOf(node, nodeId));
+  }
+
+  for (const edge of host.querySelectorAll<SVGGElement>('g.edgeLabels g.edgeLabel')) {
+    const edgeId = edge.querySelector('[data-id]')?.getAttribute('data-id');
+    if (!edgeId) continue;
+    edge.setAttribute(mermaidAttrs.edgeId, edgeId);
+    edge.setAttribute(mermaidAttrs.label, labelOf(edge, edgeId));
+  }
+}
+
+function labelOf(element: Element, fallback: string): string {
+  const text = element.querySelector('.nodeLabel, .edgeLabel, p, text')?.textContent?.trim();
+  return text && text.length > 0 ? text : fallback;
+}

--- a/packages/annotation/src/element/mermaid/mermaidAdapter.css
+++ b/packages/annotation/src/element/mermaid/mermaidAdapter.css
@@ -1,0 +1,69 @@
+/* Mermaid adapter styling — self-contained. Lives next to the adapter (not the shared
+   annotationStyles.css) because every selector targets mermaid's generated SVG structure.
+   Tokens are scoped to the mermaid block container so they don't leak globally; their values
+   mirror the amber (saved/active) + royal (hover) language used by text highlights. */
+[data-element-content-type='mermaid'] {
+  --mermaid-mark: color-mix(in oklch, var(--color-amber-300) 85%, transparent);
+  --mermaid-mark-active: var(--color-amber-400);
+  --mermaid-mark-border: var(--color-amber-500);
+  --mermaid-mark-text: var(--color-neutral-950);
+  --mermaid-hover-stroke: var(--chart-3);
+  --mermaid-hover-node: color-mix(in oklab, var(--chart-3) 22%, var(--color-neutral-900));
+  --mermaid-hover-edge: color-mix(in oklab, var(--chart-3) 35%, transparent);
+}
+
+/* Mermaid injects per-diagram `#mermaid-rN .node rect {…}` rules (ID specificity), so our marker
+   declarations need !important to win the cascade. Mirrors the text-highlight tiers as an SVG
+   fill: a filled "block" rather than a stroke outline, matching how annotated prose reads. The
+   direct-child combinator keeps the fill on the node's shape and off nested label/icon paths. */
+g.cb-mermaid-annotated > :is(rect, circle, ellipse, polygon, path) {
+  fill: var(--mermaid-mark) !important;
+  stroke: var(--mermaid-mark-border) !important;
+}
+
+g.cb-mermaid-annotated-active > :is(rect, circle, ellipse, polygon, path) {
+  fill: var(--mermaid-mark-active) !important;
+}
+
+g.cb-mermaid-annotated :is(.nodeLabel, .label, foreignObject p, foreignObject span) {
+  color: var(--mermaid-mark-text) !important;
+  fill: var(--mermaid-mark-text) !important;
+}
+
+/* A whole-diagram comment marks the block (not a single node). The block already carries
+   `border border-border`, so a border-color swap reads as "selected" without flooding the whole
+   diagram area with a fill. */
+div.cb-mermaid-annotated {
+  border-color: var(--mermaid-mark-active);
+}
+
+div.cb-mermaid-annotated-active {
+  border-color: var(--mermaid-mark-border);
+}
+
+/* Hover preview of the node a click would annotate. !important beats mermaid's injected
+   `#mermaid-rN .node rect` rule. oklab, not oklch: mixing a chromatic color with a near-achromatic
+   one in oklch wraps the hue (royal → magenta); oklab keeps the tint blue. */
+g.node:hover > :is(rect, circle, ellipse, polygon, path) {
+  fill: var(--mermaid-hover-node) !important;
+  stroke: var(--mermaid-hover-stroke) !important;
+}
+
+/* Edge-label markers — mermaid draws the label chip as `g.edgeLabel > … div.labelBkg / <p>`, both
+   background-colored via injected ID rules, so these need !important too. Amber chip + dark label
+   for a saved/active edge, royal for hover — mirroring the node treatment. */
+g.edgeLabel.cb-mermaid-annotated :is(.labelBkg, p) {
+  background-color: var(--mermaid-mark) !important;
+}
+
+g.edgeLabel.cb-mermaid-annotated-active :is(.labelBkg, p) {
+  background-color: var(--mermaid-mark-active) !important;
+}
+
+g.edgeLabel.cb-mermaid-annotated p {
+  color: var(--mermaid-mark-text) !important;
+}
+
+g.edgeLabel:hover :is(.labelBkg, p) {
+  background-color: var(--mermaid-hover-edge) !important;
+}

--- a/packages/annotation/src/element/mermaid/mermaidAdapter.test.ts
+++ b/packages/annotation/src/element/mermaid/mermaidAdapter.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ResolvedAnnotationThread } from '../../annotationTypes.ts';
+import { mermaidAdapter } from './mermaidAdapter.ts';
+
+describe('mermaidAdapter', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('claims the mermaid language only', () => {
+    expect(mermaidAdapter.claims('mermaid')).toBe(true);
+    expect(mermaidAdapter.claims('graphviz')).toBe(false);
+  });
+
+  describe('buildAnchor', () => {
+    it('builds a node anchor from a clicked node', () => {
+      const { block } = renderBlock();
+      const node = block.querySelector('[data-mermaid-node-id]')!;
+
+      expect(mermaidAdapter.buildAnchor(block, node)).toEqual({
+        kind: 'element',
+        contentType: 'mermaid',
+        blockTargetId: 'mermaid:5',
+        sourceLines: { start: 5, end: 9 },
+        element: { id: 'login', label: 'Login', descriptor: 'diagram node' },
+      });
+    });
+
+    it('builds an edge anchor from a clicked edge label', () => {
+      const { block } = renderBlock();
+      const edge = block.querySelector('[data-mermaid-edge-id]')!;
+
+      expect(mermaidAdapter.buildAnchor(block, edge)?.element).toEqual({
+        id: 'e1',
+        label: 'submits',
+        descriptor: 'diagram edge',
+      });
+    });
+
+    it('falls back to a whole-block anchor (no element id) when the click is not on a tagged element', () => {
+      const { block } = renderBlock();
+
+      expect(mermaidAdapter.buildAnchor(block, block)?.element).toEqual({ label: 'diagram', descriptor: 'diagram' });
+    });
+  });
+
+  describe('resolveTarget', () => {
+    it('round-trips a node anchor back to its element', () => {
+      const { container, block } = renderBlock();
+      const node = block.querySelector('[data-mermaid-node-id]')!;
+      const anchor = mermaidAdapter.buildAnchor(block, node)!;
+
+      expect(mermaidAdapter.resolveTarget(container, anchor)).toBe(node);
+    });
+
+    it('resolves a whole-block anchor to the block element', () => {
+      const { container, block } = renderBlock();
+      const anchor = mermaidAdapter.buildAnchor(block, block)!;
+
+      expect(mermaidAdapter.resolveTarget(container, anchor)).toBe(block);
+    });
+
+    it('returns null when the element id no longer exists', () => {
+      const { container, block } = renderBlock();
+      const anchor = mermaidAdapter.buildAnchor(block, block.querySelector('[data-mermaid-node-id]')!)!;
+      block.querySelector('[data-mermaid-node-id]')!.removeAttribute('data-mermaid-node-id');
+
+      expect(mermaidAdapter.resolveTarget(container, anchor)).toBeNull();
+    });
+  });
+
+  it('marks a thread element with the active class when it is the active annotation', () => {
+    const { container, block } = renderBlock();
+    const node = block.querySelector('[data-mermaid-node-id]')!;
+    const anchor = mermaidAdapter.buildAnchor(block, node)!;
+    const thread: ResolvedAnnotationThread = {
+      id: 'thr_1',
+      anchor,
+      range: null,
+      target: null,
+      unresolved: false,
+      quote: 'Login',
+      comments: [],
+    };
+
+    mermaidAdapter.applyMarkers({ container, threads: [thread], activeAnnotationId: 'thr_1' });
+
+    expect(node.classList.contains('cb-mermaid-annotated')).toBe(true);
+    expect(node.classList.contains('cb-mermaid-annotated-active')).toBe(true);
+  });
+});
+
+function renderBlock(): { container: HTMLElement; block: HTMLElement } {
+  const container = document.createElement('div');
+  container.innerHTML = `
+    <div data-element-block data-element-block-id="mermaid:5" data-element-content-type="mermaid"
+         data-src-start-line="5" data-src-end-line="9">
+      <svg>
+        <g class="node" data-mermaid-node-id="login" data-mermaid-label="Login"><rect></rect></g>
+        <g class="edgeLabel" data-mermaid-edge-id="e1" data-mermaid-label="submits"><rect></rect></g>
+      </svg>
+    </div>`;
+  document.body.appendChild(container);
+  const block = container.querySelector<HTMLElement>('[data-element-block-id]')!;
+  return { container, block };
+}

--- a/packages/annotation/src/element/mermaid/mermaidAdapter.ts
+++ b/packages/annotation/src/element/mermaid/mermaidAdapter.ts
@@ -1,0 +1,101 @@
+import type { ElementAnnotationAnchor } from '@contextbridge/shared/annotationSchema';
+import type { ResolvedAnnotationThread } from '../../annotationTypes.ts';
+import type { ElementAdapter } from '../ElementAdapter.ts';
+import { elementBlockAttrs } from '../elementBlock.ts';
+import { MermaidBlock, mermaidAttrs } from './MermaidBlock.tsx';
+
+const CONTENT_TYPE = 'mermaid';
+const MARK_CLASS = 'cb-mermaid-annotated';
+const ACTIVE_CLASS = 'cb-mermaid-annotated-active';
+
+/**
+ * The Mermaid {@link ElementAdapter}: renders flowchart source to SVG ({@link MermaidBlock}) and
+ * anchors annotations to its nodes, edges, or the whole diagram. Hover preview is pure CSS
+ * (`g.node:hover` etc. in mermaidAdapter.css).
+ */
+export const mermaidAdapter: ElementAdapter = {
+  contentType: CONTENT_TYPE,
+  claims: (lang) => lang === CONTENT_TYPE,
+  Block: MermaidBlock,
+  buildAnchor,
+  resolveTarget,
+  applyMarkers,
+};
+
+function buildAnchor(block: HTMLElement, clicked: Element): ElementAnnotationAnchor | null {
+  const blockTargetId = block.getAttribute(elementBlockAttrs.blockId);
+  const start = Number(block.getAttribute('data-src-start-line'));
+  const end = Number(block.getAttribute('data-src-end-line'));
+  if (!blockTargetId || !Number.isFinite(start) || !Number.isFinite(end) || start < 1) {
+    return null;
+  }
+  const sourceLines = { start, end };
+
+  const node = clicked.closest<HTMLElement>(`[${mermaidAttrs.nodeId}]`);
+  if (node && block.contains(node)) {
+    const id = node.getAttribute(mermaidAttrs.nodeId) ?? '';
+    if (id.length > 0) {
+      return elementAnchor(blockTargetId, sourceLines, { id, label: readLabel(node, id), descriptor: 'diagram node' });
+    }
+  }
+
+  const edge = clicked.closest<HTMLElement>(`[${mermaidAttrs.edgeId}]`);
+  if (edge && block.contains(edge)) {
+    const id = edge.getAttribute(mermaidAttrs.edgeId) ?? '';
+    if (id.length > 0) {
+      return elementAnchor(blockTargetId, sourceLines, { id, label: readLabel(edge, id), descriptor: 'diagram edge' });
+    }
+  }
+
+  return elementAnchor(blockTargetId, sourceLines, { label: 'diagram', descriptor: 'diagram' });
+}
+
+function resolveTarget(container: HTMLElement, anchor: ElementAnnotationAnchor): Element | null {
+  const block = container.querySelector(`[${elementBlockAttrs.blockId}="${anchor.blockTargetId}"]`);
+  if (!block) return null;
+
+  const { id } = anchor.element;
+  if (id === undefined) return block;
+
+  return (
+    block.querySelector(`[${mermaidAttrs.nodeId}="${id}"]`) ?? block.querySelector(`[${mermaidAttrs.edgeId}="${id}"]`)
+  );
+}
+
+function applyMarkers(args: {
+  container: HTMLElement;
+  threads: ResolvedAnnotationThread[];
+  activeAnnotationId: string | null;
+}): void {
+  const { container, threads, activeAnnotationId } = args;
+  clearMarkers(container);
+
+  for (const thread of threads) {
+    if (thread.anchor.kind !== 'element' || thread.anchor.contentType !== CONTENT_TYPE) continue;
+    const element = resolveTarget(container, thread.anchor);
+    if (!element) continue;
+    element.classList.add(MARK_CLASS);
+    if (thread.id === activeAnnotationId) {
+      element.classList.add(ACTIVE_CLASS);
+    }
+  }
+}
+
+function elementAnchor(
+  blockTargetId: string,
+  sourceLines: { start: number; end: number },
+  element: ElementAnnotationAnchor['element'],
+): ElementAnnotationAnchor {
+  return { kind: 'element', contentType: CONTENT_TYPE, blockTargetId, sourceLines, element };
+}
+
+function readLabel(element: Element, fallback: string): string {
+  const label = element.getAttribute(mermaidAttrs.label)?.trim();
+  return label && label.length > 0 ? label : fallback;
+}
+
+function clearMarkers(container: HTMLElement): void {
+  for (const element of container.querySelectorAll(`.${MARK_CLASS}`)) {
+    element.classList.remove(MARK_CLASS, ACTIVE_CLASS);
+  }
+}

--- a/packages/annotation/src/element/mermaid/renderer.ts
+++ b/packages/annotation/src/element/mermaid/renderer.ts
@@ -1,0 +1,24 @@
+export type MermaidTheme = 'default' | 'dark';
+
+export function currentMermaidTheme(): MermaidTheme {
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'default';
+}
+
+export interface RenderedMermaid {
+  svg: string;
+}
+
+// Mermaid is heavy (~3MB of the bundle). Load it lazily so plans without diagrams never pay
+// the parse cost. securityLevel 'strict' sanitizes the agent-authored source and strips
+// mermaid's own click/href directives so they don't fight our annotation handler.
+export async function loadMermaid(theme: MermaidTheme): Promise<typeof import('mermaid').default> {
+  const { default: mermaid } = await import('mermaid');
+  mermaid.initialize({ startOnLoad: false, securityLevel: 'strict', theme });
+  return mermaid;
+}
+
+export async function renderMermaid(id: string, source: string, theme: MermaidTheme): Promise<RenderedMermaid> {
+  const mermaid = await loadMermaid(theme);
+  const { svg } = await mermaid.render(id, source);
+  return { svg };
+}

--- a/packages/annotation/src/element/rehypeElementSources.test.ts
+++ b/packages/annotation/src/element/rehypeElementSources.test.ts
@@ -1,0 +1,46 @@
+import type { Element, Root } from 'hast';
+import { describe, expect, it } from 'vitest';
+import { ELEMENT_LANG_PROPERTY, ELEMENT_SOURCE_PROPERTY, rehypeElementSources } from './rehypeElementSources.ts';
+
+describe('rehypeElementSources', () => {
+  it('stashes source + lang and strips the language class for a claimed language', () => {
+    const code = codeNode('language-mermaid', 'flowchart TD\n  A --> B');
+    rehypeElementSources()(rootOf(code));
+
+    expect(code.properties[ELEMENT_SOURCE_PROPERTY]).toBe('flowchart TD\n  A --> B');
+    expect(code.properties[ELEMENT_LANG_PROPERTY]).toBe('mermaid');
+    expect(code.properties.className).toEqual([]);
+  });
+
+  it('leaves an unclaimed language untouched', () => {
+    const code = codeNode('language-ts', 'const x = 1;');
+    rehypeElementSources()(rootOf(code));
+
+    expect(code.properties[ELEMENT_SOURCE_PROPERTY]).toBeUndefined();
+    expect(code.properties[ELEMENT_LANG_PROPERTY]).toBeUndefined();
+    expect(code.properties.className).toEqual(['language-ts']);
+  });
+
+  it('ignores a fenced block with no language class', () => {
+    const code = codeNode(undefined, 'plain text');
+    rehypeElementSources()(rootOf(code));
+
+    expect(code.properties[ELEMENT_SOURCE_PROPERTY]).toBeUndefined();
+  });
+});
+
+function codeNode(className: string | undefined, source: string): Element {
+  return {
+    type: 'element',
+    tagName: 'code',
+    properties: className ? { className: [className] } : {},
+    children: [{ type: 'text', value: source }],
+  };
+}
+
+function rootOf(code: Element): Root {
+  return {
+    type: 'root',
+    children: [{ type: 'element', tagName: 'pre', properties: {}, children: [code] }],
+  };
+}

--- a/packages/annotation/src/element/rehypeElementSources.ts
+++ b/packages/annotation/src/element/rehypeElementSources.ts
@@ -23,12 +23,18 @@ export function rehypeElementSources() {
 
       node.properties = {
         ...node.properties,
-        className: classes.filter((cls) => !cls.startsWith(LANGUAGE_PREFIX)),
+        className: stripLanguageClasses(classes),
         [ELEMENT_SOURCE_PROPERTY]: collectText(node),
         [ELEMENT_LANG_PROPERTY]: lang,
       };
     });
   };
+}
+
+// Removes the `language-*` class so rehype-highlight leaves the block untouched; the adapter
+// renders it instead.
+function stripLanguageClasses(classes: string[]): string[] {
+  return classes.filter((cls) => !cls.startsWith(LANGUAGE_PREFIX));
 }
 
 function toClassList(className: Element['properties'][string] | undefined): string[] {

--- a/packages/annotation/src/element/rehypeElementSources.ts
+++ b/packages/annotation/src/element/rehypeElementSources.ts
@@ -1,0 +1,48 @@
+import type { Element, Root } from 'hast';
+import { visit } from 'unist-util-visit';
+import { adapterForLang } from './ElementAdapter.ts';
+
+export const ELEMENT_SOURCE_PROPERTY = 'dataElementSource';
+export const ELEMENT_LANG_PROPERTY = 'dataElementLang';
+
+const LANGUAGE_PREFIX = 'language-';
+
+// Runs before rehype-highlight: for any fenced code block whose language a registered adapter
+// claims, stashes the raw source + language onto the <code> node and drops the language class so
+// the highlighter leaves it alone. Reading raw text here (pre-highlight) avoids reconstructing it
+// from tokenized highlight spans later. Registry-driven, so adding a content type needs no change
+// here.
+export function rehypeElementSources() {
+  return (tree: Root): void => {
+    visit(tree, 'element', (node: Element) => {
+      if (node.tagName !== 'code') return;
+
+      const classes = toClassList(node.properties?.className);
+      const lang = classes.find((cls) => cls.startsWith(LANGUAGE_PREFIX))?.slice(LANGUAGE_PREFIX.length);
+      if (!lang || !adapterForLang(lang)) return;
+
+      node.properties = {
+        ...node.properties,
+        className: classes.filter((cls) => !cls.startsWith(LANGUAGE_PREFIX)),
+        [ELEMENT_SOURCE_PROPERTY]: collectText(node),
+        [ELEMENT_LANG_PROPERTY]: lang,
+      };
+    });
+  };
+}
+
+function toClassList(className: Element['properties'][string] | undefined): string[] {
+  if (Array.isArray(className)) return className.map(String);
+  if (typeof className === 'string') return className.split(/\s+/).filter(Boolean);
+  return [];
+}
+
+function collectText(node: Element): string {
+  return node.children
+    .map((child) => {
+      if (child.type === 'text') return child.value;
+      if (child.type === 'element') return collectText(child);
+      return '';
+    })
+    .join('');
+}

--- a/packages/annotation/src/element/useElementTargets.test.tsx
+++ b/packages/annotation/src/element/useElementTargets.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, fireEvent, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useElementTargets } from './useElementTargets.ts';
+
+describe('useElementTargets', () => {
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = '';
+  });
+
+  it('opens a new-thread draft with an element anchor when a tagged node is clicked', () => {
+    const container = renderBlockContainer();
+    const onOpenAnnotationCommentDraft = vi.fn();
+    const onSelectAnnotationId = vi.fn();
+
+    renderHook(() =>
+      useElementTargets({
+        activeAnnotationId: null,
+        container,
+        onOpenAnnotationCommentDraft,
+        onSelectAnnotationId,
+        resolvedThreads: [],
+        submitted: false,
+      }),
+    );
+
+    fireEvent.click(container.querySelector('[data-mermaid-node-id]')!);
+
+    expect(onOpenAnnotationCommentDraft).toHaveBeenCalledTimes(1);
+    expect(onOpenAnnotationCommentDraft.mock.calls[0]?.[0]).toMatchObject({
+      kind: 'new-thread',
+      anchor: { kind: 'element', contentType: 'mermaid', element: { id: 'login', descriptor: 'diagram node' } },
+    });
+    expect(onSelectAnnotationId).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open a draft once submitted', () => {
+    const container = renderBlockContainer();
+    const onOpenAnnotationCommentDraft = vi.fn();
+
+    renderHook(() =>
+      useElementTargets({
+        activeAnnotationId: null,
+        container,
+        onOpenAnnotationCommentDraft,
+        onSelectAnnotationId: vi.fn(),
+        resolvedThreads: [],
+        submitted: true,
+      }),
+    );
+
+    fireEvent.click(container.querySelector('[data-mermaid-node-id]')!);
+
+    expect(onOpenAnnotationCommentDraft).not.toHaveBeenCalled();
+  });
+});
+
+function renderBlockContainer(): HTMLElement {
+  const container = document.createElement('div');
+  container.innerHTML = `
+    <div data-element-block data-element-block-id="mermaid:5" data-element-content-type="mermaid"
+         data-src-start-line="5" data-src-end-line="9">
+      <svg>
+        <g class="node" data-mermaid-node-id="login" data-mermaid-label="Login"><rect></rect></g>
+      </svg>
+    </div>`;
+  document.body.appendChild(container);
+  return container;
+}

--- a/packages/annotation/src/element/useElementTargets.ts
+++ b/packages/annotation/src/element/useElementTargets.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { getNewThreadDraftId } from '../annotationResolvers.ts';
+import type { ResolvedAnnotationThread } from '../annotationTypes.ts';
+import type { OpenAnnotationCommentDraftArgs } from '../useAnnotationState.ts';
+import { adapterForContentType, elementAdapters } from './ElementAdapter.ts';
+import { ELEMENT_RENDERED_EVENT, elementBlockAttrs } from './elementBlock.ts';
+
+export interface UseElementTargetsArgs {
+  activeAnnotationId: string | null;
+  container: HTMLElement | null;
+  onOpenAnnotationCommentDraft: (args: OpenAnnotationCommentDraftArgs) => void;
+  onSelectAnnotationId: (annotationId: string) => void;
+  resolvedThreads: ResolvedAnnotationThread[];
+  submitted: boolean;
+}
+
+/**
+ * Routes clicks and marker passes for element-anchored annotations to the adapter that owns each
+ * block, keyed off the block-level contract (`data-element-block-id` / `data-element-content-type`).
+ * A single instance serves every registered adapter.
+ */
+export function useElementTargets({
+  activeAnnotationId,
+  container,
+  onOpenAnnotationCommentDraft,
+  onSelectAnnotationId,
+  resolvedThreads,
+  submitted,
+}: UseElementTargetsArgs): void {
+  const [elementVersion, setElementVersion] = useState(0);
+
+  // Adapters tag their SVG after an async render, outside React's control, so re-apply markers
+  // when a block signals it is in the DOM.
+  useEffect(() => {
+    if (!container) return;
+    const handleRendered = () => setElementVersion((version) => version + 1);
+    container.addEventListener(ELEMENT_RENDERED_EVENT, handleRendered);
+    return () => container.removeEventListener(ELEMENT_RENDERED_EVENT, handleRendered);
+  }, [container]);
+
+  useEffect(() => {
+    if (!container) return;
+    for (const adapter of elementAdapters) {
+      adapter.applyMarkers({ container, threads: resolvedThreads, activeAnnotationId });
+    }
+    return () => {
+      for (const adapter of elementAdapters) {
+        adapter.applyMarkers({ container, threads: [], activeAnnotationId: null });
+      }
+    };
+  }, [activeAnnotationId, container, elementVersion, resolvedThreads]);
+
+  useEffect(() => {
+    if (!container || submitted) return;
+
+    const handleClick = (event: MouseEvent) => {
+      if (!(event.target instanceof Element)) return;
+
+      const block = event.target.closest<HTMLElement>(`[${elementBlockAttrs.blockId}]`);
+      if (!block || !container.contains(block)) return;
+
+      const adapter = adapterForContentType(block.getAttribute(elementBlockAttrs.contentType) ?? '');
+      const anchor = adapter?.buildAnchor(block, event.target);
+      if (!anchor) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      onOpenAnnotationCommentDraft({ kind: 'new-thread', anchor });
+      onSelectAnnotationId(getNewThreadDraftId(anchor));
+    };
+
+    container.addEventListener('click', handleClick, true);
+    return () => container.removeEventListener('click', handleClick, true);
+  }, [container, onOpenAnnotationCommentDraft, onSelectAnnotationId, submitted]);
+}

--- a/packages/annotation/src/selectableTextIndex.test.ts
+++ b/packages/annotation/src/selectableTextIndex.test.ts
@@ -106,6 +106,7 @@ describe('restoreAnchor', () => {
 
     const originalTargetId = [...index.targets.keys()][0]!;
     const anchor = {
+      kind: 'text' as const,
       createdFrom: 'drag' as const,
       sourceLines: { start: 1, end: 1 },
       quote: { exact: 'refactoring the parser', prefix: 'Start by ', suffix: ' before' },
@@ -128,6 +129,7 @@ describe('restoreAnchor', () => {
     const index = buildSelectableTextIndex(container);
 
     const anchor = {
+      kind: 'text' as const,
       createdFrom: 'drag' as const,
       sourceLines: { start: 1, end: 1 },
       quote: { exact: 'not present', prefix: '', suffix: '' },

--- a/packages/annotation/src/selectableTextIndex.ts
+++ b/packages/annotation/src/selectableTextIndex.ts
@@ -1,4 +1,4 @@
-import type { StoredAnnotationAnchor } from '@contextbridge/shared/annotationSchema';
+import type { TextAnnotationAnchor } from '@contextbridge/shared/annotationSchema';
 import type { AnnotatableTarget, SelectableTextIndex } from './annotationTypes.ts';
 import { buildTargetLabel, createShortHash, findQuoteStart, normalizeText } from './textMath.ts';
 
@@ -28,9 +28,9 @@ function rangeToAnchor(args: {
   fullText: string;
   targets: Map<string, AnnotatableTarget>;
   range: Range;
-  createdFrom: StoredAnnotationAnchor['createdFrom'];
+  createdFrom: TextAnnotationAnchor['createdFrom'];
   explicitTarget?: HTMLElement;
-}): StoredAnnotationAnchor {
+}): TextAnnotationAnchor {
   const { container, fullText, targets, range, createdFrom, explicitTarget } = args;
   const selectionText = range.toString();
   if (selectionText.length === 0) {
@@ -56,6 +56,7 @@ function rangeToAnchor(args: {
   const sourceLines = resolveSourceLineRange(range.startContainer, range.endContainer);
 
   return {
+    kind: 'text',
     createdFrom,
     sourceLines,
     quote: {
@@ -95,7 +96,7 @@ function restoreAnchor(args: {
   container: HTMLElement;
   fullText: string;
   targets: Map<string, AnnotatableTarget>;
-  anchor: StoredAnnotationAnchor;
+  anchor: TextAnnotationAnchor;
 }): Range | null {
   const { container, fullText, targets, anchor } = args;
 
@@ -124,7 +125,7 @@ function restoreAnchor(args: {
   return null;
 }
 
-function restoreByEndpoints(targets: Map<string, AnnotatableTarget>, anchor: StoredAnnotationAnchor): Range | null {
+function restoreByEndpoints(targets: Map<string, AnnotatableTarget>, anchor: TextAnnotationAnchor): Range | null {
   const startTarget = targets.get(anchor.endpoints.start.targetId);
   const endTarget = targets.get(anchor.endpoints.end.targetId);
   if (!startTarget || !endTarget) {
@@ -140,7 +141,7 @@ function restoreByEndpoints(targets: Map<string, AnnotatableTarget>, anchor: Sto
   return createRangeFromPoints(startPoint, endPoint);
 }
 
-function resolveSourceLineRange(startNode: Node, endNode: Node): StoredAnnotationAnchor['sourceLines'] {
+function resolveSourceLineRange(startNode: Node, endNode: Node): TextAnnotationAnchor['sourceLines'] {
   const startElement = nearestElementWithSourceLine(startNode, 'start');
   const endElement = nearestElementWithSourceLine(endNode, 'end');
   if (!startElement || !endElement) {
@@ -168,7 +169,7 @@ function nearestElementWithSourceLine(node: Node, boundary: 'start' | 'end'): HT
   return null;
 }
 
-function createRangeFromQuote(root: HTMLElement, text: string, quote: StoredAnnotationAnchor['quote']): Range | null {
+function createRangeFromQuote(root: HTMLElement, text: string, quote: TextAnnotationAnchor['quote']): Range | null {
   const matchStart = findQuoteStart(text, quote);
   if (matchStart === null) {
     return null;

--- a/packages/annotation/src/testFactories.ts
+++ b/packages/annotation/src/testFactories.ts
@@ -20,7 +20,7 @@ export const resolvedAnnotationThread = Factory.define<ResolvedAnnotationThread>
     range: document.createRange(),
     target: null,
     unresolved: false,
-    quote: seed.subject.anchor.quote.exact,
+    quote: seed.subject.anchor.kind === 'text' ? seed.subject.anchor.quote.exact : seed.subject.anchor.element.label,
     comments: [{ kind: 'saved', threadId: seed.id, message: primaryMessage, isPrimary: true }],
   };
 });
@@ -37,7 +37,7 @@ export const resolvedAnnotationDraftThread = Factory.define<ResolvedAnnotationTh
     range: document.createRange(),
     target: null,
     unresolved: false,
-    quote: seed.subject.anchor.quote.exact,
+    quote: seed.subject.anchor.kind === 'text' ? seed.subject.anchor.quote.exact : seed.subject.anchor.element.label,
     comments: [
       {
         kind: 'draft',

--- a/packages/annotation/src/testHelpers/index.tsx
+++ b/packages/annotation/src/testHelpers/index.tsx
@@ -1,8 +1,13 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect } from 'vitest';
 import { annotatedMarkdownTestIds } from '../AnnotatedMarkdown.tsx';
+import { annotationDraftCommentComposerTestIds } from '../AnnotationDraftCommentComposer.tsx';
 import type { AppProps } from '../App.tsx';
 import { App } from '../App.tsx';
+import { submitBarTestIds } from '../SubmitBar.tsx';
 import type { AnnotationAppContext as AnnotationAppContextValue } from '../useAppContext.ts';
 import { AnnotationAppContext } from '../useAppContext.ts';
 import type { FakeAppContextResult } from './createFakeAppContext.ts';
@@ -54,4 +59,44 @@ export function drag({ target, from, to }: DragArgs): void {
   selection.removeAllRanges();
   selection.addRange(range);
   fireEvent.mouseUp(screen.getByTestId(annotatedMarkdownTestIds.container));
+}
+
+export interface SaveAnnotationArgs {
+  user: ReturnType<typeof userEvent.setup>;
+  /** An already-rendered, click-annotatable target (e.g. a tagged diagram node, edge, or block). */
+  target: Element;
+  body: string;
+}
+
+export interface AnnotateAndSubmitArgs extends SaveAnnotationArgs {
+  submitAnnotation: RenderAppResult['submitAnnotation'];
+}
+
+/**
+ * Open an annotation draft by clicking `target`, type `body`, and save it. Clicks the element
+ * directly (`fireEvent.click`), which suits click-annotatable targets like diagram nodes; text
+ * selections come from {@link drag} instead. Callers must wait until `target` is interactive first.
+ */
+export async function saveAnnotation({ user, target, body }: SaveAnnotationArgs): Promise<void> {
+  fireEvent.click(target);
+  await user.type(await screen.findByTestId(annotationDraftCommentComposerTestIds.textarea), body);
+  await user.click(screen.getByTestId(annotationDraftCommentComposerTestIds.saveButton));
+  await waitFor(() => {
+    expect(screen.queryByTestId(annotationDraftCommentComposerTestIds.container)).not.toBeInTheDocument();
+  });
+}
+
+/** {@link saveAnnotation} then submit the review; resolves with the latest submitted payload. */
+export async function annotateAndSubmit({
+  user,
+  submitAnnotation,
+  target,
+  body,
+}: AnnotateAndSubmitArgs): Promise<AnnotationSubmission | undefined> {
+  await saveAnnotation({ user, target, body });
+  await user.click(screen.getByTestId(submitBarTestIds.button));
+  await waitFor(() => {
+    expect(submitAnnotation).toHaveBeenCalled();
+  });
+  return submitAnnotation.mock.calls.at(-1)?.[0];
 }

--- a/packages/annotation/src/textMath.ts
+++ b/packages/annotation/src/textMath.ts
@@ -1,7 +1,7 @@
-import type { StoredAnnotationAnchor } from '@contextbridge/shared/annotationSchema';
+import type { TextAnnotationAnchor } from '@contextbridge/shared/annotationSchema';
 import { truncate } from './utils.ts';
 
-export function findQuoteStart(text: string, quote: StoredAnnotationAnchor['quote']): number | null {
+export function findQuoteStart(text: string, quote: TextAnnotationAnchor['quote']): number | null {
   const matches: number[] = [];
   let searchFrom = 0;
 

--- a/packages/annotation/src/useAnnotationInteractions.ts
+++ b/packages/annotation/src/useAnnotationInteractions.ts
@@ -2,9 +2,16 @@ import type { CommentThread } from '@contextbridge/shared/annotationSchema';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { clearAnnotationHighlights, syncAnnotationHighlights } from './annotationHighlights.ts';
-import { getDraftThreadId, getNewThreadDraftId, resolveAnnotationThreads } from './annotationResolvers.ts';
+import {
+  findElementAnchorTarget,
+  getDraftThreadId,
+  getNewThreadDraftId,
+  isElementAnchor,
+  resolveAnnotationThreads,
+} from './annotationResolvers.ts';
 import type { ActiveCommentDraft, ResolvedAnnotationThread, SelectableTextIndex } from './annotationTypes.ts';
 import { snapRangeToTokenBoundaries } from './codeTokenSnap.ts';
+import { useElementTargets } from './element/useElementTargets.ts';
 import { buildSelectableTextIndex } from './selectableTextIndex.ts';
 import type { OpenAnnotationCommentDraftArgs } from './useAnnotationState.ts';
 import { useCommentNavigation } from './useCommentNavigation.ts';
@@ -56,7 +63,9 @@ export function useAnnotationInteractions({
   }, [resolvedThreads]);
 
   const draftAnchor = activeDraft?.anchor ?? null;
-  const draftRange = draftAnchor && textIndex ? textIndex.restoreAnchor(draftAnchor) : null;
+  // Only text anchors resolve to a DOM range; element drafts (e.g. a diagram node) are marked
+  // by their adapter, not range-highlighted, so they have no draft range.
+  const draftRange = draftAnchor?.kind === 'text' && textIndex ? textIndex.restoreAnchor(draftAnchor) : null;
 
   const openAnnotationCommentFromRange = (
     range: Range,
@@ -77,7 +86,8 @@ export function useAnnotationInteractions({
 
   const editAnnotationComment = useCallback(
     (thread: ResolvedAnnotationThread) => {
-      if (submitted || !thread.range || !textIndex) {
+      // Element anchors (no range) are still editable — they're located via their adapter.
+      if (submitted || !textIndex || (!thread.range && !isElementAnchor(thread.anchor))) {
         return;
       }
 
@@ -112,11 +122,11 @@ export function useAnnotationInteractions({
   const activateThread = (thread: ResolvedAnnotationThread) => {
     setHoveredAnnotationId(null);
     setSelectedAnnotationId(thread.id);
-    scrollThreadIntoView(thread);
+    scrollThreadIntoView(thread, planContainer);
   };
 
   const openThreadComment = (thread: ResolvedAnnotationThread) => {
-    scrollThreadIntoView(thread);
+    scrollThreadIntoView(thread, planContainer);
     editAnnotationComment(thread);
   };
 
@@ -153,6 +163,17 @@ export function useAnnotationInteractions({
       clearAnnotationHighlights();
     };
   }, [draftRange, highlightedAnnotationId, resolvedThreads]);
+
+  // The other annotation mechanism: element-anchored content (diagrams, …) routes its clicks and
+  // markers through a per-content-type adapter. Text selection stays the path above.
+  useElementTargets({
+    activeAnnotationId: highlightedAnnotationId,
+    container: planContainer,
+    onOpenAnnotationCommentDraft,
+    onSelectAnnotationId: setSelectedAnnotationId,
+    resolvedThreads,
+    submitted,
+  });
 
   useEffect(() => {
     if (!planContainer || submitted) {
@@ -228,7 +249,7 @@ export function useAnnotationInteractions({
     }
 
     setSelectedAnnotationId(thread.id);
-    scrollThreadIntoView(thread);
+    scrollThreadIntoView(thread, planContainer);
     editAnnotationComment(thread);
   };
 
@@ -251,11 +272,14 @@ export function useAnnotationInteractions({
   };
 }
 
-function scrollThreadIntoView(thread: ResolvedAnnotationThread): void {
-  const focusElement =
+function scrollThreadIntoView(thread: ResolvedAnnotationThread, container: HTMLElement | null): void {
+  const rangeElement =
     thread.range?.startContainer instanceof Element
       ? thread.range.startContainer
       : thread.range?.startContainer.parentElement;
+  const focusElement =
+    rangeElement ??
+    (container && isElementAnchor(thread.anchor) ? findElementAnchorTarget(container, thread.anchor) : null);
   focusElement?.scrollIntoView({ behavior: 'smooth', block: 'center' });
 }
 

--- a/packages/cli/src/formatters/annotation/markdown.test.ts
+++ b/packages/cli/src/formatters/annotation/markdown.test.ts
@@ -3,6 +3,7 @@ import {
   annotationAnchor,
   annotationThread,
   commentMessage,
+  elementAnnotationAnchor,
   globalThread,
   reviewer,
 } from '@contextbridge/shared/testFactories';
@@ -209,7 +210,7 @@ describe('formatAgentResponse (annotation engine)', () => {
     expect(result).not.toContain('lines 4-9');
   });
 
-  it('passes a wrapped inline-code string as highlighted for single-line selections', () => {
+  it('describes a single-line text selection as "the highlighted text: <code>"', () => {
     const submission: AnnotationSubmission = {
       status: 'changes_requested',
       threads: [
@@ -236,10 +237,10 @@ describe('formatAgentResponse (annotation engine)', () => {
 
     const result = formatAgentResponse(buildHighlightedTemplates(), submission, 'highlight-me here');
 
-    expect(result).toContain('HIGHLIGHTED<`highlight-me`>');
+    expect(result).toContain('HIGHLIGHTED<the highlighted text: `highlight-me`>');
   });
 
-  it('omits highlighted (empty value) when the exact selection spans multiple lines', () => {
+  it('omits the focus call-out (empty value) when the exact selection spans multiple lines', () => {
     const content = ['first line', 'second line'].join('\n');
     const submission: AnnotationSubmission = {
       status: 'changes_requested',
@@ -269,6 +270,68 @@ describe('formatAgentResponse (annotation engine)', () => {
 
     expect(result).toContain('HIGHLIGHTED<>');
     expect(result).not.toMatch(/HIGHLIGHTED<.+>/);
+  });
+
+  it('describes an element-anchored node by its descriptor and label', () => {
+    const submission: AnnotationSubmission = {
+      status: 'changes_requested',
+      threads: [
+        annotationThread.build({
+          id: 'thr_el_node',
+          subject: { kind: 'annotation', anchor: elementAnnotationAnchor.build() },
+        }),
+      ],
+    };
+
+    expect(formatAgentResponse(buildHighlightedTemplates(), submission, 'unused')).toContain(
+      'HIGHLIGHTED<the diagram node: `Login`>',
+    );
+  });
+
+  it('describes an element-anchored edge by its descriptor and label', () => {
+    const submission: AnnotationSubmission = {
+      status: 'changes_requested',
+      threads: [
+        annotationThread.build({
+          id: 'thr_el_edge',
+          subject: {
+            kind: 'annotation',
+            anchor: elementAnnotationAnchor.build({
+              element: { id: 'edge1', label: 'submits', descriptor: 'diagram edge' },
+            }),
+          },
+        }),
+      ],
+    };
+
+    expect(formatAgentResponse(buildHighlightedTemplates(), submission, 'unused')).toContain(
+      'HIGHLIGHTED<the diagram edge: `submits`>',
+    );
+  });
+
+  it('describes a whole-block element annotation by descriptor alone (no label)', () => {
+    const submission: AnnotationSubmission = {
+      status: 'changes_requested',
+      threads: [
+        annotationThread.build({
+          id: 'thr_el_block',
+          subject: {
+            kind: 'annotation',
+            anchor: {
+              kind: 'element',
+              contentType: 'mermaid',
+              blockTargetId: 'mermaid:5',
+              sourceLines: { start: 5, end: 9 },
+              element: { label: 'diagram', descriptor: 'diagram' },
+            },
+          },
+        }),
+      ],
+    };
+
+    const result = formatAgentResponse(buildHighlightedTemplates(), submission, 'unused');
+    expect(result).toContain('HIGHLIGHTED<the diagram>');
+    expect(result).not.toContain('the diagram:');
   });
 
   it('threads opts.sourcePath into the approved and changesRequested templates as `source`', () => {
@@ -332,7 +395,7 @@ function buildFakeTemplates(): AnnotationTemplates {
   return {
     approved: Handlebars.compile('APPROVED-MARKER', { noEscape: true }),
     changesRequested: Handlebars.compile('CHANGES-MARKER\n{{body}}', { noEscape: true }),
-    annotationSection: Handlebars.compile('ANNOTATION-MARKER {{range}} {{sourceSlice}} {{highlighted}}\n{{comments}}', {
+    annotationSection: Handlebars.compile('ANNOTATION-MARKER {{range}} {{sourceSlice}} {{focus}}\n{{comments}}', {
       noEscape: true,
     }),
     generalFeedbackSection: Handlebars.compile('GLOBAL-MARKER\n{{comments}}', { noEscape: true }),
@@ -361,7 +424,7 @@ function buildHighlightedTemplates(): AnnotationTemplates {
   return {
     approved: Handlebars.compile('APPROVED', { noEscape: true }),
     changesRequested: Handlebars.compile('{{body}}', { noEscape: true }),
-    annotationSection: Handlebars.compile('HIGHLIGHTED<{{highlighted}}>\n{{comments}}', { noEscape: true }),
+    annotationSection: Handlebars.compile('HIGHLIGHTED<{{focus}}>\n{{comments}}', { noEscape: true }),
     generalFeedbackSection: Handlebars.compile('{{comments}}', { noEscape: true }),
   };
 }

--- a/packages/cli/src/formatters/annotation/markdown.ts
+++ b/packages/cli/src/formatters/annotation/markdown.ts
@@ -4,6 +4,7 @@ import type {
   CommentThread,
   CommentThreadSubject,
   SourceLineRange,
+  StoredAnnotationAnchor,
 } from '@contextbridge/shared/annotationSchema';
 import { instantFromString } from '@contextbridge/shared/time';
 import type { Blockquote, Root } from 'mdast';
@@ -34,12 +35,12 @@ export function formatAgentResponse(
   }
 
   for (const thread of annotationThreads) {
-    const { sourceLines, quote } = thread.subject.anchor;
+    const { anchor } = thread.subject;
     sections.push(
       templates.annotationSection({
-        range: formatLineRange(sourceLines),
-        sourceSlice: sliceSource(contentLines, sourceLines),
-        highlighted: formatHighlighted(quote.exact),
+        range: formatLineRange(anchor.sourceLines),
+        sourceSlice: sliceSource(contentLines, anchor.sourceLines),
+        focus: renderAnnotationFocus(anchor),
         comments: renderThreadsAsBlockquotes([thread]),
       }),
     );
@@ -98,6 +99,19 @@ function formatLineRange({ start, end }: SourceLineRange): string {
 function sliceSource(contentLines: string[], { start, end }: SourceLineRange): string {
   // Source lines are 1-indexed; array indices are 0-indexed.
   return contentLines.slice(start - 1, end).join('\n');
+}
+
+function renderAnnotationFocus(anchor: StoredAnnotationAnchor): string | undefined {
+  if (anchor.kind === 'text') {
+    const highlighted = formatHighlighted(anchor.quote.exact);
+    return highlighted ? `the highlighted text: ${highlighted}` : undefined;
+  }
+
+  // Element anchors carry the agent-facing wording the adapter chose at capture time
+  // (descriptor + label), so this stays generic across content types: a whole-block
+  // annotation (no element id) describes itself by descriptor alone.
+  const label = anchor.element.id ? formatHighlighted(anchor.element.label) : undefined;
+  return `the ${anchor.element.descriptor}${label ? `: ${label}` : ''}`;
 }
 
 function formatHighlighted(exact: string): string | undefined {

--- a/packages/cli/src/formatters/annotation/templates.ts
+++ b/packages/cli/src/formatters/annotation/templates.ts
@@ -8,7 +8,7 @@ export interface AnnotationTemplates {
   annotationSection: HandlebarsTemplateDelegate<{
     range: string;
     sourceSlice: string;
-    highlighted: string | undefined;
+    focus: string | undefined;
     comments: string;
   }>;
   generalFeedbackSection: HandlebarsTemplateDelegate<{ comments: string }>;

--- a/packages/cli/src/formatters/document/markdown.test.ts
+++ b/packages/cli/src/formatters/document/markdown.test.ts
@@ -58,7 +58,7 @@ Another paragraph.
     };
     const output = formatAgentResponse(DOCUMENT_TEMPLATES, submission, content);
     expect(output).toContain('## Comment (line 1)');
-    expect(output).toContain('Within that section, the reviewer specifically highlighted: `Heading`');
+    expect(output).toContain('Within that section, the reviewer commented on the highlighted text: `Heading`');
     expect(output).toContain('Title is too generic.');
   });
 
@@ -80,7 +80,7 @@ Another paragraph.
     };
     const output = formatAgentResponse(DOCUMENT_TEMPLATES, submission, content);
     expect(output).toContain('## Comment (lines 3–5)');
-    expect(output).not.toContain('specifically highlighted'); // multi-line skips the inline-code call-out
+    expect(output).not.toContain('commented on'); // multi-line skips the inline-code call-out
     expect(output).toContain('Tighten these two paragraphs.');
   });
 

--- a/packages/cli/src/formatters/document/templates/annotationSection.hbs
+++ b/packages/cli/src/formatters/document/templates/annotationSection.hbs
@@ -5,9 +5,9 @@ This comment applies to the following section:
 ````md
 {{{sourceSlice}}}
 ````
-{{#if highlighted}}
+{{#if focus}}
 
-Within that section, the reviewer specifically highlighted: {{{highlighted}}}
+Within that section, the reviewer commented on {{{focus}}}.
 {{/if}}
 
 {{{comments}}}

--- a/packages/cli/src/formatters/plan/templates.test.ts
+++ b/packages/cli/src/formatters/plan/templates.test.ts
@@ -166,7 +166,7 @@ The comment below applies to the following section of the plan:
 
     expect(output).toContain('## Annotation (line 2)');
     expect(output).toContain('- Item two with `code`.');
-    expect(output).toContain('Within that section, the reviewer specifically highlighted: `code`');
+    expect(output).toContain('Within that section, the reviewer commented on the highlighted text: `code`');
     expect(output).not.toContain('- Item one.');
     expect(output).not.toContain('- Item three.');
   });
@@ -202,6 +202,6 @@ The comment below applies to the following section of the plan:
       planContent,
     );
 
-    expect(output).not.toContain('Within that section, the reviewer specifically highlighted');
+    expect(output).not.toContain('Within that section, the reviewer commented on');
   });
 });

--- a/packages/cli/src/formatters/plan/templates/annotationSection.hbs
+++ b/packages/cli/src/formatters/plan/templates/annotationSection.hbs
@@ -5,9 +5,9 @@ The comment below applies to the following section of the plan:
 ````md
 {{{sourceSlice}}}
 ````
-{{#if highlighted}}
+{{#if focus}}
 
-Within that section, the reviewer specifically highlighted: {{{highlighted}}}
+Within that section, the reviewer commented on {{{focus}}}.
 {{/if}}
 
 {{{comments}}}

--- a/packages/shared/src/annotationSchema.test.ts
+++ b/packages/shared/src/annotationSchema.test.ts
@@ -8,8 +8,16 @@ import {
   AssetFileExtensionSchema,
   AssetSchema,
   ContentKindSchema,
+  ElementAnnotationAnchorSchema,
 } from './annotationSchema.ts';
-import { annotationAnchor, annotationThread, asset, commentMessage, globalThread } from './testFactories.ts';
+import {
+  annotationAnchor,
+  annotationThread,
+  asset,
+  commentMessage,
+  elementAnnotationAnchor,
+  globalThread,
+} from './testFactories.ts';
 import { Temporal, instantFromString, instantToString } from './time.ts';
 
 describe('AnnotationSubmissionSchema', () => {
@@ -68,6 +76,43 @@ describe('AnnotationSubmissionSchema', () => {
         ],
       }),
     ).toThrow();
+  });
+
+  it('round-trips an element anchor through the discriminated union', () => {
+    const parsed = AnnotationSubmissionSchema.parse({
+      status: 'changes_requested',
+      threads: [annotationThread.build({ subject: { kind: 'annotation', anchor: elementAnnotationAnchor.build() } })],
+    });
+
+    const subject = parsed.threads[0]?.subject;
+    expect(subject?.kind === 'annotation' ? subject.anchor.kind : null).toBe('element');
+  });
+});
+
+describe('ElementAnnotationAnchorSchema', () => {
+  it('parses an element anchor targeting a sub-element', () => {
+    const parsed = ElementAnnotationAnchorSchema.parse(elementAnnotationAnchor.build());
+    expect(parsed).toMatchObject({
+      kind: 'element',
+      contentType: 'mermaid',
+      blockTargetId: 'mermaid:5',
+      element: { id: 'login', label: 'Login', descriptor: 'diagram node' },
+    });
+  });
+
+  it('parses a whole-block element anchor with no element id', () => {
+    const parsed = ElementAnnotationAnchorSchema.parse({
+      kind: 'element',
+      contentType: 'mermaid',
+      blockTargetId: 'mermaid:5',
+      sourceLines: { start: 5, end: 9 },
+      element: { label: 'diagram', descriptor: 'diagram' },
+    });
+    expect(parsed.element.id).toBeUndefined();
+  });
+
+  it('rejects an empty contentType', () => {
+    expect(() => ElementAnnotationAnchorSchema.parse(elementAnnotationAnchor.build({ contentType: '' }))).toThrow();
   });
 });
 

--- a/packages/shared/src/annotationSchema.ts
+++ b/packages/shared/src/annotationSchema.ts
@@ -57,7 +57,13 @@ export const SourceLineRangeSchema = z
   .refine((value) => value.end >= value.start, { message: 'end must be >= start' });
 export type SourceLineRange = z.infer<typeof SourceLineRangeSchema>;
 
-export const StoredAnnotationAnchorSchema = z.object({
+/**
+ * A text-range annotation: anchored to a character selection and re-located on reload via the
+ * quote / position / endpoint selectors. This is the original (and default) annotation
+ * mechanism; see {@link ElementAnnotationAnchorSchema} for the element-anchored counterpart.
+ */
+export const TextAnnotationAnchorSchema = z.object({
+  kind: z.literal('text'),
   createdFrom: z.enum(['drag', 'element']),
   sourceLines: SourceLineRangeSchema,
   quote: TextQuoteSelectorSchema,
@@ -72,6 +78,39 @@ export const StoredAnnotationAnchorSchema = z.object({
     blockText: z.string().nonempty().optional(),
   }),
 });
+export type TextAnnotationAnchor = z.infer<typeof TextAnnotationAnchorSchema>;
+
+/**
+ * An annotation anchored to a rendered, non-text element (a diagram node, a chart bar, …),
+ * located by stable id within its block — unlike {@link TextAnnotationAnchorSchema}, which is
+ * re-located by text quote/position. Produced and consumed by the matching ElementAdapter in
+ * `@contextbridge/annotation`; the rest of the engine (resolver, CLI, sidebar) treats it
+ * generically via these fields, so a new content type needs no changes outside its adapter.
+ */
+export const ElementAnnotationAnchorSchema = z.object({
+  kind: z.literal('element'),
+  /** Adapter id, e.g. `'mermaid'`. Free string — the element-adapter registry is the source of truth, so adding a content type needs zero schema changes. */
+  contentType: z.string().nonempty(),
+  /** Stable id of the rendered block (`${contentType}:${startLine}`); re-finds the block after a reload. */
+  blockTargetId: z.string().nonempty(),
+  /** Source line span of the fenced block; drives the agent-readable source slice. */
+  sourceLines: SourceLineRangeSchema,
+  /** The annotated element within the block. */
+  element: z.object({
+    /** Stable id of the sub-element within the block. Absent ⇒ the annotation targets the whole block. */
+    id: z.string().nonempty().optional(),
+    /** Human-readable label of the target (node/edge text, or the block descriptor). */
+    label: z.string().nonempty(),
+    /** Agent-facing noun the adapter chose, e.g. `'diagram node'`, `'diagram edge'`, `'diagram'`. Drives CLI serialization. */
+    descriptor: z.string().nonempty(),
+  }),
+});
+export type ElementAnnotationAnchor = z.infer<typeof ElementAnnotationAnchorSchema>;
+
+export const StoredAnnotationAnchorSchema = z.discriminatedUnion('kind', [
+  TextAnnotationAnchorSchema,
+  ElementAnnotationAnchorSchema,
+]);
 export type StoredAnnotationAnchor = z.infer<typeof StoredAnnotationAnchorSchema>;
 
 export const CommentAuthorSchema = z.object({

--- a/packages/shared/src/testFactories.ts
+++ b/packages/shared/src/testFactories.ts
@@ -6,7 +6,8 @@ import type {
   CommentAuthor,
   CommentMessage,
   CommentThread,
-  StoredAnnotationAnchor,
+  ElementAnnotationAnchor,
+  TextAnnotationAnchor,
 } from './annotationSchema.ts';
 import type { FrontendConfig } from './frontendConfigSchema.ts';
 
@@ -36,7 +37,8 @@ export const commentMessage = Factory.define<CommentMessage>(() => ({
   createdAt: '2026-04-20T12:34:56.000Z',
 }));
 
-export const annotationAnchor = Factory.define<StoredAnnotationAnchor>(() => ({
+export const annotationAnchor = Factory.define<TextAnnotationAnchor>(() => ({
+  kind: 'text',
   createdFrom: 'drag',
   sourceLines: { start: 3, end: 3 },
   quote: {
@@ -56,6 +58,18 @@ export const annotationAnchor = Factory.define<StoredAnnotationAnchor>(() => ({
   },
   snapshot: {
     targetText: 'Start by refactoring the parser before touching the API',
+  },
+}));
+
+export const elementAnnotationAnchor = Factory.define<ElementAnnotationAnchor>(() => ({
+  kind: 'element',
+  contentType: 'mermaid',
+  blockTargetId: 'mermaid:5',
+  sourceLines: { start: 5, end: 9 },
+  element: {
+    id: 'login',
+    label: 'Login',
+    descriptor: 'diagram node',
   },
 }));
 


### PR DESCRIPTION
## Summary

Adds support for annotating rendered, non-text content in the annotation UI, with Mermaid diagrams as the first supported kind. The engine gains a kind-agnostic `ElementAdapter` layer: annotations can now be anchored to a diagram node, an edge, or a whole diagram by stable id, and the rest of the engine (resolver, CLI serializer, sidebar) stays generic over a new `element` anchor variant — adding a future content type needs no changes outside its adapter.

## Review focus

- **The `ElementAdapter` boundary** (`packages/annotation/src/element/ElementAdapter.ts` + `elementBlock.ts`). The contract is deliberately minimal: adapters own their DOM, sub-element tagging, anchor build/resolve, marker CSS, and hover; the only shared surface is the block-level data-attrs and a "rendered" event. Worth a hard look at whether that boundary is in the right place, or whether anything Mermaid-specific has leaked into the generic layer.
- **Anchor schema as a discriminated union** (`packages/shared/src/annotationSchema.ts`). `contentType` is a free string resolved against an adapter registry rather than an enum, so the schema never changes when a content type is added. The trade-off is the schema no longer constrains valid content types — that's enforced at the registry instead.

## Commits

- [`5e4a18c`](https://github.com/contextbridge/planbridge/commit/5e4a18cd1fbec42e79824c15ddf89b0a3bc14fda) — feat(shared): model annotation anchors as a text|element union (the data model)
- [`ba83a98`](https://github.com/contextbridge/planbridge/commit/ba83a98702c25dabcffbc6f4b2e5f60ac40f3d99) — feat(cli): describe annotation focus generically across anchor kinds (agent-facing serialization)
- [`125e8a0`](https://github.com/contextbridge/planbridge/commit/125e8a04b999e8f890aa5516202281c5736396f1) — feat(annotation): add generic element-annotation framework (the kind-agnostic engine, no concrete adapter registered yet)
- [`019a8f8`](https://github.com/contextbridge/planbridge/commit/019a8f8526fcaff7808e1d6a0f52dbf3a5da1c92) — feat(annotation): add Mermaid diagram adapter (first concrete adapter + e2e tests through the real `mermaid` dep)

> Reviewable commit-by-commit, bottom-up: each commit depends only on the ones before it, and the generic framework lands with an empty adapter registry so the abstraction can be judged before the ~700-line Mermaid implementation.
