### PR TITLE
fix: stop generating deprecated Homebrew URL verification

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -82,7 +82,6 @@ homebrew_casks:
     skip_upload: auto
     url:
       template: 'https://downloads.contextbridge.ai/cli/{{ .Version }}/{{ .ArtifactName }}'
-      verified: 'downloads.contextbridge.ai/cli/'
     repository:
       owner: contextbridge
       name: homebrew-tap
@@ -106,7 +105,6 @@ homebrew_casks:
     skip_upload: '{{ if .Prerelease }}false{{ else }}true{{ end }}'
     url:
       template: 'https://downloads.contextbridge.ai/cli/{{ .Version }}/{{ .ArtifactName }}'
-      verified: 'downloads.contextbridge.ai/cli/'
     repository:
       owner: contextbridge
       name: homebrew-tap


### PR DESCRIPTION
## Summary

Remove GoReleaser's deprecated `verified` URL option from the stable and alpha Homebrew cask definitions. Homebrew now performs URL verification by default and warns whenever generated casks include this no-op option.

Resolves this warning I started seeing:

```shell
Warning: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.
Please report this issue to the contextbridge/homebrew-tap tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/contextbridge/homebrew-tap/Casks/cli@alpha.rb:13
```

## Review focus

Confirm that omitting `verified` is compatible with the GoReleaser version used by the release workflow.

## Commits

- [`8a14c53`](https://github.com/contextbridge/planbridge/commit/8a14c53) — stop generating deprecated Homebrew URL verification
