### PR TITLE
ci: keep TurboSnap active across dependency-only changes

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -55,12 +55,18 @@ jobs:
         # user overrides. The CLI respects these env vars properly.
         # Issue: https://github.com/chromaui/chromatic-cli/issues/1230
         working-directory: packages/storybook
+        # TurboSnap can't trace bun.lock (it only parses npm/yarn lockfiles), so any
+        # package.json change bails to a full, quota-burning snapshot build. Untrace
+        # dependency files to keep TurboSnap active; source-level story changes are
+        # still traced through the build's module graph.
         run: |
           bun run chromatic -- \
             --project-token="${{ secrets.CHROMATIC_PROJECT_TOKEN }}" \
             --storybook-build-dir=storybook-static \
             --storybook-base-dir=packages/storybook \
             --only-changed \
+            --untraced "bun.lock" \
+            --untraced "**/package.json" \
             --exit-zero-on-changes \
             ${{ github.event.pull_request.merged && '--auto-accept-changes' || '' }}
         env:


### PR DESCRIPTION
## Summary

The Chromatic "UI Tests" check has been stuck at "Update your plan to resume testing" because the account is out of snapshots for the month. The burn rate is driven by a TurboSnap gap: the Chromatic CLI can't trace `bun.lock` (it only parses npm and yarn lockfiles — confirmed still true in the latest CLI, v18.1.0), so it falls back to `package.json` comparison and bails to a full snapshot build whenever any `package.json` changes. This untraces `bun.lock` and `**/package.json` so TurboSnap stays active and unchanged stories are skipped for free.

## Review focus

- Untracing `**/package.json` means a dependency-only bump will not re-snapshot stories it might visually affect; the change only gets snapshotted the next time a traced source file touches those stories. That's the documented Chromatic tradeoff for untraceable lockfiles, and cheaper than the current behavior of full builds on every dependency change.
- This stops future quota burn but cannot un-exhaust the current month's quota — the pending "UI Tests" checks clear only after a plan upgrade or the monthly reset.

## Commits

- [`38ca07d`](https://github.com/contextbridge/planbridge/commit/38ca07d) — ci: keep TurboSnap active across dependency-only changes
