### PR TITLE
ci: fail zizmor job on findings

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Bootstrap
-        uses: ./.github/actions/bootstrap
+        uses: $/.github/actions/bootstrap
 
       - name: Build Storybook
         run: bun run --cwd packages/storybook build-storybook

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: ./.github/actions/bootstrap
+      - uses: $/.github/actions/bootstrap
 
       - name: Pin CLI reference source
         if: ${{ inputs.cli_ref != '' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Detect changes
         id: changes
-        uses: ./.github/actions/detect-changes
+        uses: $/.github/actions/detect-changes
         with:
           mode: deploy
           workflow_name: Main Branch
@@ -52,7 +52,7 @@ jobs:
   test:
     name: Tests
     needs: detect-changes
-    uses: ./.github/workflows/test.yml
+    uses: $/.github/workflows/test.yml
     with:
       install_script_changed: ${{ needs.detect-changes.outputs.install_script_changed == 'true' }}
     permissions:
@@ -63,7 +63,7 @@ jobs:
     name: Deploy website
     needs: [detect-changes, test]
     if: ${{ needs.detect-changes.outputs.website_changed == 'true' }}
-    uses: ./.github/workflows/deploy-website.yml
+    uses: $/.github/workflows/deploy-website.yml
     with:
       cli_ref: ${{ needs.detect-changes.outputs.cli_ref }}
     secrets:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Detect changes
         id: changes
-        uses: ./.github/actions/detect-changes
+        uses: $/.github/actions/detect-changes
         with:
           mode: pull_request
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
   test:
     name: Tests
     needs: detect-changes
-    uses: ./.github/workflows/test.yml
+    uses: $/.github/workflows/test.yml
     with:
       install_script_changed: ${{ needs.detect-changes.outputs.install_script_changed == 'true' }}
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   test:
     name: Tests
-    uses: ./.github/workflows/test.yml
+    uses: $/.github/workflows/test.yml
     with:
       install_script_changed: false
     permissions:
@@ -33,10 +33,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: ./.github/actions/bootstrap
+      - uses: $/.github/actions/bootstrap
 
       - name: Fetch release secrets
-        uses: ./.github/actions/fetch-release-secrets
+        uses: $/.github/actions/fetch-release-secrets
         with:
           role-to-assume: ${{ secrets.RELEASE_ROLE_ARN }}
 
@@ -162,7 +162,7 @@ jobs:
     needs: release
     # Skip alpha releases so unreleased docs do not publish before stable CLI releases.
     if: ${{ !contains(github.ref_name, '-') }}
-    uses: ./.github/workflows/deploy-website.yml
+    uses: $/.github/workflows/deploy-website.yml
     with:
       cli_ref: ${{ github.ref_name }}
     secrets:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: ./.github/actions/bootstrap
+      - uses: $/.github/actions/bootstrap
       - name: Check formatting
         run: bun run format:check
       - name: Restore ESLint cache
@@ -46,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: ./.github/actions/bootstrap
+      - uses: $/.github/actions/bootstrap
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(jq -r '.workspaces.catalog.playwright' package.json)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -56,3 +56,11 @@ jobs:
         with:
           sarif_file: zizmor.sarif
           category: zizmor
+
+      # zizmor always exits 0 in SARIF mode, so fail here (after the upload
+      # so findings still reach code scanning) when the SARIF has results.
+      - name: Fail on findings
+        if: steps.changes.outputs.github == 'true'
+        run: |
+          jq -r '.runs[].results[] | "\(.level): \(.ruleId) — \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // "?") \(.message.text)"' zizmor.sarif
+          jq -e '[.runs[].results[]] | length == 0' zizmor.sarif > /dev/null


### PR DESCRIPTION
## Summary

zizmor always exits 0 in SARIF mode, so findings only ever showed up in the code scanning tab and never failed the check. Adds a step after the SARIF upload that fails the job when the SARIF has any results, so findings still reach code scanning but also block the PR. The first run on this PR failed as expected with 13 `self-repository` findings; the second commit fixes them and the check went green.

## Review focus

Ordering: the fail step runs after the upload on purpose so results still land in code scanning on failure.

## Commits

- [`caead0f`](https://github.com/contextbridge/planbridge/commit/caead0f2351b5581f26967f35389b9fc93ab0bf1) — fail zizmor job when SARIF contains findings
- [`ecb59f2`](https://github.com/contextbridge/planbridge/commit/ecb59f240ae3abd4c0627430a510d69211051414) — use `$/` self-repository syntax for local action references
