### PR TITLE
fix: stop draft typing from resyncing highlights

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -103,7 +103,6 @@ export default defineConfig(
   ...baseConfig,
   {
     ignores: [
-      'claude-tmp/**',
       'dist/**',
       'node_modules/**',
       'coverage/**',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -103,6 +103,7 @@ export default defineConfig(
   ...baseConfig,
   {
     ignores: [
+      'claude-tmp/**',
       'dist/**',
       'node_modules/**',
       'coverage/**',

--- a/packages/annotation/src/AnnotationDraftCommentComposer.tsx
+++ b/packages/annotation/src/AnnotationDraftCommentComposer.tsx
@@ -13,6 +13,7 @@ export const annotationDraftCommentComposerTestIds = {
 
 export interface AnnotationDraftCommentComposerProps {
   draft: ActiveCommentDraft;
+  body: string;
   onBodyChange: (body: string) => void;
   onCancel: () => void;
   onSave: () => void;
@@ -20,13 +21,14 @@ export interface AnnotationDraftCommentComposerProps {
 
 export function AnnotationDraftCommentComposer({
   draft,
+  body,
   onBodyChange,
   onCancel,
   onSave,
 }: AnnotationDraftCommentComposerProps) {
   const title = draft.kind === 'edit-comment' ? 'Edit comment' : 'Add comment';
   const handleSubmitKeyDown = useSubmitOnCmdEnter(() => {
-    if (draft.body.trim().length > 0) {
+    if (body.trim().length > 0) {
       onSave();
     }
   });
@@ -64,7 +66,7 @@ export function AnnotationDraftCommentComposer({
         onFocus={handleFocus}
         onKeyDown={handleKeyDown}
         placeholder="Add a comment."
-        value={draft.body}
+        value={body}
       />
       <div className="mt-3 flex items-center justify-end gap-2">
         <Button
@@ -77,7 +79,7 @@ export function AnnotationDraftCommentComposer({
         </Button>
         <Button
           data-testid={annotationDraftCommentComposerTestIds.saveButton}
-          disabled={draft.body.trim().length === 0}
+          disabled={body.trim().length === 0}
           onClick={onSave}
           type="button"
         >

--- a/packages/annotation/src/AnnotationThreadCard.tsx
+++ b/packages/annotation/src/AnnotationThreadCard.tsx
@@ -15,6 +15,7 @@ export interface AnnotationThreadCardProps {
   isActive: boolean;
   isCurrent: boolean;
   submitted: boolean;
+  draftBody: string;
   onClick: () => void;
   onDraftBodyChange: (body: string) => void;
   onDraftCancel: () => void;
@@ -28,6 +29,7 @@ export function AnnotationThreadCard({
   isActive,
   isCurrent,
   submitted,
+  draftBody,
   onClick,
   onDraftBodyChange,
   onDraftCancel,
@@ -77,6 +79,7 @@ export function AnnotationThreadCard({
           ) : (
             <AnnotationDraftCommentComposer
               draft={comment.draft}
+              body={draftBody}
               key="draft"
               onBodyChange={onDraftBodyChange}
               onCancel={onDraftCancel}

--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -20,6 +20,7 @@ import { updateNoticeCardTestIds } from './UpdateNoticeCard.tsx';
 
 describe('App', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     cleanup();
   });
 
@@ -536,6 +537,33 @@ describe('App', () => {
     expect(submission?.threads).toHaveLength(1);
     const anchor = submission?.threads[0]?.subject.kind === 'annotation' ? submission.threads[0].subject.anchor : null;
     expect(anchor?.kind === 'text' ? anchor.quote.exact : null).toBe('"helloWorld"');
+  });
+
+  it('does not resync CSS highlights while typing in an open annotation draft', async () => {
+    const user = userEvent.setup();
+    const setHighlight = vi.spyOn(CSS.highlights, 'set');
+    const deleteHighlight = vi.spyOn(CSS.highlights, 'delete');
+    renderApp({
+      initialPayload: {
+        contentKind: 'plan',
+        content: '# Plan\n\nThis paragraph has enough text to select and annotate.',
+      },
+    });
+
+    const paragraph = await waitForMarkdownParagraph(0);
+    drag({ target: paragraph.firstChild as Text, from: 0, to: 'This paragraph'.length });
+    await screen.findByTestId(annotationDraftCommentComposerTestIds.container);
+    await waitFor(() => {
+      expect(setHighlight).toHaveBeenCalled();
+    });
+
+    setHighlight.mockClear();
+    deleteHighlight.mockClear();
+
+    await user.type(screen.getByTestId(annotationDraftCommentComposerTestIds.textarea), 'No highlight churn');
+
+    expect(setHighlight).not.toHaveBeenCalled();
+    expect(deleteHighlight).not.toHaveBeenCalled();
   });
 
   it('scopes a code-token click to just the token, not the whole block', async () => {

--- a/packages/annotation/src/App.tsx
+++ b/packages/annotation/src/App.tsx
@@ -135,6 +135,7 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
                 <CommentsSidebar
                   threads={annotationInteractions.resolvedThreads}
                   currentThreadId={annotationInteractions.currentSidebarThreadId}
+                  draftBody={reviewState.draft.body}
                   globalComment={reviewState.globalComment}
                   highlightedAnnotationId={annotationInteractions.highlightedAnnotationId}
                   navigation={

--- a/packages/annotation/src/CommentsSidebar.tsx
+++ b/packages/annotation/src/CommentsSidebar.tsx
@@ -28,6 +28,7 @@ export interface CommentsSidebarProps {
   navigation: SidebarNavigationState | null;
   submission: SubmissionState;
   source?: AnnotationEntrypoint;
+  draftBody: string;
   onThreadClick: (thread: ResolvedAnnotationThread) => void;
   onAnnotationHoverChange: (annotationId: string, hovered: boolean) => void;
   onDraftBodyChange: (body: string) => void;
@@ -44,6 +45,7 @@ export function CommentsSidebar({
   navigation,
   submission,
   source,
+  draftBody,
   onThreadClick,
   onAnnotationHoverChange,
   onDraftBodyChange,
@@ -99,6 +101,7 @@ export function CommentsSidebar({
                       thread={thread}
                       isActive={highlightedAnnotationId === thread.id}
                       isCurrent={isCurrent}
+                      draftBody={draftBody}
                       onClick={() => onThreadClick(thread)}
                       onDraftBodyChange={onDraftBodyChange}
                       onDraftCancel={onDraftCancel}

--- a/packages/annotation/src/annotationTypes.ts
+++ b/packages/annotation/src/annotationTypes.ts
@@ -40,18 +40,20 @@ export interface SelectableTextIndex {
   resolveTarget(targetId: string): AnnotatableTarget | null;
 }
 
+// The live draft body is tracked separately in useAnnotationState — deliberately not on this
+// descriptor. Editing the body must not change this object's identity, because it flows through
+// resolveAnnotationThreads into the CSS Custom Highlight + element-marker effects; a per-keystroke
+// identity churn there rebuilds the whole highlight range and is pathologically slow in Firefox.
 export type ActiveCommentDraft =
   | {
       kind: 'new-thread';
       anchor: StoredAnnotationAnchor;
-      body: string;
     }
   | {
       kind: 'edit-comment';
       threadId: string;
       messageId: string;
       anchor: StoredAnnotationAnchor;
-      body: string;
     };
 
 export type AnnotationThreadComment =

--- a/packages/annotation/src/testFactories.ts
+++ b/packages/annotation/src/testFactories.ts
@@ -42,7 +42,7 @@ export const resolvedAnnotationDraftThread = Factory.define<ResolvedAnnotationTh
       {
         kind: 'draft',
         mode: 'new-thread',
-        draft: { kind: 'new-thread', anchor: seed.subject.anchor, body: '' },
+        draft: { kind: 'new-thread', anchor: seed.subject.anchor },
       },
     ],
   };

--- a/packages/annotation/src/useAnnotationState.test.ts
+++ b/packages/annotation/src/useAnnotationState.test.ts
@@ -143,7 +143,7 @@ describe('useAnnotationState', () => {
       expectBeforeUnloadGuard(browser);
 
       expect(result.current.closeReview.dialogOpen).toBe(true);
-      expect(result.current.draft.active?.body).toBe('Unsaved draft feedback');
+      expect(result.current.draft.body).toBe('Unsaved draft feedback');
     });
 
     it('keeps reviewing by closing only the custom dialog', () => {
@@ -521,14 +521,14 @@ describe('useAnnotationState', () => {
         });
       });
 
-      expect(result.current.draft.active?.body).toBe('Unsaved original');
+      expect(result.current.draft.body).toBe('Unsaved original');
       expect(result.current.draft.discardDialogOpen).toBe(true);
 
       act(() => {
         result.current.draft.confirmDiscard();
       });
 
-      expect(result.current.draft.active?.body).toBe('replacement');
+      expect(result.current.draft.body).toBe('replacement');
       expect(result.current.draft.active?.anchor).toBe(nextAnchor);
       expect(result.current.draft.discardDialogOpen).toBe(false);
     });
@@ -547,7 +547,7 @@ describe('useAnnotationState', () => {
       });
 
       expect(result.current.removal.pendingId).toBeNull();
-      expect(result.current.draft.active?.body).toBe(originalBody + ' edited');
+      expect(result.current.draft.body).toBe(originalBody + ' edited');
       expect(result.current.draft.discardDialogOpen).toBe(true);
 
       act(() => {

--- a/packages/annotation/src/useAnnotationState.test.ts
+++ b/packages/annotation/src/useAnnotationState.test.ts
@@ -354,7 +354,7 @@ describe('useAnnotationState', () => {
       expect(result.current.removal.pendingId).toBeNull();
     });
 
-    it('clears the active draft when the removed thread matches the open draft', () => {
+    it('clears the active draft state when the removed thread matches the open draft', () => {
       const thread = annotationThread.build({ id: 'thr_target' });
       const originalBody = thread.messages[0]?.body ?? '';
       const { result } = renderAnnotationHook(() => useAnnotationState({ initialThreads: [thread] }));
@@ -375,6 +375,7 @@ describe('useAnnotationState', () => {
       });
 
       expect(result.current.draft.active).toBeNull();
+      expect(result.current.draft.body).toBe('');
     });
   });
 

--- a/packages/annotation/src/useAnnotationState.ts
+++ b/packages/annotation/src/useAnnotationState.ts
@@ -96,7 +96,9 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
 
   const removeComment = (threadId: string) => {
     setThreads((current) => current.filter((thread) => thread.id !== threadId));
-    setActiveDraft((current) => (current?.kind === 'edit-comment' && current.threadId === threadId ? null : current));
+    if (activeDraft?.kind === 'edit-comment' && activeDraft.threadId === threadId) {
+      closeDraft();
+    }
   };
 
   const requestRemove = (threadId: string | null) => {

--- a/packages/annotation/src/useAnnotationState.ts
+++ b/packages/annotation/src/useAnnotationState.ts
@@ -37,6 +37,7 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
     (initialThreads ?? []).filter(isAnnotationCommentThread),
   );
   const [activeDraft, setActiveDraft] = useState<ActiveCommentDraft | null>(null);
+  const [draftBody, setDraftBody] = useState('');
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -54,11 +55,12 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
 
   const closeDraft = () => {
     setActiveDraft(null);
+    setDraftBody('');
     setPendingDraftAction(null);
   };
 
   const requestDraftAction = (action: PendingDraftAction) => {
-    if (!activeDraft || !getDraftDirty(activeDraft, threads)) {
+    if (!activeDraft || !getDraftDirty(activeDraft, draftBody, threads)) {
       runDraftAction(action);
       return;
     }
@@ -74,16 +76,12 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
     requestDraftAction({ kind: 'replace', draft });
   };
 
-  const setDraftBody = (body: string) => {
-    setActiveDraft((current) => (current ? { ...current, body } : current));
-  };
-
   const saveDraft = () => {
     if (submitted || !activeDraft) {
       return;
     }
 
-    const nextBody = activeDraft.body.trim();
+    const nextBody = draftBody.trim();
     if (nextBody.length === 0) {
       return;
     }
@@ -110,7 +108,7 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
     if (
       activeDraft?.kind === 'edit-comment' &&
       activeDraft.threadId === threadId &&
-      getDraftDirty(activeDraft, threads)
+      getDraftDirty(activeDraft, draftBody, threads)
     ) {
       setPendingDraftAction({ kind: 'remove', threadId });
       return;
@@ -159,7 +157,7 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
   };
 
   const submit = async () => {
-    if (activeDraft && getDraftDirty(activeDraft, threads)) {
+    if (activeDraft && getDraftDirty(activeDraft, draftBody, threads)) {
       requestCloseDraft();
       return;
     }
@@ -190,11 +188,13 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
         closeDraft();
         return;
       case 'replace':
-        setActiveDraft(normalizeDraft(action.draft));
+        setActiveDraft(toDraftDescriptor(action.draft));
+        setDraftBody(initialDraftBody(action.draft));
         setPendingDraftAction(null);
         return;
       case 'remove':
         setActiveDraft(null);
+        setDraftBody('');
         setPendingDraftAction(null);
         setPendingRemoveId(action.threadId);
         return;
@@ -238,6 +238,7 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
     threads,
     draft: {
       active: activeDraft,
+      body: draftBody,
       open: openAnnotationCommentDraft,
       requestClose: requestCloseDraft,
       setBody: setDraftBody,
@@ -274,16 +275,20 @@ export function useAnnotationState({ initialThreads, initialGlobalComment }: Use
   };
 }
 
-function normalizeDraft(draft: OpenAnnotationCommentDraftArgs): ActiveCommentDraft {
+function toDraftDescriptor(draft: OpenAnnotationCommentDraftArgs): ActiveCommentDraft {
   if (draft.kind === 'new-thread') {
-    return { ...draft, body: draft.body ?? '' };
+    return { kind: 'new-thread', anchor: draft.anchor };
   }
 
-  return draft;
+  return { kind: 'edit-comment', threadId: draft.threadId, messageId: draft.messageId, anchor: draft.anchor };
 }
 
-function getDraftDirty(draft: ActiveCommentDraft, threads: CommentThread[]): boolean {
-  const nextBody = draft.body.trim();
+function initialDraftBody(draft: OpenAnnotationCommentDraftArgs): string {
+  return draft.kind === 'new-thread' ? (draft.body ?? '') : draft.body;
+}
+
+function getDraftDirty(draft: ActiveCommentDraft, body: string, threads: CommentThread[]): boolean {
+  const nextBody = body.trim();
   if (draft.kind === 'new-thread') {
     return nextBody.length > 0;
   }


### PR DESCRIPTION
## Summary

Fixes the Firefox-specific annotation composer lag from #224 by keeping the live draft comment body out of the draft descriptor that feeds annotation range resolution and CSS Custom Highlight sync. Typing in the sidebar now updates only the composer body, while the highlighted document range remains stable.

This also clears stale draft body state when an edited thread is removed and adds a browser regression test proving textarea input no longer calls `CSS.highlights.set/delete`.

## Review focus

Please focus on the React state split between the draft descriptor and draft body: the goal is to keep the descriptor identity stable for highlight/marker effects while still preserving existing dirty-draft and save behavior.

## Commits

- [`52a426d`](https://github.com/contextbridge/planbridge/commit/52a426d) — split live draft body from the annotation descriptor to avoid highlight churn
- [`fc2f4ee`](https://github.com/contextbridge/planbridge/commit/fc2f4ee) — add regression coverage, clear stale draft body state, and remove local-only lint ignore
