### PR TITLE
fix(annotation): preserve line breaks in saved comment bodies

### DIFF
--- a/packages/annotation/src/AnnotationThreadCard.test.tsx
+++ b/packages/annotation/src/AnnotationThreadCard.test.tsx
@@ -1,0 +1,45 @@
+import '@contextbridge/ui/styles.css';
+import { commentMessage } from '@contextbridge/shared/testFactories';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AnnotationThreadCard, annotationThreadCardTestIds } from './AnnotationThreadCard.tsx';
+import { resolvedAnnotationThread } from './testFactories.ts';
+
+describe('AnnotationThreadCard', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a saved comment body across the lines the author typed', () => {
+    const singleLine = renderSavedComment({ id: 'msg_single', body: 'Foo' });
+    const multiLine = renderSavedComment({ id: 'msg_multi', body: 'Foo\n\nBar\n\nBaz' });
+
+    expect(multiLine.getBoundingClientRect().height).toBeGreaterThan(singleLine.getBoundingClientRect().height * 2);
+  });
+});
+
+function renderSavedComment({ id, body }: { id: string; body: string }): HTMLElement {
+  const message = commentMessage.build({ id, body });
+  const thread = resolvedAnnotationThread.build({
+    id: `thr_${id}`,
+    comments: [{ kind: 'saved', threadId: `thr_${id}`, message, isPrimary: true }],
+  });
+
+  render(
+    <AnnotationThreadCard
+      draftBody=""
+      isActive={false}
+      isCurrent={false}
+      onClick={vi.fn()}
+      onDraftBodyChange={vi.fn()}
+      onDraftCancel={vi.fn()}
+      onDraftSave={vi.fn()}
+      onHoverChange={vi.fn()}
+      onRequestRemove={vi.fn()}
+      submitted={false}
+      thread={thread}
+    />,
+  );
+
+  return screen.getByTestId(annotationThreadCardTestIds.comment(message.id));
+}

--- a/packages/annotation/src/AnnotationThreadCard.tsx
+++ b/packages/annotation/src/AnnotationThreadCard.tsx
@@ -70,7 +70,7 @@ export function AnnotationThreadCard({
         {thread.comments.map((comment) =>
           comment.kind === 'saved' ? (
             <p
-              className="mt-3 text-sm leading-6 text-foreground/80"
+              className="mt-3 whitespace-pre-wrap text-sm leading-6 text-foreground/80"
               data-testid={annotationThreadCardTestIds.comment(comment.message.id)}
               key={comment.message.id}
             >

--- a/packages/annotation/src/App.stories.tsx
+++ b/packages/annotation/src/App.stories.tsx
@@ -84,6 +84,28 @@ const seededThreads = [
 
 const seededGlobalComment = 'The plan never says how rollback works if the verifier swap causes issues.';
 
+const multiLineCommentBody = [
+  'Three things worry me about this ordering.',
+  '',
+  'The verifier swap lands before anything documents the migration, so downstream callers get no lead time.',
+  '',
+  'And rollback is undefined once the flag flips.',
+].join('\n');
+
+const multiLineThreads = [
+  {
+    ...seededThreads[0]!,
+    id: 'thr_multiline_01',
+    messages: [
+      {
+        ...seededThreads[0]!.messages[0]!,
+        id: 'msg_multiline_01',
+        body: multiLineCommentBody,
+      },
+    ],
+  },
+];
+
 const mermaidPlan = [
   '# Auth flow',
   '',
@@ -176,6 +198,27 @@ export const SeededReview: Story = {
     initialGlobalComment: seededGlobalComment,
   },
   decorators: [withAppContext({ submitAnnotation: delayedSubmit })],
+};
+
+export const MultiLineComment: Story = {
+  args: {
+    initialPayload: {
+      contentKind: 'plan',
+      content: samplePlan,
+      title: 'Refactor auth middleware',
+      metadata: { entrypoint: 'plan_command' },
+    },
+    initialThreads: multiLineThreads,
+  },
+  decorators: [withAppContext({ submitAnnotation: delayedSubmit })],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Reproduces #252. The saved thread card must keep the line breaks the author typed rather than collapsing the body onto one line.',
+      },
+    },
+  },
 };
 
 export const MermaidDiagram: Story = {

--- a/packages/annotation/vitest.config.ts
+++ b/packages/annotation/vitest.config.ts
@@ -1,3 +1,4 @@
+import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
@@ -9,6 +10,7 @@ export default defineConfig({
         plugins: ['babel-plugin-react-compiler'],
       },
     }),
+    tailwindcss(),
   ],
   optimizeDeps: {
     include: ['@testing-library/jest-dom/vitest'],


### PR DESCRIPTION
## Summary

A saved comment body was rendered as raw text in a `<p>` with no whitespace handling, so HTML collapsed every newline into a space and a three-line comment displayed as one run-on line. Reopening it for editing showed the original lines, so the text was always intact in state and only the display was wrong. Adds `whitespace-pre-wrap`, a regression test, and a story. Closes #252.

## Review focus

The vitest config change is the part I'd look at. There was no way to test this as things stood: vitest had no `@tailwindcss/vite` plugin, so a test importing `styles.css` got the theme layer but none of the generated utilities, and every utility class resolved to its unstyled default. I added the plugin. It only affects tests that import `styles.css` themselves, which today means `App.mermaid.test.tsx` (still passing) and the new file. Those tests now measure real Tailwind output instead of unstyled markup, which is what you want, but it does change what they were asserting.

I also skipped markdown rendering, which the issue floated. Comment bodies are plain text the agent reads verbatim, and rendering markdown in the card while the textarea still shows source would recreate the same edit-versus-display mismatch this PR fixes. Happy to file that separately if you disagree.

## Commits

- [`4159460`](https://github.com/contextbridge/planbridge/commit/415946036350dfc08545149ac3683ddee1cc18ea) — enable Tailwind in vitest browser runs so utility classes actually resolve
- [`655bdd1`](https://github.com/contextbridge/planbridge/commit/655bdd156af6b291fb53a8981910927a4b31da58) — add `whitespace-pre-wrap`, the height-comparison regression test, and the `MultiLineComment` story
