### PR TITLE
chore(ci): drop the unused GitHub Packages registry from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,41 +1,31 @@
 # Groups minor/patch updates, isolates major versions, and lets security updates through immediately
 version: 2
-# Dependabot doesn't support GITHUB_TOKEN for private registry auth
-# (https://github.com/dependabot/dependabot-core/issues/8411), so we use a
-# fine-grained PAT (blimmer's account) with Packages: Read permission.
-registries:
-  github-packages:
-    type: npm-registry
-    url: https://npm.pkg.github.com
-    token: ${{secrets.GH_PACKAGES_TOKEN}}
 updates:
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: 'github-actions'
     directories:
-      - "/"
-      - "/.github/actions/*"
+      - '/'
+      - '/.github/actions/*'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     cooldown:
       default-days: 3 # zizmor: ignore[dependabot-cooldown]
     groups:
       github-actions:
-        patterns: ["*"]
+        patterns: ['*']
 
-  - package-ecosystem: "bun"
-    directory: "/"
-    registries:
-      - github-packages
+  - package-ecosystem: 'bun'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     cooldown:
       default-days: 3 # zizmor: ignore[dependabot-cooldown]
     ignore:
-      - dependency-name: "@types/bun"
+      - dependency-name: '@types/bun'
     groups:
       # drizzle-orm and drizzle-kit must stay in lockstep on the same beta version.
       # Once Drizzle 1.x is released from beta, we can remove this group.
       drizzle:
-        patterns: ["drizzle-orm", "drizzle-kit"]
+        patterns: ['drizzle-orm', 'drizzle-kit']
       npm-minor-patch:
-        update-types: ["minor", "patch"]
-        exclude-patterns: ["drizzle-orm", "drizzle-kit"]
+        update-types: ['minor', 'patch']
+        exclude-patterns: ['drizzle-orm', 'drizzle-kit']


### PR DESCRIPTION
## Summary

Dependabot's bun version-update jobs have failed since mid-June with "Dependabot can't resolve your JavaScript dependency files." The `registries:` block sends the bun updater to `npm.pkg.github.com` authenticated with `GH_PACKAGES_TOKEN`, and that secret is no longer present in the repo's Dependabot secrets, so the updater can't authenticate against the registry it was told to use.

We do depend on two packages out of `contextbridge/config`, `@contextbridge-ai/eslint-config` and `@contextbridge-ai/prettier-config`, but both are published to npmjs rather than GitHub Packages. Both resolve from the default registry in `bun.lock`, and there's no `.npmrc` or registry mapping in `bunfig.toml` pointing anywhere else. The block dates back to the initial setup commit and hasn't been needed since.

## Review focus

If we ever move the `@contextbridge-ai/*` packages onto GitHub Packages, this block has to come back along with a working token. GitHub Packages requires authentication to read npm packages even when the package is public, so publishing them publicly wouldn't be enough on its own.

Separately: the whole file reads as changed because the pre-commit Prettier hook formats YAML while the `format:check` script only globs `ts,tsx,md,mdx,json,astro`. Committing requoted everything to single quotes. Worth deciding which of the two should move.

## Commits

- [`4c491b2`](https://github.com/contextbridge/planbridge/commit/4c491b2) — drop the registry block and the bun updater's reference to it
