### PR TITLE
feat(settings): persist the theme preference through the settings store

### DIFF
--- a/packages/annotation/AGENTS.md
+++ b/packages/annotation/AGENTS.md
@@ -26,7 +26,7 @@ Demo-only code lives under `src/demo/` (TerminalWindow, DemoStage, terminalScrip
 
 Consumes `@contextbridge/ui` — `styles.css` import in the entry, `cn()` helper, shared components under `@contextbridge/ui/components/*` (e.g. `Header`, `BrandMark`), and shadcn primitives under `@contextbridge/ui/components/ui/*`. See `packages/ui/AGENTS.md` for the wiring steps and the "do not remove" notes on the `@source` directive.
 
-The annotation experience owns the curated Shiki theme catalog in `src/themes.ts`. `ThemeController` keeps localStorage, system-color-scheme observation, and root-element mutation behind the injected app context; components consume only semantic CSS properties. Shiki themes provide both the application palette and fenced-code token colors. Preserve the `System` default and keep explicit selections persistent across review sessions.
+The annotation experience owns the curated Shiki theme catalog in `src/themes.ts`, whose themes supply both the application palette and the fenced-code token colors. The preference persists through the user settings file rather than localStorage — the review server binds a fresh ephemeral origin every run, so browser storage never survives a session.
 
 ## Design language: utilitarian, not SaaS
 

--- a/packages/annotation/src/App.test.tsx
+++ b/packages/annotation/src/App.test.tsx
@@ -1,6 +1,6 @@
 import type { AnnotationPayload, AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
 import { DOCS_URL, FEEDBACK_URL, GITHUB_REPO_URL, SLACK_COMMUNITY_URL } from '@contextbridge/shared/links';
-import { annotationThread } from '@contextbridge/shared/testFactories';
+import { annotationThread, settings } from '@contextbridge/shared/testFactories';
 import { createDeferred } from '@contextbridge/shared/testHelpers';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
 import { headerTestIds } from '@contextbridge/ui/components/Header';
@@ -10,7 +10,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { annotatedMarkdownTestIds } from './AnnotatedMarkdown.tsx';
 import { annotationDraftCommentComposerTestIds } from './AnnotationDraftCommentComposer.tsx';
 import { annotationThreadCardTestIds } from './AnnotationThreadCard.tsx';
-import { appTestIds } from './App.tsx';
+import { appCopy, appTestIds } from './App.tsx';
 import { commentNavigationBarTestIds } from './CommentNavigationBar.tsx';
 import { commentsSidebarTestIds } from './CommentsSidebar.tsx';
 import { globalCommentComposerTestIds } from './GlobalCommentComposer.tsx';
@@ -999,8 +999,10 @@ Run \`${longCode}\` now.
   });
 
   describe('theme picker', () => {
-    it('renders the curated theme grid and persists the selected theme', async () => {
-      const { themeController } = renderApp({ initialPayload: { contentKind: 'plan', content: '# Ready' } });
+    it('renders the curated theme grid and persists the selected theme through settings', async () => {
+      const { themeController, updateSettings } = renderApp({
+        initialPayload: { contentKind: 'plan', content: '# Ready' },
+      });
       const user = userEvent.setup();
 
       await user.click(screen.getByTestId(themePickerTestIds.trigger));
@@ -1010,10 +1012,39 @@ Run \`${longCode}\` now.
 
       await user.click(screen.getByTestId(themePickerTestIds.option('dracula')));
 
-      expect(themeController.savedPreferences).toEqual(['dracula']);
+      expect(updateSettings).toHaveBeenCalledExactlyOnceWith({ ui: { theme: 'dracula' } });
       expect(screen.getByTestId(themePickerTestIds.option('dracula'))).toHaveAttribute('aria-pressed', 'true');
       await waitFor(() => {
         expect(themeController.appliedThemes.at(-1)?.id).toBe('dracula');
+      });
+    });
+
+    it('shows a warning when a settings save does not persist and clears it on the next success', async () => {
+      const { updateSettings } = renderApp({ initialPayload: { contentKind: 'plan', content: '# Ready' } });
+      const user = userEvent.setup();
+      updateSettings.mockResolvedValueOnce(false);
+
+      await user.click(screen.getByTestId(themePickerTestIds.trigger));
+      await user.click(await screen.findByTestId(themePickerTestIds.option('dracula')));
+
+      const warning = await screen.findByTestId(appTestIds.settingsSaveWarning);
+      expect(warning).toHaveTextContent(appCopy.settingsSaveFailed);
+
+      await user.click(screen.getByTestId(themePickerTestIds.option('nord')));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(appTestIds.settingsSaveWarning)).not.toBeInTheDocument();
+      });
+    });
+
+    it('starts from the theme preference in the CLI-provided settings', async () => {
+      const { themeController } = renderApp(
+        { initialPayload: { contentKind: 'plan', content: '# Ready' } },
+        { settings: settings.build({ ui: { theme: 'nord' } }) },
+      );
+
+      await waitFor(() => {
+        expect(themeController.appliedThemes.at(-1)?.id).toBe('nord');
       });
     });
 

--- a/packages/annotation/src/App.tsx
+++ b/packages/annotation/src/App.tsx
@@ -1,5 +1,6 @@
 import type { AnnotationPayload, CommentThread } from '@contextbridge/shared/annotationSchema';
 import { DOCS_URL, FEEDBACK_URL, GITHUB_REPO_URL, SLACK_COMMUNITY_URL } from '@contextbridge/shared/links';
+import type { SettingsPatch } from '@contextbridge/shared/settingsSchema';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
 import { Header } from '@contextbridge/ui/components/Header';
 import {
@@ -20,17 +21,20 @@ import { AnnotatedMarkdown } from './AnnotatedMarkdown.tsx';
 import { getAnnotationHighlightWarning } from './annotationHighlights.ts';
 import { CommentsSidebar } from './CommentsSidebar.tsx';
 import { ThemePicker } from './ThemePicker.tsx';
+import type { ThemePreference } from './themes.ts';
 import { UpdateNoticeCard } from './UpdateNoticeCard.tsx';
 import { useAnnotationInteractions } from './useAnnotationInteractions.ts';
 import { useAnnotationState } from './useAnnotationState.ts';
 import { useAnnotationAppContext } from './useAppContext.ts';
 import { useTheme } from './useTheme.ts';
+import { WarningNotice } from './WarningNotice.tsx';
 
 export const appTestIds = {
   container: 'plan-review-app',
   loading: 'plan-review-loading',
   highlightWarning: 'plan-review-highlight-warning',
   emptyState: 'plan-review-empty-state',
+  settingsSaveWarning: 'plan-review-settings-save-warning',
   removeDialog: 'plan-review-remove-dialog',
   discardDraftDialog: 'plan-review-discard-draft-dialog',
   discardDraftDialogCancelButton: 'plan-review-discard-draft-dialog-cancel',
@@ -42,6 +46,7 @@ export const appTestIds = {
 
 export const appCopy = {
   emptyState: 'No content was provided.',
+  settingsSaveFailed: 'Your settings could not be saved. Changes apply to this session only.',
 } as const;
 
 export interface AppProps {
@@ -51,12 +56,21 @@ export interface AppProps {
 }
 
 export function App({ initialPayload, initialThreads, initialGlobalComment }: AppProps = {}) {
-  const { fetchPayload, fetchUpdateNotice, analytics, buildInfo, themeController } = useAnnotationAppContext();
+  const { fetchPayload, fetchUpdateNotice, analytics, buildInfo, settings, updateSettings, themeController } =
+    useAnnotationAppContext();
   const [payload, setPayload] = useState<AnnotationPayload | null>(initialPayload ?? null);
   const [updateNotice, setUpdateNotice] = useState<UpdateNotice | null>(null);
   const [updateNoticeDismissed, setUpdateNoticeDismissed] = useState(false);
   const reviewState = useAnnotationState({ initialThreads, initialGlobalComment });
-  const themeState = useTheme(themeController);
+  const [settingsSaveFailed, setSettingsSaveFailed] = useState(false);
+  const saveSettings = (patch: SettingsPatch) => {
+    void updateSettings(patch).then((persisted) => setSettingsSaveFailed(!persisted));
+  };
+  const themeState = useTheme(themeController, { initialPreference: settings.ui.theme });
+  const handleThemeSelect = (preference: ThemePreference) => {
+    themeState.selectTheme(preference);
+    saveSettings({ ui: { theme: preference } });
+  };
   const annotationInteractions = useAnnotationInteractions({
     threads: reviewState.threads,
     submitted: reviewState.submission.submitted,
@@ -67,7 +81,7 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
   const highlightWarning = getAnnotationHighlightWarning();
   const showCommentNavigation = annotationInteractions.navigation.total > 0;
   const commentNavigationDisabled = reviewState.draft.active !== null;
-  const themePicker = <ThemePicker preference={themeState.preference} onSelect={themeState.selectTheme} />;
+  const themePicker = <ThemePicker preference={themeState.preference} onSelect={handleThemeSelect} />;
 
   useEffect(() => {
     if (initialPayload) {
@@ -108,13 +122,12 @@ export function App({ initialPayload, initialThreads, initialGlobalComment }: Ap
           />
           <div className="w-full px-4 py-4 sm:px-6 sm:py-6">
             <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,52rem)_minmax(0,1fr)_minmax(15rem,28rem)]">
+              {settingsSaveFailed ? (
+                <WarningNotice testId={appTestIds.settingsSaveWarning}>{appCopy.settingsSaveFailed}</WarningNotice>
+              ) : null}
+
               {highlightWarning ? (
-                <div
-                  className="border-l-2 border-chart-1 px-3 py-2 text-sm leading-6 text-muted-foreground xl:col-start-2"
-                  data-testid={appTestIds.highlightWarning}
-                >
-                  {highlightWarning}
-                </div>
+                <WarningNotice testId={appTestIds.highlightWarning}>{highlightWarning}</WarningNotice>
               ) : null}
 
               <section className="min-w-0 xl:col-start-2">

--- a/packages/annotation/src/ThemeController.test.ts
+++ b/packages/annotation/src/ThemeController.test.ts
@@ -1,24 +1,9 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { ThemeControllerImpl } from './ThemeController.ts';
+import { describe, expect, it } from 'vitest';
+import { FakeThemeController } from './testHelpers/FakeThemeController.ts';
+import { ThemeControllerImpl, applyInitialTheme } from './ThemeController.ts';
 import { themeById } from './themes.ts';
 
 describe('ThemeControllerImpl', () => {
-  afterEach(() => {
-    window.localStorage.clear();
-  });
-
-  it('persists and restores an explicit theme preference', () => {
-    const controller = new ThemeControllerImpl();
-
-    controller.savePreference('dracula');
-
-    expect(new ThemeControllerImpl().loadPreference()).toBe('dracula');
-  });
-
-  it('falls back to System when no valid preference is stored', () => {
-    expect(new ThemeControllerImpl().loadPreference()).toBe('system');
-  });
-
   it('applies all semantic colors and dark-mode metadata to the root', () => {
     const root = document.createElement('div');
     const controller = new ThemeControllerImpl({ root });
@@ -31,5 +16,23 @@ describe('ThemeControllerImpl', () => {
     expect(root.style.colorScheme).toBe('dark');
     expect(root.style.getPropertyValue('--background')).toBe(theme.styles['--background']);
     expect(root.style.getPropertyValue('--annotation-background')).toBe(theme.styles['--annotation-background']);
+  });
+});
+
+describe('applyInitialTheme', () => {
+  it('applies an explicit preference directly', () => {
+    const controller = new FakeThemeController('light');
+
+    applyInitialTheme(controller, 'dracula');
+
+    expect(controller.appliedThemes.at(-1)?.id).toBe('dracula');
+  });
+
+  it('resolves the system preference against the current color scheme', () => {
+    const controller = new FakeThemeController('dark');
+
+    applyInitialTheme(controller, 'system');
+
+    expect(controller.appliedThemes.at(-1)?.id).toBe('github-dark-default');
   });
 });

--- a/packages/annotation/src/ThemeController.ts
+++ b/packages/annotation/src/ThemeController.ts
@@ -1,47 +1,27 @@
-import { fromThrowable } from 'neverthrow';
 import type { ColorScheme, ThemeDefinition, ThemePreference } from './themes.ts';
-import { isThemePreference, resolveTheme } from './themes.ts';
+import { resolveTheme } from './themes.ts';
 
-const THEME_STORAGE_KEY = 'contextbridge.theme';
 const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)';
 
 export interface ThemeController {
-  loadPreference(): ThemePreference;
-  savePreference(preference: ThemePreference): void;
   getSystemColorScheme(): ColorScheme;
   subscribeToSystemColorScheme(listener: (colorScheme: ColorScheme) => void): () => void;
   applyTheme(theme: ThemeDefinition): void;
 }
 
 export interface ThemeControllerImplOptions {
-  readonly storage?: Storage;
   readonly root?: HTMLElement;
   readonly systemThemeQuery?: MediaQueryList;
 }
 
 export class ThemeControllerImpl implements ThemeController {
-  readonly #storage: Storage;
   readonly #root: HTMLElement;
   readonly #systemThemeQuery: MediaQueryList;
 
   constructor(options: ThemeControllerImplOptions = {}) {
-    const {
-      storage = window.localStorage,
-      root = document.documentElement,
-      systemThemeQuery = window.matchMedia(SYSTEM_DARK_QUERY),
-    } = options;
-    this.#storage = storage;
+    const { root = document.documentElement, systemThemeQuery = window.matchMedia(SYSTEM_DARK_QUERY) } = options;
     this.#root = root;
     this.#systemThemeQuery = systemThemeQuery;
-  }
-
-  loadPreference(): ThemePreference {
-    const stored = readStoredPreference(this.#storage).unwrapOr(null);
-    return isThemePreference(stored) ? stored : 'system';
-  }
-
-  savePreference(preference: ThemePreference): void {
-    writeStoredPreference(this.#storage, preference);
   }
 
   getSystemColorScheme(): ColorScheme {
@@ -68,12 +48,6 @@ export class ThemeControllerImpl implements ThemeController {
   }
 }
 
-export function applyInitialTheme(controller: ThemeController): void {
-  const preference = controller.loadPreference();
+export function applyInitialTheme(controller: ThemeController, preference: ThemePreference): void {
   controller.applyTheme(resolveTheme(preference, controller.getSystemColorScheme()));
 }
-
-const readStoredPreference = fromThrowable((storage: Storage) => storage.getItem(THEME_STORAGE_KEY));
-const writeStoredPreference = fromThrowable((storage: Storage, preference: ThemePreference) => {
-  storage.setItem(THEME_STORAGE_KEY, preference);
-});

--- a/packages/annotation/src/WarningNotice.tsx
+++ b/packages/annotation/src/WarningNotice.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+interface WarningNoticeProps {
+  testId: string;
+  children: ReactNode;
+}
+
+export function WarningNotice({ testId, children }: WarningNoticeProps) {
+  return (
+    <div
+      className="border-l-2 border-chart-1 px-3 py-2 text-sm leading-6 text-muted-foreground xl:col-start-2"
+      data-testid={testId}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/annotation/src/main.tsx
+++ b/packages/annotation/src/main.tsx
@@ -9,6 +9,7 @@ import { createRoot } from 'react-dom/client';
 import { App } from './App.tsx';
 import { fetchUpdateNotice } from './fetchUpdateNotice.ts';
 import { ThemeControllerImpl, applyInitialTheme } from './ThemeController.ts';
+import { createUpdateSettings } from './updateSettings.ts';
 import type { AnnotationAppContext as AnnotationAppContextValue } from './useAppContext.ts';
 import { AnnotationAppContext } from './useAppContext.ts';
 
@@ -24,10 +25,10 @@ if (!rootElement) throw new Error('#root not found');
 void bootstrap(rootElement);
 
 async function bootstrap(target: HTMLElement): Promise<void> {
-  const themeController = new ThemeControllerImpl();
-  applyInitialTheme(themeController);
-
   const config = (await fetchConfig()) ?? FALLBACK_CONFIG;
+
+  const themeController = new ThemeControllerImpl();
+  applyInitialTheme(themeController, config.settings.ui.theme);
 
   const base = createFrontendContext({
     config,
@@ -39,6 +40,8 @@ async function bootstrap(target: HTMLElement): Promise<void> {
     fetchPayload,
     fetchUpdateNotice: () => fetchUpdateNotice(base.fetcher),
     submitAnnotation,
+    settings: config.settings,
+    updateSettings: createUpdateSettings({ logger: base.logger }),
     autoCloseDelaySeconds: 3,
     themeController,
   };

--- a/packages/annotation/src/testHelpers/FakeThemeController.ts
+++ b/packages/annotation/src/testHelpers/FakeThemeController.ts
@@ -1,26 +1,14 @@
 import type { ThemeController } from '#src/ThemeController.ts';
-import type { ColorScheme, ThemeDefinition, ThemePreference } from '#src/themes.ts';
+import type { ColorScheme, ThemeDefinition } from '#src/themes.ts';
 
 export class FakeThemeController implements ThemeController {
   readonly appliedThemes: ThemeDefinition[] = [];
-  readonly savedPreferences: ThemePreference[] = [];
 
-  preference: ThemePreference;
   systemColorScheme: ColorScheme;
   #listeners = new Set<(colorScheme: ColorScheme) => void>();
 
-  constructor(preference: ThemePreference = 'system', systemColorScheme: ColorScheme = 'light') {
-    this.preference = preference;
+  constructor(systemColorScheme: ColorScheme = 'light') {
     this.systemColorScheme = systemColorScheme;
-  }
-
-  loadPreference(): ThemePreference {
-    return this.preference;
-  }
-
-  savePreference(preference: ThemePreference): void {
-    this.preference = preference;
-    this.savedPreferences.push(preference);
   }
 
   getSystemColorScheme(): ColorScheme {

--- a/packages/annotation/src/testHelpers/appContextDecorator.tsx
+++ b/packages/annotation/src/testHelpers/appContextDecorator.tsx
@@ -1,4 +1,5 @@
 import { FakeFrontendBrowser, fakeFrontendContext } from '@contextbridge/context/testHelpers';
+import { settings } from '@contextbridge/shared/testFactories';
 import type { ComponentType, ReactElement } from 'react';
 import { ThemeControllerImpl } from '#src/ThemeController.ts';
 import type { AnnotationAppContext as AnnotationAppContextValue } from '#src/useAppContext.ts';
@@ -12,8 +13,10 @@ export function createStoryAppContext(overrides?: Partial<AnnotationAppContextVa
     fetchPayload: () => Promise.resolve({ content: '', contentKind: 'plan' }),
     fetchUpdateNotice: () => Promise.resolve(null),
     submitAnnotation: () => Promise.resolve(),
+    settings: settings.build(),
+    updateSettings: () => Promise.resolve(true),
     autoCloseDelaySeconds: 3,
-    themeController: new ThemeControllerImpl({ storage: new StoryThemeStorage() }),
+    themeController: new ThemeControllerImpl(),
     ...overrides,
   };
 }
@@ -27,32 +30,4 @@ export function withAppContext(overrides?: Partial<AnnotationAppContextValue>) {
       </AnnotationAppContext.Provider>
     );
   };
-}
-
-class StoryThemeStorage implements Storage {
-  readonly #values = new Map<string, string>();
-
-  get length(): number {
-    return this.#values.size;
-  }
-
-  clear(): void {
-    this.#values.clear();
-  }
-
-  getItem(key: string): string | null {
-    return this.#values.get(key) ?? null;
-  }
-
-  key(index: number): string | null {
-    return [...this.#values.keys()][index] ?? null;
-  }
-
-  removeItem(key: string): void {
-    this.#values.delete(key);
-  }
-
-  setItem(key: string, value: string): void {
-    this.#values.set(key, value);
-  }
 }

--- a/packages/annotation/src/testHelpers/createFakeAppContext.ts
+++ b/packages/annotation/src/testHelpers/createFakeAppContext.ts
@@ -5,6 +5,8 @@ import {
   fakeFrontendContext,
 } from '@contextbridge/context/testHelpers';
 import type { AnnotationPayload, AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
+import type { SettingsPatch } from '@contextbridge/shared/settingsSchema';
+import { settings } from '@contextbridge/shared/testFactories';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
 import type { Mock } from 'vitest';
 import { vi } from 'vitest';
@@ -17,6 +19,7 @@ export interface FakeAppContextResult {
   submitAnnotation: Mock<(submission: AnnotationSubmission) => Promise<void>>;
   fetchPayload: Mock<() => Promise<AnnotationPayload>>;
   fetchUpdateNotice: Mock<() => Promise<UpdateNotice | null>>;
+  updateSettings: Mock<(patch: SettingsPatch) => Promise<boolean>>;
   analytics: FakeAnalytics;
   telemetry: FakeFrontendTelemetry;
   themeController: FakeThemeController;
@@ -29,6 +32,7 @@ export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>):
     .fn<() => Promise<AnnotationPayload>>()
     .mockResolvedValue({ content: '', contentKind: 'plan' });
   const fetchUpdateNotice = vi.fn<() => Promise<UpdateNotice | null>>().mockResolvedValue(null);
+  const updateSettings = vi.fn<(patch: SettingsPatch) => Promise<boolean>>().mockResolvedValue(true);
   const themeController = new FakeThemeController();
   const context: AnnotationAppContext = {
     ...fakeFrontendContext({
@@ -37,6 +41,8 @@ export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>):
     fetchPayload,
     fetchUpdateNotice,
     submitAnnotation,
+    settings: settings.build(),
+    updateSettings,
     autoCloseDelaySeconds: 3,
     themeController,
     ...overrides,
@@ -47,6 +53,7 @@ export function createFakeAppContext(overrides?: Partial<AnnotationAppContext>):
     submitAnnotation,
     fetchPayload,
     fetchUpdateNotice,
+    updateSettings,
     analytics: context.analytics as FakeAnalytics,
     telemetry: context.telemetry as FakeFrontendTelemetry,
     themeController,

--- a/packages/annotation/src/themes.ts
+++ b/packages/annotation/src/themes.ts
@@ -61,10 +61,6 @@ export function resolveTheme(preference: ThemePreference, systemColorScheme: Col
   return themeById.get(id) ?? themeById.get(systemThemeIds[systemColorScheme])!;
 }
 
-export function isThemePreference(value: string | null): value is ThemePreference {
-  return value === 'system' || (value !== null && themeById.has(value as ThemeId));
-}
-
 function createThemeDefinition(id: ThemeId, label: string, shikiTheme: ThemeRegistrationAny): ThemeDefinition {
   const colors = shikiTheme.colors ?? {};
   const colorScheme: ColorScheme = shikiTheme.type === 'light' ? 'light' : 'dark';

--- a/packages/annotation/src/updateSettings.test.ts
+++ b/packages/annotation/src/updateSettings.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createUpdateSettings } from './updateSettings.ts';
+
+describe('createUpdateSettings', () => {
+  it('posts the patch to /settings as JSON and resolves true', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response('{}', { status: 200 }));
+    const logger = { error: vi.fn() };
+
+    await expect(createUpdateSettings({ logger, fetcher })({ ui: { theme: 'dracula' } })).resolves.toBe(true);
+
+    expect(fetcher).toHaveBeenCalledExactlyOnceWith('/settings', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ui: { theme: 'dracula' } }),
+    });
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('resolves false and reports the status, response body, and patch on a rejected patch', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('{"error":"settings file cannot be safely updated"}', { status: 409 }));
+    const logger = { error: vi.fn() };
+
+    await expect(createUpdateSettings({ logger, fetcher })({ ui: { theme: 'nord' } })).resolves.toBe(false);
+
+    expect(logger.error).toHaveBeenCalledExactlyOnceWith(
+      {
+        status: 409,
+        body: '{"error":"settings file cannot be safely updated"}',
+        patch: { ui: { theme: 'nord' } },
+      },
+      expect.any(String),
+    );
+  });
+
+  it('resolves false and reports the cause and patch when the request itself fails', async () => {
+    const failure = new TypeError('network down');
+    const fetcher = vi.fn<typeof fetch>().mockRejectedValue(failure);
+    const logger = { error: vi.fn() };
+
+    await expect(createUpdateSettings({ logger, fetcher })({ ui: { theme: 'nord' } })).resolves.toBe(false);
+
+    expect(logger.error).toHaveBeenCalledExactlyOnceWith(
+      { err: failure, patch: { ui: { theme: 'nord' } } },
+      expect.any(String),
+    );
+  });
+});

--- a/packages/annotation/src/updateSettings.ts
+++ b/packages/annotation/src/updateSettings.ts
@@ -1,0 +1,38 @@
+import type { Logger } from '@contextbridge/context/frontend';
+import type { SettingsPatch } from '@contextbridge/shared/settingsSchema';
+import { ResultAsync } from 'neverthrow';
+
+export type UpdateSettings = (patch: SettingsPatch) => Promise<boolean>;
+
+export interface CreateUpdateSettingsOptions {
+  readonly logger: Pick<Logger, 'error'>;
+  readonly fetcher?: typeof fetch;
+}
+
+/** Never rejects: resolves false when the patch did not persist. */
+export function createUpdateSettings(options: CreateUpdateSettingsOptions): UpdateSettings {
+  const { logger, fetcher = fetch } = options;
+
+  return async (patch: SettingsPatch): Promise<boolean> => {
+    const result = await ResultAsync.fromPromise(
+      fetcher('/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(patch),
+      }),
+      (cause) => cause,
+    );
+
+    if (result.isErr()) {
+      logger.error({ err: result.error, patch }, 'POST /settings never reached the review server');
+      return false;
+    }
+    const response = result.value;
+    if (!response.ok) {
+      const body = (await response.text().catch(() => '')).trim();
+      logger.error({ status: response.status, body, patch }, 'the review server rejected the settings patch');
+      return false;
+    }
+    return true;
+  };
+}

--- a/packages/annotation/src/useAppContext.ts
+++ b/packages/annotation/src/useAppContext.ts
@@ -1,5 +1,6 @@
 import type { FrontendContext } from '@contextbridge/context/frontend';
 import type { AnnotationPayload, AnnotationSubmission } from '@contextbridge/shared/annotationSchema';
+import type { Settings, SettingsPatch } from '@contextbridge/shared/settingsSchema';
 import type { UpdateNotice } from '@contextbridge/shared/updateNoticeSchema';
 import { createContext, useContext } from 'react';
 import type { ThemeController } from './ThemeController.ts';
@@ -8,6 +9,8 @@ export interface AnnotationAppContext extends FrontendContext {
   fetchPayload: () => Promise<AnnotationPayload>;
   fetchUpdateNotice: () => Promise<UpdateNotice | null>;
   submitAnnotation: (submission: AnnotationSubmission) => Promise<void>;
+  settings: Settings;
+  updateSettings: (patch: SettingsPatch) => Promise<boolean>;
   autoCloseDelaySeconds: number;
   themeController: ThemeController;
 }

--- a/packages/annotation/src/useTheme.ts
+++ b/packages/annotation/src/useTheme.ts
@@ -3,8 +3,13 @@ import type { ThemeController } from './ThemeController.ts';
 import type { ThemePreference } from './themes.ts';
 import { resolveTheme } from './themes.ts';
 
-export function useTheme(controller: ThemeController) {
-  const [preference, setPreference] = useState<ThemePreference>(() => controller.loadPreference());
+export interface UseThemeOptions {
+  readonly initialPreference: ThemePreference;
+}
+
+export function useTheme(controller: ThemeController, options: UseThemeOptions) {
+  const { initialPreference } = options;
+  const [preference, setPreference] = useState<ThemePreference>(initialPreference);
   const [systemColorScheme, setSystemColorScheme] = useState(() => controller.getSystemColorScheme());
   const theme = resolveTheme(preference, systemColorScheme);
 
@@ -18,7 +23,6 @@ export function useTheme(controller: ThemeController) {
   }, [controller, preference]);
 
   const selectTheme = (nextPreference: ThemePreference) => {
-    controller.savePreference(nextPreference);
     if (nextPreference === 'system') {
       setSystemColorScheme(controller.getSystemColorScheme());
     }


### PR DESCRIPTION
## Summary

Part of #251: the theme preference now rides the settings store instead of localStorage, which never actually persisted for users because the review server binds a fresh ephemeral port (origin) each run. `src/main.tsx` fetches the config from the existing `GET /config` endpoint and applies the saved theme before first render; selections save through `POST /settings`, and a failed save surfaces a session-only warning in the UI. The `ThemePicker` wiring is deliberately minimal — selecting a theme still persists immediately here, and #259 (next in the stack) replaces that selection surface with a Save/Cancel settings dialog. The durable review surface is the transport contract and the `ThemeController` change, not the selection-time interaction.

## Review focus

- We measured the fetch-vs-inline-injection tradeoff with the real 9.5 MB bundle on localhost: `GET /config` takes ~0.6 ms and completes ~50 ms before the browser's first paint, so the theme is applied before any pixel renders — no flash. That let us keep the plain endpoint instead of splicing config into the served HTML.
- All settings saves flow through one codepath: `updateSettings` never rejects and resolves `false` when the patch did not persist, and the App shows a single warning notice ("changes apply to this session only") that clears on the next successful save.
- `ThemeController` loses its localStorage tier entirely rather than keeping it as a fallback; standalone dev/Storybook sessions apply theme choices for the session but don't persist them across reloads.

## Commits

- [`6ea390e`](https://github.com/contextbridge/planbridge/commit/6ea390e7eca773b62b064b0a781ee0aaaa37c26f) — feat(settings): persist the theme preference through the settings store
