### PR TITLE
feat(settings): persist settings through the local server

### DIFF
--- a/.claude/rules/neverthrow-error-handling.md
+++ b/.claude/rules/neverthrow-error-handling.md
@@ -1,0 +1,76 @@
+---
+paths:
+  - packages/**/*.ts
+  - packages/**/*.tsx
+---
+# Neverthrow Error Handling
+
+Fallible operations return `Result<T, E>` (from `neverthrow`) instead of throwing. Callers
+handle the error path explicitly. This extends the safe-wrapper rule in
+`.contextbridge/rules/error-handling-neverthrow.md`.
+
+## Prefer combinators over manual `isErr()` checks
+
+Chain the pipeline with combinators — `.andThen()` / `.map()` / `.mapErr()` / `.orElse()` /
+`.asyncAndThen()` — instead of awaiting each step and branching on `isErr()`. A long
+sequence of `if (x.isErr()) return err(x.error)` is a smell: it's the manual expansion of
+what `.andThen()` already does, and it grows the diff without adding logic. Let the error
+short-circuit through the chain; only the `Ok` path stays in your callbacks.
+
+```ts
+// Good — one chain, error short-circuits automatically
+private applyAndWrite(patch: SettingsPatch): ResultAsync<Settings, SettingsStoreError> {
+  return this.readPersisted().andThen((persisted) => {
+    const updated = applyPatch(persisted ?? emptyDocument(), patch);
+    return this.writePersisted(updated).map(() => resolveSettings(updated));
+  });
+}
+
+// Avoid — manual unwrap-and-rewrap at every step
+const readResult = await this.readPersisted();
+if (readResult.isErr()) return err(readResult.error);
+const updated = applyPatch(readResult.value ?? emptyDocument(), patch);
+const writeResult = await this.writePersisted(updated);
+if (writeResult.isErr()) return err(writeResult.error);
+// ...
+```
+
+Mechanics:
+
+- Return `ResultAsync<T, E>` directly from async fallible functions (it's awaitable to
+  `Result<T, E>`, so callers can still `await` + `isErr()`). Synchronous functions
+  return `Result<T, E>`.
+- Bridge sync→async with `.asyncAndThen()`; a `Result` from a parser or zod check flows
+  straight into an async chain without an intermediate `await`.
+- Wrap a throwing promise with `ResultAsync.fromPromise(promise, toError)`. Wrap a
+  `Promise<Result<…>>` (an already-fallible async API) with `new ResultAsync(promise)` so
+  it joins the chain without double-wrapping.
+- Inside an `.andThen()` callback you may return a plain `Result` (`ok(...)` / `err(...)`)
+  or another `ResultAsync` — mix freely. Short imperative guards (a validation `for` loop
+  returning `err(...)`) are fine *inside* a callback; the win is not re-checking the
+  surrounding pipeline by hand.
+- Use `.orElse()` for idempotent recovery — swallow expected conditions by returning
+  `ok(...)` so the operation is retry-safe. Use `.mapErr()` only to log/translate.
+- Keep try/catch + a `toError` normalizer for genuinely imperative code (pagination loops,
+  `for await`).
+
+`isErr()` propagation is still correct where a chain doesn't read better — but reach for it
+as the exception, not the default.
+
+## In tests, narrow with `assert`, never `_unsafeUnwrap`
+
+Use `node:assert` to narrow the `Result` before reading `.value` / `.error`; it gives a
+clear failure message and type narrowing. Never call `_unsafeUnwrap()` /
+`_unsafeUnwrapErr()`.
+
+```ts
+import assert from 'node:assert';
+
+const result = await store.patch({ ui: { theme: 'nord' } });
+assert(result.isOk());
+expect(result.value.ui.theme).toBe('nord');
+
+const bad = await store.patch({ ui: { theme: 'nope' } });
+assert(bad.isErr());
+expect(bad.error.kind).toBe('conflict');
+```

--- a/bun.lock
+++ b/bun.lock
@@ -168,6 +168,7 @@
       "dependencies": {
         "@contextbridge/context": "workspace:*",
         "@contextbridge/shared": "workspace:*",
+        "neverthrow": "catalog:",
       },
       "peerDependencies": {
         "bun": ">=1.0.0",

--- a/packages/annotation/src/main.tsx
+++ b/packages/annotation/src/main.tsx
@@ -3,6 +3,7 @@ import '@contextbridge/shared/time';
 import { createFrontendContext } from '@contextbridge/context/frontend';
 import type { AnnotationPayload, AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
 import { type FrontendConfig, FrontendConfigSchema } from '@contextbridge/shared/frontendConfigSchema';
+import { resolveSettings } from '@contextbridge/shared/settingsSchema';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App.tsx';
@@ -14,6 +15,7 @@ import { AnnotationAppContext } from './useAppContext.ts';
 const FALLBACK_CONFIG: FrontendConfig = {
   distinctId: 'local-development',
   telemetryDisabled: true,
+  settings: resolveSettings(),
 };
 
 const rootElement = document.getElementById('root');

--- a/packages/cli/src/annotation/runAnnotation.test.ts
+++ b/packages/cli/src/annotation/runAnnotation.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
+import { SettingsStoreError } from '@contextbridge/shared/settingsStore';
 import { createDeferred } from '@contextbridge/shared/testHelpers';
 import { describe, expect, it } from 'bun:test';
 import { annotationArgs, environment } from '#src/testFactories.ts';
@@ -44,18 +45,14 @@ describe('runAnnotation', () => {
     expect(deps.port).toBe(3000);
   });
 
-  it('reads fresh settings for each session', async () => {
+  it('fails fast when the settings file cannot be read', () => {
     const settingsStore = new FakeSettingsStore();
+    settingsStore.readError = new SettingsStoreError('conflict', 'settings file is not a valid settings document');
     const { context } = createStubContext({ settingsStore });
-    const first = createAnnotationDependencies();
-    await runAnnotation(context, annotationArgs.build(), first);
+    const deps = createAnnotationDependencies();
 
-    settingsStore.settings = { ui: { theme: 'nord' }, harnesses: {} };
-    const second = createAnnotationDependencies();
-    await runAnnotation(context, annotationArgs.build(), second);
-
-    expect(first.configs[0]?.settings).toEqual({ ui: { theme: 'system' }, harnesses: {} });
-    expect(second.configs[0]?.settings).toEqual({ ui: { theme: 'nord' }, harnesses: {} });
+    expect(runAnnotation(context, annotationArgs.build(), deps)).rejects.toBe(settingsStore.readError);
+    expect(deps.payloads).toEqual([]);
   });
 
   it('captures plan-review lifecycle analytics around a successful review', async () => {

--- a/packages/cli/src/annotation/runAnnotation.test.ts
+++ b/packages/cli/src/annotation/runAnnotation.test.ts
@@ -5,7 +5,7 @@ import type { AnnotationSubmission } from '@contextbridge/shared/annotationSchem
 import { createDeferred } from '@contextbridge/shared/testHelpers';
 import { describe, expect, it } from 'bun:test';
 import { annotationArgs, environment } from '#src/testFactories.ts';
-import { createAnnotationDependencies, createStubContext } from '#src/testHelpers/index.ts';
+import { FakeSettingsStore, createAnnotationDependencies, createStubContext } from '#src/testHelpers/index.ts';
 import { AnnotationEnvironmentError, runAnnotation } from './runAnnotation.ts';
 
 describe('runAnnotation', () => {
@@ -42,6 +42,20 @@ describe('runAnnotation', () => {
     await runAnnotation(context, annotationArgs.build({ port: 3000 }), deps);
 
     expect(deps.port).toBe(3000);
+  });
+
+  it('reads fresh settings for each session', async () => {
+    const settingsStore = new FakeSettingsStore();
+    const { context } = createStubContext({ settingsStore });
+    const first = createAnnotationDependencies();
+    await runAnnotation(context, annotationArgs.build(), first);
+
+    settingsStore.settings = { ui: { theme: 'nord' }, harnesses: {} };
+    const second = createAnnotationDependencies();
+    await runAnnotation(context, annotationArgs.build(), second);
+
+    expect(first.configs[0]?.settings).toEqual({ ui: { theme: 'system' }, harnesses: {} });
+    expect(second.configs[0]?.settings).toEqual({ ui: { theme: 'nord' }, harnesses: {} });
   });
 
   it('captures plan-review lifecycle analytics around a successful review', async () => {

--- a/packages/cli/src/annotation/runAnnotation.ts
+++ b/packages/cli/src/annotation/runAnnotation.ts
@@ -77,9 +77,14 @@ export async function runAnnotation(
   };
   analytics.capture('plan_review_started', { source: args.entrypoint });
 
+  const settings = await settingsStore.read();
+  if (settings.isErr()) {
+    throw settings.error;
+  }
+
   const config: FrontendConfig = {
     ...frontendConfig,
-    settings: await settingsStore.read(),
+    settings: settings.value,
   };
 
   const assets = await extractAssets(ctx, {

--- a/packages/cli/src/annotation/runAnnotation.ts
+++ b/packages/cli/src/annotation/runAnnotation.ts
@@ -9,6 +9,7 @@ import type {
 } from '@contextbridge/shared/annotationSchema';
 import { getErrorMessage, hasErrorCode } from '@contextbridge/shared/errors';
 import type { FrontendConfig } from '@contextbridge/shared/frontendConfigSchema';
+import type { SettingsStore } from '@contextbridge/shared/settingsStore';
 import { nowInstant } from '@contextbridge/shared/time';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
 import type { CliContext } from '#src/context.ts';
@@ -50,6 +51,7 @@ export interface AnnotationDependencies {
       config: FrontendConfig;
       port?: number;
       checkForUpdate?: () => Promise<UpdateNotice | null>;
+      updateSettings: SettingsStore['patch'];
     },
   ): RunningServer;
   registerSigintHandler(handler: () => void): () => void;
@@ -60,7 +62,7 @@ export async function runAnnotation(
   args: RunAnnotationArgs,
   deps: AnnotationDependencies = defaultAnnotationDependencies,
 ): Promise<AnnotationSubmission> {
-  const { analytics, logger, openUrl, frontendConfig, updater, env } = ctx;
+  const { analytics, logger, openUrl, frontendConfig, settingsStore, updater, env } = ctx;
   const { port = env.CONTEXTBRIDGE_PORT } = args;
   const startedAt = nowInstant();
 
@@ -74,6 +76,11 @@ export async function runAnnotation(
     },
   };
   analytics.capture('plan_review_started', { source: args.entrypoint });
+
+  const config: FrontendConfig = {
+    ...frontendConfig,
+    settings: await settingsStore.read(),
+  };
 
   const assets = await extractAssets(ctx, {
     content: args.content,
@@ -104,9 +111,10 @@ export async function runAnnotation(
       server = deps.startReviewServer(ctx, {
         html: htmlPromise,
         payload,
-        config: frontendConfig,
+        config,
         port,
         checkForUpdate: () => updater.checkForUpdate().catch(() => null),
+        updateSettings: (patch) => settingsStore.patch(patch),
       });
     } catch (err) {
       if (isLikelyLocalServerNetworkSandboxError(err, port ?? 0)) {
@@ -159,8 +167,8 @@ export function isLikelyLocalServerNetworkSandboxError(err: unknown, port: numbe
 
 const defaultAnnotationDependencies: AnnotationDependencies = {
   loadHtml: () => import('./bundledAnnotationHtml.ts').then((m) => m.bundledAnnotationHtml),
-  startReviewServer: (ctx, { html, payload, config, port, checkForUpdate }) =>
-    startServer(ctx, { html, payload, config, port, checkForUpdate }),
+  startReviewServer: (ctx, { html, payload, config, port, checkForUpdate, updateSettings }) =>
+    startServer(ctx, { html, payload, config, port, checkForUpdate, updateSettings }),
   registerSigintHandler: (handler) => {
     process.on('SIGINT', handler);
     return () => {

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -17,7 +17,7 @@ import { type CommandRunner, CommandRunnerImpl } from '#src/CommandRunnerImpl.ts
 import { type Environment, getEnvironment } from '#src/environment.ts';
 import { type Io, IoImpl } from '#src/IoImpl.ts';
 import { type Prompter, createClackPrompter } from '#src/prompter.ts';
-import { SettingsStoreImpl } from '#src/settings/SettingsStoreImpl.ts';
+import { SettingsFileStore } from '#src/settings/SettingsFileStore.ts';
 import { type Updater, UpdaterImpl } from '#src/updater/UpdaterImpl.ts';
 
 export interface CliContext extends BaseContext {
@@ -51,7 +51,7 @@ export function createContext(): CliContext {
     level: env.LOG_LEVEL,
     destination: io.stderr,
   });
-  const settingsStore = new SettingsStoreImpl({ env, logger });
+  const settingsStore = new SettingsFileStore({ env, logger });
 
   const fetcher = new FetcherImpl();
   const commandRunner = new CommandRunnerImpl({ out: io.stdout, err: io.stderr });

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -10,19 +10,22 @@ import {
 } from '@contextbridge/context';
 import { createNodeInstrumentation, getOrCreateAnonymousId } from '@contextbridge/instrumentation/node';
 import type { FrontendConfig } from '@contextbridge/shared/frontendConfigSchema';
+import type { SettingsStore } from '@contextbridge/shared/settingsStore';
 import { Temporal } from '@contextbridge/shared/time';
 import open from 'open';
 import { type CommandRunner, CommandRunnerImpl } from '#src/CommandRunnerImpl.ts';
 import { type Environment, getEnvironment } from '#src/environment.ts';
 import { type Io, IoImpl } from '#src/IoImpl.ts';
 import { type Prompter, createClackPrompter } from '#src/prompter.ts';
+import { SettingsStoreImpl } from '#src/settings/SettingsStoreImpl.ts';
 import { type Updater, UpdaterImpl } from '#src/updater/UpdaterImpl.ts';
 
 export interface CliContext extends BaseContext {
   readonly env: Environment;
   readonly projectRoot: string;
   readonly io: Io;
-  readonly frontendConfig: FrontendConfig;
+  readonly frontendConfig: Omit<FrontendConfig, 'settings'>;
+  readonly settingsStore: SettingsStore;
   readonly openUrl: (url: string) => Promise<void>;
   readonly commandRunner: CommandRunner;
   readonly prompter: Prompter;
@@ -48,6 +51,7 @@ export function createContext(): CliContext {
     level: env.LOG_LEVEL,
     destination: io.stderr,
   });
+  const settingsStore = new SettingsStoreImpl({ env, logger });
 
   const fetcher = new FetcherImpl();
   const commandRunner = new CommandRunnerImpl({ out: io.stdout, err: io.stderr });
@@ -68,6 +72,7 @@ export function createContext(): CliContext {
     projectRoot: resolveProjectRoot(process.cwd()),
     io,
     frontendConfig: { distinctId, telemetryDisabled },
+    settingsStore,
     openUrl: defaultOpenUrl,
     commandRunner,
     prompter,

--- a/packages/cli/src/settings/SettingsFileStore.test.ts
+++ b/packages/cli/src/settings/SettingsFileStore.test.ts
@@ -4,21 +4,10 @@ import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { resolveSettings } from '@contextbridge/shared/settingsSchema';
-import { afterEach, describe, expect, it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import pino from 'pino';
 import { environment } from '#src/testFactories.ts';
-import { SettingsStoreImpl, resolveSettingsPath } from './SettingsStoreImpl.ts';
-
-const temporaryDirectories: string[] = [];
-
-afterEach(async () => {
-  await Promise.all(
-    temporaryDirectories.splice(0).map(async (path) => {
-      await chmod(path, 0o700).catch(() => {});
-      await rm(path, { recursive: true, force: true });
-    }),
-  );
-});
+import { SettingsFileStore, resolveSettingsPath } from './SettingsFileStore.ts';
 
 describe('resolveSettingsPath', () => {
   it('uses XDG_CONFIG_HOME when set to an absolute path', () => {
@@ -49,29 +38,41 @@ describe('resolveSettingsPath', () => {
   });
 });
 
-describe('SettingsStoreImpl', () => {
+describe('SettingsFileStore', () => {
   it('reads a missing file as defaults without creating it', async () => {
-    const store = createStore();
-    expect(await store.read()).toEqual(resolveSettings());
+    await using root = tempConfigDir();
+    const store = createStore(root.path);
+    const result = await store.read();
+    assert(result.isOk());
+    expect(result.value).toEqual(resolveSettings());
     expect(existsSync(store.path)).toBe(false);
   });
 
-  it('reads a file with malformed JSON as defaults without rewriting it', async () => {
-    const store = createStore();
-    await writeSettings(store, '{"version":');
-    expect(await store.read()).toEqual(resolveSettings());
+  it('refuses to read a file with malformed JSON without rewriting it', async () => {
+    await using root = tempConfigDir();
+    const store = createStore(root.path);
+    await seedSettingsFile(store, '{"version":');
+    const result = await store.read();
+    assert(result.isErr());
+    expect(result.error.kind).toBe('conflict');
+    expect(result.error.message).toContain(store.path);
     expect(readFileSync(store.path, 'utf8')).toBe('{"version":');
   });
 
-  it('reads an invalid settings document as defaults without rewriting it', async () => {
-    const store = createStore();
-    await writeSettings(store, '{"version":1,"ui":{"theme":"not-a-theme"}}');
-    expect(await store.read()).toEqual(resolveSettings());
+  it('refuses to read an invalid settings document without rewriting it', async () => {
+    await using root = tempConfigDir();
+    const store = createStore(root.path);
+    await seedSettingsFile(store, '{"version":1,"ui":{"theme":"not-a-theme"}}');
+    const result = await store.read();
+    assert(result.isErr());
+    expect(result.error.kind).toBe('conflict');
+    expect(result.error.message).toContain(store.path);
     expect(JSON.parse(readFileSync(store.path, 'utf8'))).toEqual({ version: 1, ui: { theme: 'not-a-theme' } });
   });
 
   it('writes a formatted sparse document', async () => {
-    const store = createStore();
+    await using root = tempConfigDir();
+    const store = createStore(root.path);
     const result = await store.patch({ ui: { theme: 'dracula' } });
     assert(result.isOk());
     expect(result.value.ui.theme).toBe('dracula');
@@ -79,8 +80,9 @@ describe('SettingsStoreImpl', () => {
   });
 
   it('updates an existing file in place', async () => {
-    const store = createStore();
-    await writeSettings(store, '{"version":1,"ui":{"theme":"dracula"}}');
+    await using root = tempConfigDir();
+    const store = createStore(root.path);
+    await seedSettingsFile(store, '{"version":1,"ui":{"theme":"dracula"}}');
     const result = await store.patch({ ui: { theme: 'nord' } });
     assert(result.isOk());
     expect(result.value.ui.theme).toBe('nord');
@@ -95,8 +97,9 @@ describe('SettingsStoreImpl', () => {
       '{"version":1,"ui":["not-an-object"]}',
     ];
     for (const contents of invalidContents) {
-      const store = createStore();
-      await writeSettings(store, contents);
+      await using root = tempConfigDir();
+      const store = createStore(root.path);
+      await seedSettingsFile(store, contents);
       const result = await store.patch({ ui: { theme: 'nord' } });
       assert(result.isErr());
       expect(result.error.kind).toBe('conflict');
@@ -105,7 +108,8 @@ describe('SettingsStoreImpl', () => {
   });
 
   it('does not create or touch the file for a patch that changes nothing', async () => {
-    const store = createStore();
+    await using root = tempConfigDir();
+    const store = createStore(root.path);
     for (const patch of [{}, { ui: {} }]) {
       const result = await store.patch(patch);
       assert(result.isOk());
@@ -120,27 +124,37 @@ describe('SettingsStoreImpl', () => {
   });
 
   it('returns a filesystem error when the config root is unwritable', async () => {
-    const store = createStore();
-    const root = join(store.path, '..', '..');
-    await chmod(root, 0o500);
+    await using root = tempConfigDir();
+    const store = createStore(root.path);
+    await chmod(root.path, 0o500);
     const result = await store.patch({ ui: { theme: 'nord' } });
-    await chmod(root, 0o700);
+    await chmod(root.path, 0o700);
     assert(result.isErr());
     expect(result.error.kind).toBe('filesystem');
-    expect(readdirSync(root)).toEqual([]);
+    expect(readdirSync(root.path)).toEqual([]);
   });
 });
 
-function createStore(): SettingsStoreImpl {
-  const root = mkdtempSync(join(tmpdir(), 'contextbridge-settings-'));
-  temporaryDirectories.push(root);
-  return new SettingsStoreImpl({
+function tempConfigDir(): AsyncDisposable & { path: string } {
+  const path = mkdtempSync(join(tmpdir(), 'contextbridge-settings-'));
+  return {
+    path,
+    async [Symbol.asyncDispose]() {
+      await chmod(path, 0o700).catch(() => {});
+      await rm(path, { recursive: true, force: true });
+    },
+  };
+}
+
+function createStore(root: string): SettingsFileStore {
+  return new SettingsFileStore({
     env: environment.build({ XDG_CONFIG_HOME: root }),
     logger: pino({ level: 'silent' }),
   });
 }
 
-async function writeSettings(store: SettingsStoreImpl, contents: string): Promise<void> {
+/** Seeds raw pre-existing on-disk state, including states the store refuses to write. */
+async function seedSettingsFile(store: SettingsFileStore, contents: string): Promise<void> {
   await mkdir(join(store.path, '..'), { recursive: true });
   await writeFile(store.path, contents);
 }

--- a/packages/cli/src/settings/SettingsFileStore.ts
+++ b/packages/cli/src/settings/SettingsFileStore.ts
@@ -16,30 +16,24 @@ import type { Environment } from '#src/environment.ts';
 
 const SETTINGS_FILE = 'settings.json';
 
-interface SettingsStoreImplOptions {
+interface SettingsFileStoreOptions {
   readonly env: Pick<Environment, 'HOME' | 'XDG_CONFIG_HOME'>;
   readonly logger: Logger;
 }
 
-export class SettingsStoreImpl implements SettingsStore {
+export class SettingsFileStore implements SettingsStore {
   readonly path: string;
   private readonly logger: Logger;
 
-  constructor(options: SettingsStoreImplOptions) {
+  constructor(options: SettingsFileStoreOptions) {
     const { env, logger } = options;
 
     this.path = resolveSettingsPath(env);
     this.logger = logger;
   }
 
-  async read(): Promise<Settings> {
-    return this.readPersisted().match(
-      (persisted) => resolveSettings(persisted),
-      (error) => {
-        this.logger.warn({ err: error, path: this.path }, 'could not read settings; using defaults');
-        return resolveSettings();
-      },
-    );
+  async read(): Promise<Result<Settings, SettingsStoreError>> {
+    return this.readPersisted().map((persisted) => resolveSettings(persisted));
   }
 
   async patch(patch: SettingsPatch): Promise<Result<Settings, SettingsStoreError>> {
@@ -65,11 +59,11 @@ export class SettingsStoreImpl implements SettingsStore {
   /** Resolves to `undefined` when no settings file exists. */
   private readPersisted(): ResultAsync<PersistedSettings | undefined, SettingsStoreError> {
     return ResultAsync.fromPromise(Bun.file(this.path).text(), (cause) => cause)
-      .andThen(parsePersisted)
+      .andThen((contents) => parsePersisted(this.path, contents))
       .orElse((cause) => {
         if (hasCode(cause, 'ENOENT')) return ok(undefined);
         if (cause instanceof SettingsStoreError) return err(cause);
-        return err(new SettingsStoreError('filesystem', 'could not read settings file', { cause }));
+        return err(new SettingsStoreError('filesystem', `could not read settings file at ${this.path}`, { cause }));
       });
   }
 
@@ -77,7 +71,7 @@ export class SettingsStoreImpl implements SettingsStore {
     const contents = `${JSON.stringify(persisted, null, 2)}\n`;
     return ResultAsync.fromPromise(
       Bun.write(this.path, contents),
-      (cause) => new SettingsStoreError('filesystem', 'could not write settings file', { cause }),
+      (cause) => new SettingsStoreError('filesystem', `could not write settings file at ${this.path}`, { cause }),
     ).map(() => undefined);
   }
 }
@@ -89,15 +83,17 @@ export function resolveSettingsPath(
   return join(configDir(env, options), SETTINGS_FILE);
 }
 
-function parsePersisted(contents: string): Result<PersistedSettings, SettingsStoreError> {
+function parsePersisted(path: string, contents: string): Result<PersistedSettings, SettingsStoreError> {
   return Result.fromThrowable(
     () => JSON.parse(contents) as unknown,
-    (cause) => new SettingsStoreError('conflict', 'settings file contains malformed JSON', { cause }),
+    (cause) => new SettingsStoreError('conflict', `settings file at ${path} contains malformed JSON`, { cause }),
   )().andThen((raw) => {
     const parsed = PersistedSettingsSchema.safeParse(raw);
     if (!parsed.success) {
       return err(
-        new SettingsStoreError('conflict', 'settings file is not a valid settings document', { cause: parsed.error }),
+        new SettingsStoreError('conflict', `settings file at ${path} is not a valid settings document`, {
+          cause: parsed.error,
+        }),
       );
     }
     return ok(parsed.data);

--- a/packages/cli/src/settings/SettingsStoreImpl.test.ts
+++ b/packages/cli/src/settings/SettingsStoreImpl.test.ts
@@ -1,0 +1,146 @@
+import assert from 'node:assert';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveSettings } from '@contextbridge/shared/settingsSchema';
+import { afterEach, describe, expect, it } from 'bun:test';
+import pino from 'pino';
+import { environment } from '#src/testFactories.ts';
+import { SettingsStoreImpl, resolveSettingsPath } from './SettingsStoreImpl.ts';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(async (path) => {
+      await chmod(path, 0o700).catch(() => {});
+      await rm(path, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe('resolveSettingsPath', () => {
+  it('uses XDG_CONFIG_HOME when set to an absolute path', () => {
+    expect(resolveSettingsPath(environment.build({ XDG_CONFIG_HOME: '/xdg', HOME: '/home/test' }))).toBe(
+      '/xdg/contextbridge/settings.json',
+    );
+  });
+
+  it('ignores a relative XDG_CONFIG_HOME', () => {
+    expect(resolveSettingsPath(environment.build({ XDG_CONFIG_HOME: 'rel/dir', HOME: '/home/test' }))).toBe(
+      '/home/test/.config/contextbridge/settings.json',
+    );
+  });
+
+  it('falls back to ~/.config', () => {
+    expect(resolveSettingsPath(environment.build({ XDG_CONFIG_HOME: undefined, HOME: '/home/test' }))).toBe(
+      '/home/test/.config/contextbridge/settings.json',
+    );
+  });
+
+  it('falls back to the OS home directory when HOME is unset or empty', () => {
+    const homedir = () => '/os/home';
+    for (const HOME of [undefined, '']) {
+      expect(resolveSettingsPath(environment.build({ XDG_CONFIG_HOME: undefined, HOME }), { homedir })).toBe(
+        '/os/home/.config/contextbridge/settings.json',
+      );
+    }
+  });
+});
+
+describe('SettingsStoreImpl', () => {
+  it('reads a missing file as defaults without creating it', async () => {
+    const store = createStore();
+    expect(await store.read()).toEqual(resolveSettings());
+    expect(existsSync(store.path)).toBe(false);
+  });
+
+  it('reads a file with malformed JSON as defaults without rewriting it', async () => {
+    const store = createStore();
+    await writeSettings(store, '{"version":');
+    expect(await store.read()).toEqual(resolveSettings());
+    expect(readFileSync(store.path, 'utf8')).toBe('{"version":');
+  });
+
+  it('reads an invalid settings document as defaults without rewriting it', async () => {
+    const store = createStore();
+    await writeSettings(store, '{"version":1,"ui":{"theme":"not-a-theme"}}');
+    expect(await store.read()).toEqual(resolveSettings());
+    expect(JSON.parse(readFileSync(store.path, 'utf8'))).toEqual({ version: 1, ui: { theme: 'not-a-theme' } });
+  });
+
+  it('writes a formatted sparse document', async () => {
+    const store = createStore();
+    const result = await store.patch({ ui: { theme: 'dracula' } });
+    assert(result.isOk());
+    expect(result.value.ui.theme).toBe('dracula');
+    expect(readFileSync(store.path, 'utf8')).toBe('{\n  "version": 1,\n  "ui": {\n    "theme": "dracula"\n  }\n}\n');
+  });
+
+  it('updates an existing file in place', async () => {
+    const store = createStore();
+    await writeSettings(store, '{"version":1,"ui":{"theme":"dracula"}}');
+    const result = await store.patch({ ui: { theme: 'nord' } });
+    assert(result.isOk());
+    expect(result.value.ui.theme).toBe('nord');
+    expect(JSON.parse(readFileSync(store.path, 'utf8'))).toEqual({ version: 1, ui: { theme: 'nord' } });
+  });
+
+  it('refuses to overwrite a file it does not understand', async () => {
+    const invalidContents = [
+      '{"version":',
+      '{"ui":{"theme":"nord"}}',
+      '{"version":1,"future":true}',
+      '{"version":1,"ui":["not-an-object"]}',
+    ];
+    for (const contents of invalidContents) {
+      const store = createStore();
+      await writeSettings(store, contents);
+      const result = await store.patch({ ui: { theme: 'nord' } });
+      assert(result.isErr());
+      expect(result.error.kind).toBe('conflict');
+      expect(readFileSync(store.path, 'utf8')).toBe(contents);
+    }
+  });
+
+  it('does not create or touch the file for a patch that changes nothing', async () => {
+    const store = createStore();
+    for (const patch of [{}, { ui: {} }]) {
+      const result = await store.patch(patch);
+      assert(result.isOk());
+      expect(result.value).toEqual(resolveSettings());
+    }
+    expect(existsSync(store.path)).toBe(false);
+
+    await store.patch({ ui: { theme: 'dracula' } });
+    const written = statSync(store.path);
+    await store.patch({ ui: { theme: 'dracula' } });
+    expect(statSync(store.path).mtimeMs).toBe(written.mtimeMs);
+  });
+
+  it('returns a filesystem error when the config root is unwritable', async () => {
+    const store = createStore();
+    const root = join(store.path, '..', '..');
+    await chmod(root, 0o500);
+    const result = await store.patch({ ui: { theme: 'nord' } });
+    await chmod(root, 0o700);
+    assert(result.isErr());
+    expect(result.error.kind).toBe('filesystem');
+    expect(readdirSync(root)).toEqual([]);
+  });
+});
+
+function createStore(): SettingsStoreImpl {
+  const root = mkdtempSync(join(tmpdir(), 'contextbridge-settings-'));
+  temporaryDirectories.push(root);
+  return new SettingsStoreImpl({
+    env: environment.build({ XDG_CONFIG_HOME: root }),
+    logger: pino({ level: 'silent' }),
+  });
+}
+
+async function writeSettings(store: SettingsStoreImpl, contents: string): Promise<void> {
+  await mkdir(join(store.path, '..'), { recursive: true });
+  await writeFile(store.path, contents);
+}

--- a/packages/cli/src/settings/SettingsStoreImpl.ts
+++ b/packages/cli/src/settings/SettingsStoreImpl.ts
@@ -1,0 +1,126 @@
+import { join } from 'node:path';
+import { configDir } from '@contextbridge/instrumentation/node';
+import {
+  CURRENT_SETTINGS_VERSION,
+  type PersistedSettings,
+  PersistedSettingsSchema,
+  type Settings,
+  type SettingsPatch,
+  resolveSettings,
+} from '@contextbridge/shared/settingsSchema';
+import { type SettingsStore, SettingsStoreError } from '@contextbridge/shared/settingsStore';
+import { isRecord } from '@contextbridge/shared/typeGuards';
+import { Result, ResultAsync, err, ok, okAsync } from 'neverthrow';
+import type { Logger } from 'pino';
+import type { Environment } from '#src/environment.ts';
+
+const SETTINGS_FILE = 'settings.json';
+
+interface SettingsStoreImplOptions {
+  readonly env: Pick<Environment, 'HOME' | 'XDG_CONFIG_HOME'>;
+  readonly logger: Logger;
+}
+
+export class SettingsStoreImpl implements SettingsStore {
+  readonly path: string;
+  private readonly logger: Logger;
+
+  constructor(options: SettingsStoreImplOptions) {
+    const { env, logger } = options;
+
+    this.path = resolveSettingsPath(env);
+    this.logger = logger;
+  }
+
+  async read(): Promise<Settings> {
+    return this.readPersisted().match(
+      (persisted) => resolveSettings(persisted),
+      (error) => {
+        this.logger.warn({ err: error, path: this.path }, 'could not read settings; using defaults');
+        return resolveSettings();
+      },
+    );
+  }
+
+  async patch(patch: SettingsPatch): Promise<Result<Settings, SettingsStoreError>> {
+    return this.applyAndWrite(patch).mapErr((error) => {
+      this.logger.warn({ err: error, path: this.path }, 'settings patch failed');
+      return error;
+    });
+  }
+
+  private applyAndWrite(patch: SettingsPatch): ResultAsync<Settings, SettingsStoreError> {
+    return this.readPersisted().andThen((persisted) => {
+      const current = persisted ?? { version: CURRENT_SETTINGS_VERSION };
+      const updated = applyPatch(current, patch);
+
+      // Sparse-file rule: a patch that changes nothing writes nothing — an
+      // untouched (or absent) file stays exactly as it was.
+      if (Bun.deepEquals(updated, current)) return okAsync(resolveSettings(updated));
+
+      return this.writePersisted(updated).map(() => resolveSettings(updated));
+    });
+  }
+
+  /** Resolves to `undefined` when no settings file exists. */
+  private readPersisted(): ResultAsync<PersistedSettings | undefined, SettingsStoreError> {
+    return ResultAsync.fromPromise(Bun.file(this.path).text(), (cause) => cause)
+      .andThen(parsePersisted)
+      .orElse((cause) => {
+        if (hasCode(cause, 'ENOENT')) return ok(undefined);
+        if (cause instanceof SettingsStoreError) return err(cause);
+        return err(new SettingsStoreError('filesystem', 'could not read settings file', { cause }));
+      });
+  }
+
+  private writePersisted(persisted: PersistedSettings): ResultAsync<void, SettingsStoreError> {
+    const contents = `${JSON.stringify(persisted, null, 2)}\n`;
+    return ResultAsync.fromPromise(
+      Bun.write(this.path, contents),
+      (cause) => new SettingsStoreError('filesystem', 'could not write settings file', { cause }),
+    ).map(() => undefined);
+  }
+}
+
+export function resolveSettingsPath(
+  env: Pick<Environment, 'HOME' | 'XDG_CONFIG_HOME'>,
+  options: { homedir?: () => string } = {},
+): string {
+  return join(configDir(env, options), SETTINGS_FILE);
+}
+
+function parsePersisted(contents: string): Result<PersistedSettings, SettingsStoreError> {
+  return Result.fromThrowable(
+    () => JSON.parse(contents) as unknown,
+    (cause) => new SettingsStoreError('conflict', 'settings file contains malformed JSON', { cause }),
+  )().andThen((raw) => {
+    const parsed = PersistedSettingsSchema.safeParse(raw);
+    if (!parsed.success) {
+      return err(
+        new SettingsStoreError('conflict', 'settings file is not a valid settings document', { cause: parsed.error }),
+      );
+    }
+    return ok(parsed.data);
+  });
+}
+
+function applyPatch(current: PersistedSettings, patch: SettingsPatch): PersistedSettings {
+  const updated = { ...current };
+  const ui = definedValues(patch.ui);
+  if (ui) updated.ui = { ...updated.ui, ...ui };
+  const harnesses = definedValues(patch.harnesses);
+  if (harnesses) updated.harnesses = { ...updated.harnesses, ...harnesses };
+  return updated;
+}
+
+/** The section's explicitly-set values, or `undefined` when there are none. */
+function definedValues<T extends Record<string, unknown>>(section: T | undefined): T | undefined {
+  if (!section) return undefined;
+  const entries = Object.entries(section).filter(([, value]) => value !== undefined);
+  if (entries.length === 0) return undefined;
+  return Object.fromEntries(entries) as T;
+}
+
+function hasCode(value: unknown, code: string): boolean {
+  return isRecord(value) && value.code === code;
+}

--- a/packages/cli/src/testHelpers/FakeSettingsStore.ts
+++ b/packages/cli/src/testHelpers/FakeSettingsStore.ts
@@ -1,13 +1,14 @@
 import { type Settings, type SettingsPatch, resolveSettings } from '@contextbridge/shared/settingsSchema';
 import type { SettingsStore, SettingsStoreError } from '@contextbridge/shared/settingsStore';
-import { type Result, ok } from 'neverthrow';
+import { type Result, err, ok } from 'neverthrow';
 
 export class FakeSettingsStore implements SettingsStore {
   settings: Settings = resolveSettings();
+  readError: SettingsStoreError | undefined;
   readonly patches: SettingsPatch[] = [];
 
-  read(): Promise<Settings> {
-    return Promise.resolve(this.settings);
+  read(): Promise<Result<Settings, SettingsStoreError>> {
+    return Promise.resolve(this.readError ? err(this.readError) : ok(this.settings));
   }
 
   patch(patch: SettingsPatch): Promise<Result<Settings, SettingsStoreError>> {

--- a/packages/cli/src/testHelpers/FakeSettingsStore.ts
+++ b/packages/cli/src/testHelpers/FakeSettingsStore.ts
@@ -1,0 +1,20 @@
+import { type Settings, type SettingsPatch, resolveSettings } from '@contextbridge/shared/settingsSchema';
+import type { SettingsStore, SettingsStoreError } from '@contextbridge/shared/settingsStore';
+import { type Result, ok } from 'neverthrow';
+
+export class FakeSettingsStore implements SettingsStore {
+  settings: Settings = resolveSettings();
+  readonly patches: SettingsPatch[] = [];
+
+  read(): Promise<Settings> {
+    return Promise.resolve(this.settings);
+  }
+
+  patch(patch: SettingsPatch): Promise<Result<Settings, SettingsStoreError>> {
+    this.patches.push(patch);
+    if (patch.ui?.theme !== undefined) {
+      this.settings = { ...this.settings, ui: { ...this.settings.ui, theme: patch.ui.theme } };
+    }
+    return Promise.resolve(ok(this.settings));
+  }
+}

--- a/packages/cli/src/testHelpers/annotationFakes.ts
+++ b/packages/cli/src/testHelpers/annotationFakes.ts
@@ -1,4 +1,5 @@
 import type { AnnotationPayload, AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
+import type { FrontendConfig } from '@contextbridge/shared/frontendConfigSchema';
 import { annotationSubmission } from '@contextbridge/shared/testFactories';
 import { createDeferred } from '@contextbridge/shared/testHelpers';
 import type { AnnotationDependencies } from '#src/annotation/runAnnotation.ts';
@@ -6,6 +7,8 @@ import type { AnnotationDependencies } from '#src/annotation/runAnnotation.ts';
 export interface TrackedAnnotationDependencies extends AnnotationDependencies {
   /** Payloads passed to startReviewServer in invocation order. */
   payloads: AnnotationPayload[];
+  /** Frontend configs passed to startReviewServer in invocation order. */
+  configs: FrontendConfig[];
   /** Submission the fake server resolves with (unless `result` overrides it). */
   submission: AnnotationSubmission;
   /** Port passed to startReviewServer, if any. */
@@ -35,6 +38,7 @@ export function createAnnotationDependencies(
 ): TrackedAnnotationDependencies {
   const { submission = annotationSubmission.build(), result = Promise.resolve(submission) } = options;
   const payloads: AnnotationPayload[] = [];
+  const configs: FrontendConfig[] = [];
   const sigintRegistration = createDeferred<void>();
   let closeCount = 0;
   let observedPort: number | undefined;
@@ -43,6 +47,7 @@ export function createAnnotationDependencies(
 
   return {
     payloads,
+    configs,
     submission,
     sigintHandlerRegistered: sigintRegistration.promise,
     get port() {
@@ -65,8 +70,9 @@ export function createAnnotationDependencies(
       sigintHandler();
     },
     loadHtml: () => Promise.resolve('<html><body>annotation</body></html>'),
-    startReviewServer: (_ctx, { payload, port }) => {
+    startReviewServer: (_ctx, { payload, config, port }) => {
       payloads.push(payload);
+      configs.push(config);
       observedPort = port;
       return {
         port: 4312,

--- a/packages/cli/src/testHelpers/createStubContext.ts
+++ b/packages/cli/src/testHelpers/createStubContext.ts
@@ -8,6 +8,7 @@ import {
 import pino from 'pino';
 import type { CliContext } from '#src/context.ts';
 import { environment } from '#src/testFactories.ts';
+import { FakeSettingsStore } from './FakeSettingsStore.ts';
 import { FakeCommandRunner, FakeIo, FakePrompter, FakeUpdater, MemoryStream } from './index.ts';
 
 export interface TestContext {
@@ -30,6 +31,7 @@ export function createStubContext(overrides: Partial<CliContext> = {}): TestCont
   const commandRunner = new FakeCommandRunner();
   const prompter = new FakePrompter();
   const updater = new FakeUpdater();
+  const settingsStore = new FakeSettingsStore();
 
   const context: CliContext = {
     ...fakeBaseContext({ logger, analytics, telemetry }),
@@ -37,6 +39,7 @@ export function createStubContext(overrides: Partial<CliContext> = {}): TestCont
     projectRoot: '/work',
     io,
     frontendConfig: { distinctId: 'fake-distinct-id', telemetryDisabled: true },
+    settingsStore,
     openUrl: () => Promise.resolve(),
     commandRunner,
     prompter,

--- a/packages/cli/src/testHelpers/index.ts
+++ b/packages/cli/src/testHelpers/index.ts
@@ -11,6 +11,7 @@ export { type CommandStub, type FakeCommandCall, FakeCommandRunner } from './Fak
 export { FakeIo } from './FakeIo.ts';
 export { FakePrompter } from './FakePrompter.ts';
 export { FakeUpdater } from './FakeUpdater.ts';
+export { FakeSettingsStore } from './FakeSettingsStore.ts';
 export { MemoryStream } from './MemoryStream.ts';
 export { type TestContext, createStubContext } from './createStubContext.ts';
 export { parseStdoutJson } from './parseStdoutJson.ts';

--- a/packages/instrumentation/src/node/anonymousId.ts
+++ b/packages/instrumentation/src/node/anonymousId.ts
@@ -1,15 +1,11 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { fromThrowable } from 'neverthrow';
+import { type ConfigDirEnv, configDir } from './configDir.ts';
 
-const APP_DIR_NAME = 'contextbridge';
 const FILE_NAME = 'anonymous_id';
 
-export interface AnonymousIdEnv {
-  readonly XDG_CONFIG_HOME?: string;
-  readonly HOME?: string;
-}
+export type AnonymousIdEnv = ConfigDirEnv;
 
 const safeRead = fromThrowable((path: string) => readFileSync(path, 'utf8').trim());
 const safeWrite = fromThrowable((dir: string, path: string, id: string) => {
@@ -31,12 +27,4 @@ export function getOrCreateAnonymousId(env: AnonymousIdEnv): string {
   // Result and return the generated id either way.
   safeWrite(dir, path, id);
   return id;
-}
-
-function configDir(env: AnonymousIdEnv): string {
-  if (env.XDG_CONFIG_HOME && env.XDG_CONFIG_HOME.length > 0) {
-    return join(env.XDG_CONFIG_HOME, APP_DIR_NAME);
-  }
-  const home = env.HOME && env.HOME.length > 0 ? env.HOME : homedir();
-  return join(home, '.config', APP_DIR_NAME);
 }

--- a/packages/instrumentation/src/node/configDir.ts
+++ b/packages/instrumentation/src/node/configDir.ts
@@ -1,0 +1,21 @@
+import { homedir as defaultHomedir } from 'node:os';
+import { isAbsolute, join } from 'node:path';
+
+const APP_DIR_NAME = 'contextbridge';
+
+export interface ConfigDirEnv {
+  readonly XDG_CONFIG_HOME?: string;
+  readonly HOME?: string;
+}
+
+/**
+ * The per-user ContextBridge config directory: `$XDG_CONFIG_HOME/contextbridge`
+ * when XDG_CONFIG_HOME is an absolute path, otherwise `~/.config/contextbridge`.
+ */
+export function configDir(env: ConfigDirEnv, options: { homedir?: () => string } = {}): string {
+  const { XDG_CONFIG_HOME: xdgConfigHome, HOME: home } = env;
+  const { homedir = defaultHomedir } = options;
+  if (xdgConfigHome && isAbsolute(xdgConfigHome)) return join(xdgConfigHome, APP_DIR_NAME);
+  const homeDirectory = home && home.length > 0 ? home : homedir();
+  return join(homeDirectory, '.config', APP_DIR_NAME);
+}

--- a/packages/instrumentation/src/node/index.ts
+++ b/packages/instrumentation/src/node/index.ts
@@ -4,6 +4,7 @@ import { createPostHogAnalytics } from './postHogAnalytics.ts';
 import { createSentryTelemetry } from './sentryTelemetry.ts';
 
 export { type AnonymousIdEnv, getOrCreateAnonymousId } from './anonymousId.ts';
+export { type ConfigDirEnv, configDir } from './configDir.ts';
 export {
   reportHarnessDiscovery,
   type HarnessDiscoveryEnv,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "@contextbridge/context": "workspace:*",
-    "@contextbridge/shared": "workspace:*"
+    "@contextbridge/shared": "workspace:*",
+    "neverthrow": "catalog:"
   },
   "peerDependencies": {
     "bun": ">=1.0.0"

--- a/packages/server/src/annotation.test.ts
+++ b/packages/server/src/annotation.test.ts
@@ -1,6 +1,7 @@
 import { fakeBaseContext } from '@contextbridge/context/testHelpers';
 import { annotationPayload, frontendConfig } from '@contextbridge/shared/testFactories';
 import { describe, expect, it } from 'bun:test';
+import { ok } from 'neverthrow';
 import { resolveListenPort, startServer } from './annotation.ts';
 import { withServer } from './testHelpers.ts';
 
@@ -22,6 +23,25 @@ describe('startServer', () => {
     });
   });
 
+  it('serves the latest saved settings from /config after a patch', async () => {
+    const config = frontendConfig.build();
+    const saved = { ...config.settings, ui: { theme: 'nord' as const } };
+    await withServer(ctx, { config, updateSettings: () => Promise.resolve(ok(saved)) }, async (running) => {
+      const before = (await (await fetch(`${running.url}/config`)).json()) as unknown;
+      expect(before).toEqual(config);
+
+      const patch = await fetch(`${running.url}/settings`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ ui: { theme: 'nord' } }),
+      });
+      expect(patch.status).toBe(200);
+
+      const after = (await (await fetch(`${running.url}/config`)).json()) as unknown;
+      expect(after).toEqual({ ...config, settings: saved });
+    });
+  });
+
   // Regression test for the submit→close race: the /submit response must be
   // fully delivered to the client even though the CLI tears the server down
   // immediately after `running.result` resolves. Pre-fix, this failed with a
@@ -32,6 +52,7 @@ describe('startServer', () => {
       html: Promise.resolve('<html><body>ui</body></html>'),
       payload: annotationPayload.build(),
       config: frontendConfig.build(),
+      updateSettings: () => Promise.resolve(ok(frontendConfig.build().settings)),
     });
     const submission = {
       status: 'approved' as const,

--- a/packages/server/src/annotation.ts
+++ b/packages/server/src/annotation.ts
@@ -5,6 +5,7 @@ import { handleAsset } from './routes/assets.ts';
 import { handleConfig } from './routes/config.ts';
 import { handleHtml } from './routes/html.ts';
 import { handlePayload } from './routes/payload.ts';
+import { type UpdateSettings, handleSettings } from './routes/settings.ts';
 import { handleSubmit } from './routes/submit.ts';
 import { type CheckForUpdate, handleUpdateNotice } from './routes/updateNotice.ts';
 
@@ -15,6 +16,7 @@ export interface StartServerOptions {
   readonly config: FrontendConfig;
   readonly port?: number;
   readonly checkForUpdate?: CheckForUpdate;
+  readonly updateSettings: UpdateSettings;
 }
 
 export interface RunningServer {
@@ -26,22 +28,32 @@ export interface RunningServer {
 
 export function startServer(ctx: ServerContext, opts: StartServerOptions): RunningServer {
   const { logger } = ctx;
-  const { html, payload, config, checkForUpdate } = opts;
+  const { html, payload, config, checkForUpdate, updateSettings } = opts;
 
   let resolveResult!: (r: AnnotationSubmission) => void;
   const result = new Promise<AnnotationSubmission>((resolve) => {
     resolveResult = resolve;
   });
 
+  // Successful patches fold into the served config so a page load after a
+  // save sees the saved settings, not the ones from server start.
+  let currentConfig = config;
+  const applySettingsPatch: UpdateSettings = async (patch) => {
+    const patched = await updateSettings(patch);
+    if (patched.isOk()) currentConfig = { ...currentConfig, settings: patched.value };
+    return patched;
+  };
+
   const server = Bun.serve({
     port: resolveListenPort(opts),
     routes: {
       '/': { GET: () => handleHtml(ctx, html) },
       '/assets/:id': { GET: (req) => handleAsset(payload, req.params.id) },
-      '/config': { GET: () => handleConfig(config) },
+      '/config': { GET: () => handleConfig(currentConfig) },
       '/payload': { GET: () => handlePayload(payload) },
       '/update-notice': { GET: () => handleUpdateNotice(checkForUpdate) },
       '/submit': { POST: (req) => handleSubmit(ctx, req, resolveResult) },
+      '/settings': { POST: (req) => handleSettings(req, applySettingsPatch) },
     },
     fetch: () => new Response('not found', { status: 404 }),
   });

--- a/packages/server/src/routes/settings.test.ts
+++ b/packages/server/src/routes/settings.test.ts
@@ -1,0 +1,60 @@
+import { fakeBaseContext } from '@contextbridge/context/testHelpers';
+import { SettingsStoreError } from '@contextbridge/shared/settingsStore';
+import { describe, expect, it } from 'bun:test';
+import { err, ok } from 'neverthrow';
+import { withServer } from '#src/testHelpers.ts';
+
+describe('POST /settings', () => {
+  const ctx = fakeBaseContext();
+
+  it('forwards the parsed patch to the store and returns newly resolved settings', async () => {
+    const received: unknown[] = [];
+    await withServer(
+      ctx,
+      {
+        updateSettings: (patch) => {
+          received.push(patch);
+          return Promise.resolve(ok({ ui: { theme: 'nord' }, harnesses: {} }));
+        },
+      },
+      async (running) => {
+        const response = await fetch(`${running.url}/settings`, request({ ui: { theme: 'nord' } }));
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ ui: { theme: 'nord' }, harnesses: {} });
+        expect(received).toEqual([{ ui: { theme: 'nord' } }]);
+      },
+    );
+  });
+
+  it('returns 400 for malformed JSON and invalid patches', async () => {
+    await withServer(ctx, async (running) => {
+      const malformed = await fetch(`${running.url}/settings`, requestBody('{'));
+      const unknown = await fetch(`${running.url}/settings`, request({ unknown: true }));
+      expect([malformed.status, unknown.status]).toEqual([400, 400]);
+    });
+  });
+
+  it('maps conflict and filesystem failures to 409 and 500', async () => {
+    for (const [kind, expected] of [
+      ['conflict', 409],
+      ['filesystem', 500],
+    ] as const) {
+      await withServer(
+        ctx,
+        { updateSettings: () => Promise.resolve(err(new SettingsStoreError(kind, 'nope'))) },
+        async (running) => {
+          const response = await fetch(`${running.url}/settings`, request({ ui: { theme: 'nord' } }));
+          expect(response.status).toBe(expected);
+        },
+      );
+    }
+  });
+});
+
+function request(body: unknown): RequestInit {
+  return requestBody(JSON.stringify(body));
+}
+
+function requestBody(body: string): RequestInit {
+  return { method: 'POST', headers: { 'content-type': 'application/json' }, body };
+}

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -1,0 +1,21 @@
+import { safeJsonParse } from '@contextbridge/shared/json';
+import { SettingsPatchSchema } from '@contextbridge/shared/settingsSchema';
+import type { SettingsStore } from '@contextbridge/shared/settingsStore';
+
+export type UpdateSettings = SettingsStore['patch'];
+
+export async function handleSettings(request: Request, updateSettings: UpdateSettings): Promise<Response> {
+  const body = safeJsonParse(await request.text());
+  if (body.isErr()) return Response.json({ error: 'invalid settings patch' }, { status: 400 });
+  const parsed = SettingsPatchSchema.safeParse(body.value);
+  if (!parsed.success) return Response.json({ error: 'invalid settings patch' }, { status: 400 });
+
+  const result = await updateSettings(parsed.data);
+  return result.match(
+    (settings) => Response.json(settings),
+    (error) =>
+      error.kind === 'conflict'
+        ? Response.json({ error: 'settings file cannot be safely updated' }, { status: 409 })
+        : Response.json({ error: 'settings could not be saved' }, { status: 500 }),
+  );
+}

--- a/packages/server/src/testHelpers.ts
+++ b/packages/server/src/testHelpers.ts
@@ -1,4 +1,5 @@
 import { annotationPayload, frontendConfig } from '@contextbridge/shared/testFactories';
+import { ok } from 'neverthrow';
 import { type RunningServer, type StartServerOptions, startServer } from '#src/annotation.ts';
 import type { ServerContext } from '#src/context.ts';
 
@@ -21,6 +22,7 @@ export async function withServer<T = void>(
     html: Promise.resolve(DEFAULT_HTML),
     payload: annotationPayload.build(),
     config: frontendConfig.build(),
+    updateSettings: () => Promise.resolve(ok(frontendConfig.build().settings)),
     ...opts,
   });
   try {

--- a/packages/shared/src/frontendConfigSchema.ts
+++ b/packages/shared/src/frontendConfigSchema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { SettingsSchema } from './settingsSchema.ts';
 
 /**
  * Wire contract between the CLI and the plan-review browser UI.
@@ -11,6 +12,7 @@ import { z } from 'zod';
 export const FrontendConfigSchema = z.object({
   distinctId: z.string().nonempty(),
   telemetryDisabled: z.boolean(),
+  settings: SettingsSchema,
 });
 
 export type FrontendConfig = z.infer<typeof FrontendConfigSchema>;

--- a/packages/shared/src/testFactories.ts
+++ b/packages/shared/src/testFactories.ts
@@ -110,4 +110,5 @@ export const settings = Factory.define<Settings>(() => resolveSettings());
 export const frontendConfig = Factory.define<FrontendConfig>(() => ({
   distinctId: 'test-distinct-id',
   telemetryDisabled: false,
+  settings: settings.build(),
 }));


### PR DESCRIPTION
## Summary

Second layer of #251: persistence and plumbing. `SettingsStoreImpl` owns the sparse file at `$XDG_CONFIG_HOME/contextbridge/settings.json`, the CLI context carries a `SettingsStore`, and `runAnnotation` reads fresh settings per session into the frontend config — `FrontendConfig` gains its `settings` field here, alongside the code that fills it. The review server gains `POST /settings` for validated patches from the browser, and successful patches fold into what `GET /config` serves so a page load after a save sees the saved settings. Path resolution is shared with the anonymous-id store through a new `configDir` helper in `@contextbridge/instrumentation/node`.

## Review focus

- The store is deliberately plain: `Bun.file` read, `Bun.write` write, no atomic-rename or permission ceremony — matching how the anonymous-id store next door persists its file. The tradeoff is that a crash mid-write can tear the file; a torn file warns and reads as defaults, and refuses patches until removed.
- Patch conflict semantics: `read` never fails (a missing file is defaults silently; a malformed or invalid one logs a warning and resolves to defaults), but `patch` refuses with a `conflict` error rather than rewrite a file it can't parse as a valid v1 document.
- The file stays sparse: only explicit user choices are written, never defaults, so flipping a default in a later release is not a migration. A patch that changes nothing writes nothing.
- Also ports the fuller neverthrow rule (combinators over manual `isErr()` chains; `assert` narrowing over `_unsafeUnwrap` in tests) into `.claude/rules/`, which this PR's code and tests follow.

## Commits

- [`fb92c8d`](https://github.com/contextbridge/planbridge/commit/fb92c8d5516621d371ff146df6e88b376237a852) — feat(settings): persist settings through the local server

