### PR TITLE
chore: track Drizzle rc dist-tag

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -206,11 +206,11 @@
       "version": "0.0.0-development",
       "dependencies": {
         "@contextbridge/shared": "workspace:*",
-        "drizzle-orm": "1.0.0-rc.4-273829f",
+        "drizzle-orm": "rc",
         "neverthrow": "catalog:",
       },
       "devDependencies": {
-        "drizzle-kit": "1.0.0-rc.4-273829f",
+        "drizzle-kit": "rc",
         "fishery": "catalog:",
       },
     },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -19,11 +19,11 @@
   },
   "dependencies": {
     "@contextbridge/shared": "workspace:*",
-    "drizzle-orm": "1.0.0-rc.4-273829f",
+    "drizzle-orm": "rc",
     "neverthrow": "catalog:"
   },
   "devDependencies": {
-    "drizzle-kit": "1.0.0-rc.4-273829f",
+    "drizzle-kit": "rc",
     "fishery": "catalog:"
   }
 }


### PR DESCRIPTION
## Summary

Configure `drizzle-orm` and `drizzle-kit` to follow the publisher-controlled `rc` dist-tag. The committed Bun lockfile continues to pin both packages to `1.0.0-rc.4-273829f`, while future explicit dependency updates can advance them together through the RC channel.

## Review focus

Confirm that the manifest specifiers follow the `rc` tag while the committed lockfile retains the current exact artifacts.

## Commits

- [`8f9a202`](https://github.com/contextbridge/planbridge/commit/8f9a202a5ed4f96160541cee349865ebac98324f) — track the Drizzle rc dist-tag